### PR TITLE
Make `getAsUri` add `http://` to `localhost`

### DIFF
--- a/src/lib/util/get-as-uri.ts
+++ b/src/lib/util/get-as-uri.ts
@@ -44,8 +44,10 @@ export const getAsUri = (source: string): url.Url | null => {
     if (!shell.test('-e', entry)) {
         target = url.parse(`http://${entry}`);
 
-        // hostname needs to have a . at least. Private domains should have http in front
-        if (target.hostname.includes('.')) {
+        // Except for the case of the well known and used `localhost`,
+        // for all other cases the `hostname` needs to contain at least
+        // a `.`. Private domains should have `http(s)://` in front.
+        if (target.hostname === 'localhost' || target.hostname.includes('.')) {
             debug(`Adding modified target: ${url.format(target)}`);
 
             return target;

--- a/tests/lib/util/get-as-uri.js
+++ b/tests/lib/util/get-as-uri.js
@@ -12,6 +12,7 @@ const normalize = (path) => {
 
 const targets = [
     [__filename, `file://${normalize(__filename)}`],
+    ['localhost', 'http://localhost/'],
     ['https://www.wikipedia.org', 'https://www.wikipedia.org/'],
     ['www.wikipedia.org', 'http://www.wikipedia.org/'],
     [`file://${normalize(__filename)}`, `file://${normalize(__filename)}`],
@@ -38,7 +39,7 @@ test('getAsUris converts to url.Url and removes invalid entries', (t) => {
 
     const results = getAsUris(urls);
 
-    t.is(results.length, 4);
+    t.is(results.length, 5);
     results.forEach((result) => {
         t.true(result instanceof url.Url);
     });


### PR DESCRIPTION
Since `localhost` will most probably be frequently used, change `getAsUri` function so that it  treats it as special case and automatically adds `http://` to it.

---

Ref: https://github.com/MicrosoftEdge/Sonar/pull/40#discussion_r106384420