### PR TITLE
Add support for loading files with `fetchContent` 

### DIFF
--- a/src/lib/rule-context.ts
+++ b/src/lib/rule-context.ts
@@ -42,8 +42,8 @@ export class RuleContext {
     }
 
     /** A useful way of making requests */
-    get pageRequest() {
-        return this.sonar.pageRequest;
+    get fetchContent() {
+        return this.sonar.fetchContent;
     }
 
     /** Finds the exact location in the page's HTML for a match in an element */

--- a/src/lib/sonar.ts
+++ b/src/lib/sonar.ts
@@ -43,8 +43,8 @@ export class Sonar extends EventEmitter {
         return this.collector.headers;
     }
 
-    get pageRequest() {
-        return this.collector.request;
+    fetchContent(target, headers) {
+        return this.collector.fetchContent(target, headers);
     }
 
     constructor(config) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,7 +36,14 @@ export interface Collector {
     /** The headers from the response if applicable */
     headers: object;
     /** A way for you to make requests if needed */
-    request;
+    fetchContent(target: URL | string, customHeaders?: object): Promise<FetchResponse>;
+}
+
+/** The response of fetching an item using the request of a collector */
+export interface FetchResponse {
+    body: string;
+    headers: object;
+    originalBytes?: Uint8Array // TODO: is this the right type?
 }
 
 export interface Config {

--- a/src/tests/lib/collectors/fixtures/file-protocol.txt
+++ b/src/tests/lib/collectors/fixtures/file-protocol.txt
@@ -1,0 +1,1 @@
+This is a file read using file://

--- a/src/tests/lib/collectors/jsdom.ts
+++ b/src/tests/lib/collectors/jsdom.ts
@@ -1,0 +1,33 @@
+import * as fileUrl from 'file-url';
+import * as path from 'path';
+
+import { test, ContextualTestContext } from 'ava'; // eslint-disable-line no-unused-vars
+import * as sinon from 'sinon';
+
+
+import { Collector, CollectorBuilder } from '../../../lib/types';
+import * as builder from '../../../lib/collectors/jsdom';
+import { Sonar } from '../../../lib/sonar'; // eslint-disable-line no-unused-vars
+
+test.beforeEach((t) => {
+    const server = { emitAsync() { } };
+    const collector = (<CollectorBuilder>builder)(server, {});
+
+    sinon.spy(server, 'emitAsync');
+    t.context.collector = collector;
+    t.context.emitAsync = server.emitAsync;
+});
+
+test.afterEach((t) => {
+    t.context.emitAsync.restore();
+});
+
+
+test(async (t) => {
+    const collector = <Collector>t.context.collector;
+    const filePath = fileUrl(path.resolve(__dirname, './fixtures/file-protocol.txt'));
+    const content = await collector.fetchContent(filePath);
+
+    t.is(content.body, 'This is a file read using file://', 'jsdom collector can read file://');
+    t.falsy(content.headers, 'no headers are returned for file:// target');
+});


### PR DESCRIPTION
Until now, `fetchContent` in JSDOM collector could only load `http(s)://`
resources. Now it also supports `file://`.
With the refactor we are changing some other things:
* Instead of exposing the request object, we now have a method that accepts a url
object or a string (it will try to convert it to a valid url object) as well as headers
* Change from exposing the `request` object to have a method `fetchContent`
* Rename `pagetRequest` to `fetchContent`
* Add test to check `jsdom` loads files from the file system