### PR TITLE
Check targets before passing them to the engine

### DIFF
--- a/src/bin/sonar.ts
+++ b/src/bin/sonar.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-/*
+/**
  * @fileoverview Main CLI that is run via the sonar command. Based on ESLint.
  * @author Anton Molleda
  */


### PR DESCRIPTION
* Add `http://` to targets that seem to omit it.
* Remove targets that are not regular files or are URI schemes different from `HTTP` or `HTTPS`.