### PR TITLE
Let `eslint` interpret the glob patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:assets": "cpx \"./src/**/*.!(ts)\" dist",
     "build:ts":"tsc --outDir dist --rootDir src",
     "build": "npm-run-all build:*",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint \"src/**/*.ts\"",
     "site": "node dist/bin/sonar --debug",
     "test": "npm run build && nyc ava",
     "watch": "npm run build && npm-run-all --parallel -c watch:*",


### PR DESCRIPTION
From https://github.com/eslint/eslint/issues/8191#issuecomment-284056465:

> When a glob pattern is quoted, it will (generally) not be interpreted by a shell. When it is not quoted, it probably will be interpreted by a shell and then ESLint just receives a list of filenames.
>
> If ESLint sees a glob pattern (i.e., the pattern was not interpreted by a shell), we use `node-glob` to expand the glob, which follows the `.gitignore` standard. Shell glob expansions may not follow `.gitignore`. "

---

@molant With the [current command](https://github.com/MicrosoftEdge/Sonar/blob/3ff220ecf0928a0a840c6c0b9ddbe22c672da830/package.json#L11), on my system, only the following are passed to `eslint`:

```
src/bin/sonar.ts
src/lib/cli.ts
src/lib/config.ts
src/lib/rule-context.ts
src/lib/sonar.ts
src/lib/types.ts
```