### PR TITLE
Add rule to check the web app manifest extension

### DIFF
--- a/.sonarrc
+++ b/.sonarrc
@@ -7,6 +7,7 @@
     },
     "formatter": "json",
     "rules": {
-        "no-double-slash": "warning"
+        "no-double-slash": "warning",
+        "web-app-manifest-file-extension": "warning"
     }
 }

--- a/src/lib/rules/web-app-manifest-file-extension/web-app-manifest-file-extension.md
+++ b/src/lib/rules/web-app-manifest-file-extension/web-app-manifest-file-extension.md
@@ -1,0 +1,19 @@
+# Disallow non-standard file extension the web app manifest file (web-app-manifest-file-extension)   
+
+##  Rule Details
+
+This rule warns against using non-standard file extensions for the 
+[web app manifest](https://www.w3.org/TR/appmanifest) file, if the 
+recommended [`.webmanifest`](https://w3c.github.io/manifest/#media-type-registration)
+file extension is not used.
+
+While the `.webmanifest` file extension is not enforced by the 
+specification, nor is it required by browsers, using it makes it:
+
+  * [easier to set custom server configurations](https://github.com/w3c/manifest/issues/346) 
+    for the web app manifest file
+  * possible to benefit from [existing configurations](https://github.com/jshttp/mime-db/blob/67a4d013c31e73c47b5d975062f0088aea6cd5cd/src/custom-types.json#L85-L92)
+
+## Resources
+
+* [Web App Manifest Specification](https://www.w3.org/TR/appmanifest)

--- a/src/lib/rules/web-app-manifest-file-extension/web-app-manifest-file-extension.ts
+++ b/src/lib/rules/web-app-manifest-file-extension/web-app-manifest-file-extension.ts
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview Check if `.webmanifest` is used as the file extension
+ * for the web app manifest file.
+ */
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+import * as path from 'path';
+
+import { Rule, RuleBuilder, ElementFoundEvent } from '../../types'; // eslint-disable-line no-unused-vars
+import { RuleContext } from '../../rule-context'; // eslint-disable-line no-unused-vars
+import { findElementLocation } from '../../util/find-element-location';
+
+const debug = require('debug')('sonar:rules:web-app-manifest-file-extension');
+
+// ------------------------------------------------------------------------------
+// Public
+// ------------------------------------------------------------------------------
+
+const rule: RuleBuilder = {
+    create(context: RuleContext): Rule {
+
+        const standardManifestFileExtension = '.webmanifest';
+
+        const validate = (data: ElementFoundEvent) => {
+            const { element, resource } = data;
+
+            if (element.getAttribute('rel') === 'manifest') {
+                const href = element.getAttribute('href');
+                const fileExtension = path.extname(href);
+
+                if (fileExtension !== standardManifestFileExtension) {
+                    debug('Web app manifest file with invalid extension found');
+                    const location = findElementLocation(element, context.pageContent, fileExtension);
+
+                    context.report(resource, element, `The file extension for '${href}' file should be '${standardManifestFileExtension}' not '${fileExtension}'`, location);
+                }
+            }
+        };
+
+        return {
+            'element::link': validate
+        };
+
+    },
+    meta: {
+        docs: {
+            category: 'PWA',
+            description: 'Use `.webmanifest` as the file extension for the web app manifest file',
+            recommended: true
+        },
+        fixable: 'code',
+        schema: []
+    }
+};
+
+module.exports = rule;

--- a/src/lib/sonar.ts
+++ b/src/lib/sonar.ts
@@ -43,6 +43,10 @@ export class Sonar extends EventEmitter {
         return this.collector.headers;
     }
 
+    get pageRequest() {
+        return this.collector.request;
+    }
+
     constructor(config) {
 
         super({
@@ -103,8 +107,9 @@ export class Sonar extends EventEmitter {
         }
 
         debug('Loading collector');
-        let collectorId,
-            collectorConfig;
+
+        let collectorId;
+        let collectorConfig;
 
         if (typeof config.collector === 'string') {
             collectorId = config.collector;
@@ -128,7 +133,7 @@ export class Sonar extends EventEmitter {
     report(ruleId: string, severity: Severity, node, location: ProblemLocation, message: string, resource: string) {
 
         const problem = {
-            column: location.column + 1,
+            column: location.column,
             line: location.line,
             message,
             resource,

--- a/src/lib/util/find-element-location.ts
+++ b/src/lib/util/find-element-location.ts
@@ -1,0 +1,50 @@
+import { ProblemLocation } from './../types'; // eslint-disable-line no-unused-vars
+
+/** Finds the Location of an HTMLElement in the document */
+export const findElementLocation = (element: HTMLElement, html: string, inElemContent?: string): ProblemLocation => {
+
+    const occurrences = (html.match(new RegExp(element.outerHTML, 'g')) || []).length;
+
+    let htmlBeforeElement = '';
+    let htmlFromElementToEndOfElement = '';
+
+    if (occurrences === 1) {
+        htmlBeforeElement = html.substring(0, html.indexOf(element.outerHTML));
+    } else if (occurrences > 1) {
+        // TODO: return the right start place
+        htmlBeforeElement = html.substring(0, html.indexOf(element.outerHTML));
+    } else {
+        return null;
+    }
+
+    const lines = htmlBeforeElement.split('\n');
+    let line = lines.length
+    let column = lines.pop().length;
+
+    // Try to determine where in the element is inElemContent, and update
+    // the column accordingly.
+    //
+    // e.g.:
+    //
+    //  If `inElemContent` is `src` and the element is `<script src="...">`,
+    //  then `pos` will be `9`:
+    //
+    //  <script src="...">
+    //  |       |
+    //  1       9
+
+    if (inElemContent) {
+        htmlFromElementToEndOfElement = html.substr(htmlBeforeElement.length, element.outerHTML.length);
+        const index = htmlFromElementToEndOfElement.indexOf(inElemContent) + 1;
+
+        if (index > 0) {
+            column += index;
+        }
+    }
+
+    return {
+        column: column,
+        line: line
+    };
+
+};


### PR DESCRIPTION
##  Rule Details

This rule warns against using non-standard file extensions for the [web app manifest](https://www.w3.org/TR/appmanifest) file, if the recommended [`.webmanifest`](https://w3c.github.io/manifest/#media-type-registration) file extension is not used.

While the `.webmanifest` file extension is not enforced by the specification, nor is it required by browsers, using it makes it:

  * [easier to set custom server configurations](https://github.com/w3c/manifest/issues/346) for the web app manifest file
  * possible to benefit from [existing configurations](https://github.com/jshttp/mime-db/blob/67a4d013c31e73c47b5d975062f0088aea6cd5cd/src/custom-types.json#L85-L92)

## Resources: 

* [Web App Manifest Specification](https://www.w3.org/TR/appmanifest)

---

Ref #32