### PR TITLE
Make `cli` skip targets that cannot be fetched

### DIFF
--- a/src/bin/sonar.ts
+++ b/src/bin/sonar.ts
@@ -30,16 +30,14 @@ import { cli } from '../lib/cli';
 // ------------------------------------------------------------------------------
 
 process.once('uncaughtException', (err) => {
-
     console.log(err.message);
     console.log(err.stack);
-
     process.exitCode = 1;
-
 });
 
 process.once('unhandledRejection', (reason) => {
     console.log(reason);
+    process.exitCode = 1;
 });
 
 const run = async () => {

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -77,9 +77,13 @@ export const cli = {
         const start = Date.now();
 
         for (const target of targets) {
-            const results = await engine.executeOn(target); // eslint-disable-line no-await-in-loop
+            try {
+                const results = await engine.executeOn(target); // eslint-disable-line no-await-in-loop
 
-            format(results);
+                format(results);
+            } catch (e) {
+                debug(`Failed to analyze: ${target.href}`);
+            }
         }
 
         debug(`Total runtime: ${Date.now() - start}ms`);

--- a/src/lib/sonar.ts
+++ b/src/lib/sonar.ts
@@ -155,7 +155,13 @@ export class Sonar extends EventEmitter {
         const start = Date.now();
 
         debug(`Starting the analysis on ${target.path}`);
-        await this.collector.collect(target);
+
+        try {
+            await this.collector.collect(target);
+        } catch (e) {
+            return Promise.reject(e);
+        }
+
         debug(`Total runtime ${Date.now() - start}`);
 
         return this.messages;


### PR DESCRIPTION
Without handling the failures sonar will stop at the first target that cannot be fetched, or read from the disk.