### PR TITLE
Add `Cache-Control: no-cache` header to requests

### DIFF
--- a/src/lib/collectors/jsdom.ts
+++ b/src/lib/collectors/jsdom.ts
@@ -5,6 +5,7 @@
     gzip: true,
     headers: {
         'Accept-Language': 'en-US,en;q=0.8,es;q=0.6,fr;q=0.4',
+        'Cache-Control': 'no-cache',
         DNT: 1,
         Pragma: 'no-cache',
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36'
@@ -40,6 +41,7 @@ const defaultOptions = {
     gzip: true,
     headers: {
         'Accept-Language': 'en-US,en;q=0.8,es;q=0.6,fr;q=0.4',
+        'Cache-Control': 'no-cache',
         DNT: 1,
         Pragma: 'no-cache',
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36'


### PR DESCRIPTION
From https://tools.ietf.org/html/rfc7234#section-5.4

>  In HTTP/1.0, Pragma was defined as an extensible field for
   implementation-specified directives for recipients.  This
   specification deprecates such extensions to improve interoperability.
>
> When the Cache-Control header field is not present in a request,
   caches MUST consider the no-cache request pragma-directive as having
   the same effect as if "Cache-Control: no-cache" were present (see
   Section 5.2.1).
>  
> **When sending a no-cache request, a client ought to include both the
   pragma and cache-control directives,** unless Cache-Control: no-cache
   is purposefully omitted to target other Cache-Control response
   directives at HTTP/1.1 caches. 
>
>...
>     
>   Note: **Because the meaning of "Pragma: no-cache" in responses is
      not specified, it does not provide a reliable replacement for
      "Cache-Control: no-cache" in them.**

---

See also: https://tools.ietf.org/html/rfc7234