### PR TITLE
Add support for redirects in test-server

### DIFF
--- a/src/tests/helpers/test-server.ts
+++ b/src/tests/helpers/test-server.ts
@@ -63,6 +63,12 @@ class Server {
                     return;
                 }
 
+                if (value && (value.status === 301 || value.status === 302)) {
+                    res.redirect(value.status, content);
+
+                    return;
+                }
+
                 if (value && value.status) {
                     res.status(value.status);
                 }


### PR DESCRIPTION
We can now do redirects passing the following configuration to test server:
```javascript
{
  '/redirect': {
    content: '/target',
    status: 301
  },
  '/target': 'Final destination'
}
```

The valid values for `status` are `301` and `302`.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #69