### PR TITLE
Add rule to check if the `lang` attribute is used on `html` element

### DIFF
--- a/.sonarrc
+++ b/.sonarrc
@@ -7,6 +7,7 @@
     },
     "formatter": "json",
     "rules": {
+        "lang-attribute": "warning",
         "no-double-slash": "warning",
         "web-app-manifest-file-extension": "warning"
     }

--- a/src/lib/rule-context.ts
+++ b/src/lib/rule-context.ts
@@ -74,7 +74,7 @@ export class RuleContext {
             this.id,
             this.severity,
             descriptor,
-            location,
+            position,
             message,
             resource
         );

--- a/src/lib/rules/lang-attribute/lang-attribute.md
+++ b/src/lib/rules/lang-attribute/lang-attribute.md
@@ -1,0 +1,37 @@
+# Require `lang` attribute on the `html` element (`lang-attribute`)
+
+##  Rule Details
+
+This rule warns against not using the `lang` attribute on the `html`
+element, or using it on the `html` element but with the value of empty
+string.
+
+It's indicated to always set the `lang` attribute on the `html`
+element so that it's inherited by all other elements ([even the ones
+in the `<head>`](https://www.w3.org/International/questions/qa-html-language-declarations#basics)),
+and it sets the primary language of the document.
+
+Setting the `lang` attribute provides an explicit indicate to user
+agents about the language of the content, which can help, among other:
+
+  * [screen readers and similar assistive technologies with voice
+    output and pronunciation of content using the correct voice/language
+    library](http://blog.adrianroselli.com/2015/01/on-use-of-lang-attribute.html)
+
+  * determine the appropriate language dictionary, the types of
+    [quotation marks for `q` elements](https://www.w3.org/International/questions/qa-lang-why#rendering),
+    the styling such as the one for
+    [hyphenation](http://www.quirksmode.org/blog/archives/2012/11/hyphenation_wor.html),
+    [case conversion, line-breaking, and
+    spell-checking](https://www.w3.org/International/questions/qa-lang-why#authoring)
+
+  * [font selection where different alphabets are
+    mixed](https://www.w3.org/International/questions/qa-lang-why#fonts)
+
+  * improve localization (e.g. [what numeric software keyboard will be opened for
+    `<input type="number">`](https://ctrl.blog/entry/html5-input-number-localization))
+
+## Resources
+
+* [Declaring the language in HTML](https://www.w3.org/International/questions/qa-html-language-declarations)
+* [Why use the language attribute?](https://www.w3.org/International/questions/qa-lang-why)

--- a/src/lib/rules/lang-attribute/lang-attribute.ts
+++ b/src/lib/rules/lang-attribute/lang-attribute.ts
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview Check if the `lang` attribute is specified on the
+ * `html` element and has a non empty value.
+ */
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+import { Rule, RuleBuilder, ElementFoundEvent } from '../../types'; // eslint-disable-line no-unused-vars
+import { RuleContext } from '../../rule-context'; // eslint-disable-line no-unused-vars
+
+const debug = require('debug')('sonar:rules:lang-attribute'); // eslint-disable-line no-unused-vars
+
+// ------------------------------------------------------------------------------
+// Public
+// ------------------------------------------------------------------------------
+
+const rule: RuleBuilder = {
+    create(context: RuleContext): Rule {
+        const validate = (data: ElementFoundEvent) => {
+            const { element, resource } = data;
+            const langAttributeValue = element.getAttribute('lang');
+
+            // Check if the `lang` attribute is specified.
+            if (langAttributeValue === null) {
+                context.report(resource, element, `'lang' attribute not specified on the 'html' element`);
+
+                return;
+            }
+
+            // Check if the `lang` has no value or the value is an empty string.
+            if (langAttributeValue === '') {
+                const location = context.findProblemLocation(element, 'lang');
+
+                context.report(resource, element, `empty 'lang' attribute specified on the 'html' element`, location);
+            }
+
+        };
+
+        return { 'element::html': validate };
+    },
+    meta: {
+        docs: {
+            category: 'a11y',
+            description: 'Use `lang` attribute on `html` element',
+            recommended: true
+        },
+        fixable: 'code',
+        schema: []
+    }
+};
+
+module.exports = rule;

--- a/src/lib/util/location-helpers.ts
+++ b/src/lib/util/location-helpers.ts
@@ -108,7 +108,9 @@ export const findInElement = (element: HTMLElement, content?: string): ProblemLo
     const html = element.outerHTML.substring(0, startIndex);
     const lines = html.split('\n');
     const line = lines.length;
-    const column = lines.length === 1 ? startIndex : lines.pop().length;
+
+    // `startIndex + 1` because `indexOf` starts from `0`.
+    const column = lines.length === 1 ? startIndex + 1 : lines.pop().length;
 
     return {
         column,

--- a/src/lib/util/resource-loader.ts
+++ b/src/lib/util/resource-loader.ts
@@ -41,13 +41,9 @@ const loadOfType = (type: string): Map<string, Resource> => {
         const name = path.basename(resource, '.js');
 
         if (!resourceMap.has(name)) {
-
             resourceMap.set(name, require(resource));
-
         } else {
-
             throw new Error(`Failed to add resource ${name} from ${resource}. It already exists.`);
-
         }
 
         return resourceMap;
@@ -55,26 +51,19 @@ const loadOfType = (type: string): Map<string, Resource> => {
     }, new Map());
 
     return resourcesOfType;
-
 };
 
 const resources = Object.freeze(_.reduce(TYPE, (acum, value, key) => {
-
     acum[key] = loadOfType(value);
 
     return acum;
-
 }, {}));
 
 /** Returns the resources for a given type. */
 const get = (type: string): (() => Map<string, any>) => {
-
     return () => {
-
         return resources[type];
-
     };
-
 };
 
 // ------------------------------------------------------------------------------

--- a/src/tests/lib/rules/lang-attribute/fixtures/lang-attribute-with-no-value.html
+++ b/src/tests/lib/rules/lang-attribute/fixtures/lang-attribute-with-no-value.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang>
+<head>
+    <title>test</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/tests/lib/rules/lang-attribute/fixtures/lang-attribute-with-valid-value.html
+++ b/src/tests/lib/rules/lang-attribute/fixtures/lang-attribute-with-valid-value.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <title>test</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/tests/lib/rules/lang-attribute/fixtures/lang-attribute-with-value-of-empty-string.html
+++ b/src/tests/lib/rules/lang-attribute/fixtures/lang-attribute-with-value-of-empty-string.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="">
+<head>
+    <title>test</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/tests/lib/rules/lang-attribute/fixtures/no-lang-attribute.html
+++ b/src/tests/lib/rules/lang-attribute/fixtures/no-lang-attribute.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head>
+    <title>test</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/tests/lib/rules/lang-attribute/tests.ts
+++ b/src/tests/lib/rules/lang-attribute/tests.ts
@@ -1,0 +1,65 @@
+import * as jsdom from 'jsdom';
+import * as path from 'path';
+import * as pify from 'pify';
+import * as sinon from 'sinon';
+import test from 'ava';
+
+import { readFile } from '../../../../lib/util/misc';
+import { findProblemLocation } from '../../../../lib/util/location-helpers';
+import * as rule from '../../../../lib/rules/lang-attribute/lang-attribute';
+
+import { Rule, RuleBuilder, ElementFoundEvent } from '../../../../lib/types'; // eslint-disable-line no-unused-vars
+
+const getDOM = async (filePath) => {
+    return await pify(jsdom.env)(readFile(filePath));
+};
+
+const runRule = async (t, filePath: string, tests): Promise<void> => {
+    const context = {
+        findProblemLocation: (element, content) => {
+            return findProblemLocation(element, {column: 0, line: 0}, content);
+        },
+        report: sinon.spy()
+    };
+
+    const window = await getDOM(path.join(__dirname, 'fixtures', filePath));
+    const instance = (<Rule>rule).create(context);
+    const eventData = { element: window.document.documentElement };
+
+    instance['element::html'](eventData);
+
+    tests(t, context, eventData);
+};
+
+test(`'lang' attribute is not specified`, runRule, 'no-lang-attribute.html', (t, context, eventData) => {
+    t.is(context.report.calledOnce, true);
+    t.is(context.report.calledWithExactly(
+        eventData.resource,
+        eventData.element,
+        `'lang' attribute not specified on the 'html' element`
+    ), true);
+});
+
+test(`'lang' attribute is specified with no value`, runRule, 'lang-attribute-with-no-value.html', (t, context, eventData) => {
+    t.is(context.report.calledOnce, true);
+    t.is(context.report.calledWithExactly(
+        eventData.resource,
+        eventData.element,
+        `empty 'lang' attribute specified on the 'html' element`,
+        {column: 7, line: 1}
+    ), true);
+});
+
+test(`'lang' attribute is specified and its value is an empty string`, runRule, 'lang-attribute-with-value-of-empty-string.html', (t, context, eventData) => {
+    t.is(context.report.calledOnce, true);
+    t.is(context.report.calledWithExactly(
+        eventData.resource,
+        eventData.element,
+        `empty 'lang' attribute specified on the 'html' element`,
+        {column: 7, line: 1}
+    ), true);
+});
+
+test(`'lang' attribute is specified and its value is not an empty string`, runRule, 'lang-attribute-with-valid-value.html', (t, context) => {
+    t.is(context.report.notCalled, true);
+});

--- a/src/tests/lib/util/location-helpers.ts
+++ b/src/tests/lib/util/location-helpers.ts
@@ -47,7 +47,7 @@ const findInElementEntries = [
         content: 'https://',
         position: {
             line: 1,
-            column: 9
+            column: 10
         }
     },
     {


### PR DESCRIPTION
##  Rule Details

This rule warns against not using the `lang` attribute on the `html` element, or using it on the `html` element but with the value of empty string.

It's indicated to always set the `lang` attribute on the `html` element so that it's inherited by all other elements ([even the ones in the `<head>`](https://www.w3.org/International/questions/qa-html-language-declarations#basics)), and it sets the primary language of the document.

Setting the `lang` attribute provides an explicit indicate to user agents about the language of the content, which can help, among other:

  * [screen readers and similar assistive technologies with voice output and pronunciation of content using the correct voice/language library](http://blog.adrianroselli.com/2015/01/on-use-of-lang-attribute.html)

  * determine the appropriate language dictionary, the types of [quotation marks for `q` elements](https://www.w3.org/International/questions/qa-lang-why#rendering), the styling such as the one for [hyphenation](http://www.quirksmode.org/blog/archives/2012/11/hyphenation_wor.html), [case conversion, line-breaking, and spell-checking](https://www.w3.org/International/questions/qa-lang-why#authoring)

  * [font selection where different alphabets are mixed](https://www.w3.org/International/questions/qa-lang-why#fonts)

  * improve localization (e.g. [what numeric software keyboard will be opened for `<input type="number">`](https://ctrl.blog/entry/html5-input-number-localization))

## Resources

* [Declaring the language in HTML](https://www.w3.org/International/questions/qa-html-language-declarations)
* [Why use the language attribute?](https://www.w3.org/International/questions/qa-lang-why)


---

Note: This rule does not check if the value of the `lang` attribute is valid or not (that will be covered by a different [rule](https://github.com/MicrosoftEdge/Sonar/issues/28)).

---

Close #16