### PR TITLE
Make `fetch::end` event also send the original URL

### DIFF
--- a/src/lib/collectors/cdp/cdp.ts
+++ b/src/lib/collectors/cdp/cdp.ts
@@ -49,7 +49,7 @@ class CDPCollector implements ICollector {
         this._options = Object.assign({}, defaultOptions, config);
         this._headers = this._options.headers;
 
-        //TODO: setExtraHTTPHeaders with _headers in an async way
+        // TODO: setExtraHTTPHeaders with _headers in an async way.
 
         this._requests = new Map();
     }
@@ -67,24 +67,24 @@ class CDPCollector implements ICollector {
             // const { lineNumber } = initiator;
             await DOM.querySelectorAll('[src]');
 
-            // do a query selector to get the asset that has this url and then do some magic
+            // do a query selector to get the asset that has this url and then do some magic.
         }
     }
 
-    /** Event handler for when the browser is about to make a request */
+    /** Event handler for when the browser is about to make a request. */
     private async onRequestWillBeSent(params) {
         const requestUrl = params.request.url;
 
         this._requests.set(params.requestId, params);
 
         if (!this._headers) {
-            // TODO: do some clean up, we probably don't want all the headers as the "defaults"
+            // TODO: do some clean up, we probably don't want all the headers as the "defaults".
             this._headers = params.request.headers;
         }
 
         if (params.redirectResponse) {
             debug(`Redirect found for ${requestUrl}`);
-            // We store the redirects with the finalUrl as a key to do a reverse search in onResponseReceived
+            // We store the redirects with the finalUrl as a key to do a reverse search in onResponseReceived.
             this._redirects.add(requestUrl, params.redirectResponse.url);
 
             return;
@@ -98,7 +98,7 @@ class CDPCollector implements ICollector {
 
     /** Event handler fired when HTTP request fails for some reason. */
     private onLoadingFailed(params) {
-        //TODO: implement this for `fetch::error` and `targetfetch::error`
+        // TODO: implement this for `fetch::error` and `targetfetch::error`.
         console.error(params);
     }
 
@@ -128,10 +128,11 @@ class CDPCollector implements ICollector {
             }
         };
 
-        await this._server.emitAsync(eventName, null, data);
+        // TODO: Replace `null` with `CDPAsyncHTMLElement` object.
+        await this._server.emitAsync(eventName, originalUrl, null, data);
     }
 
-    /** Traverses the DOM notifying when a new element is traversed */
+    /** Traverses the DOM notifying when a new element is traversed. */
     private async traverseAndNotify(element) {
         const eventName = `element::${element.nodeName.toLowerCase()}`;
 
@@ -187,7 +188,7 @@ class CDPCollector implements ICollector {
 
                 callback();
             });
-            // We enable all the domains we need to receive events from the CDP
+            // We enable all the domains we need to receive events from the CDP.
             await Promise.all([
                 Network.enable(),
                 Page.enable()
@@ -197,7 +198,7 @@ class CDPCollector implements ICollector {
     }
 
     async fetchContent(target: URL | string, customHeaders?: object) {
-        // TODO: This should create a new tab, navigate to the resource and control what is received somehow via an event
+        // TODO: This should create a new tab, navigate to the resource and control what is received somehow via an event.
         let req;
         const href = typeof target === 'string' ? target : target.href;
 
@@ -220,7 +221,7 @@ class CDPCollector implements ICollector {
                 body,
                 headers: response.headers,
                 hops: [], // TODO: populate
-                originalBytes: null, // Add original compressed bytes here (originalBytes)
+                originalBytes: null, // Add original compressed bytes here (originalBytes).
                 statusCode: response.statusCode,
                 url: href
             }

--- a/src/lib/collectors/jsdom/jsdom.ts
+++ b/src/lib/collectors/jsdom/jsdom.ts
@@ -211,7 +211,7 @@ const builder: ICollectorBuilder = (server: Sonar, config): ICollector => {
                 }
 
                 debug(`HTML for ${href} downloaded`);
-                await server.emitAsync('targetfetch::end', null, targetNetworkData);
+                await server.emitAsync('targetfetch::end', href, null, targetNetworkData);
 
                 jsdom.env({
                     done: (err, window) => {
@@ -261,7 +261,9 @@ const builder: ICollectorBuilder = (server: Sonar, config): ICollector => {
 
                             debug(`resource ${resourceUrl} fetched`);
 
-                            await server.emitAsync('fetch::end', resource, resourceNetworkData);
+                            // TODO: Replace `null` with `resource` once it
+                            // can be converted to `JSDOMAsyncHTMLElement`.
+                            await server.emitAsync('fetch::end', resourceUrl, null, resourceNetworkData);
 
                             return callback(null, resourceNetworkData.response.body);
                         } catch (err) {

--- a/src/lib/rules/disallowed-headers/disallowed-headers.ts
+++ b/src/lib/rules/disallowed-headers/disallowed-headers.ts
@@ -6,7 +6,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-import { IElementFoundEvent, IRule, IRuleBuilder } from '../../interfaces'; // eslint-disable-line no-unused-vars
+import { IAsyncHTMLElement, IElementFoundEvent, IRule, IRuleBuilder, INetworkData } from '../../interfaces'; // eslint-disable-line no-unused-vars
 import { RuleContext } from '../../rule-context'; // eslint-disable-line no-unused-vars
 
 // ------------------------------------------------------------------------------
@@ -64,11 +64,11 @@ const rule: IRuleBuilder = {
             return headersFound;
         };
 
-        const validate = (resource, networkData) => {
+        const validate = (resourceURL: string, element: IAsyncHTMLElement, networkData: INetworkData) => {
             const headers = findDisallowedHeaders(networkData.response.headers);
 
             if (headers.length > 0) {
-                context.report(resource, null, `Disallowed HTTP header${headers.length > 1 ? 's' : ''} found: ${headers.join(', ')}`);
+                context.report(resourceURL, element, `Disallowed HTTP header${headers.length > 1 ? 's' : ''} found: ${headers.join(', ')}`);
             }
         };
 

--- a/src/lib/rules/manifest-exists/manifest-exists.ts
+++ b/src/lib/rules/manifest-exists/manifest-exists.ts
@@ -106,7 +106,7 @@ const rule: IRuleBuilder = {
     },
     meta: {
         docs: {
-            category: 'PWA',
+            category: 'pwa',
             description: 'Provide a web app manifest file',
             recommended: true
         },

--- a/src/lib/rules/manifest-file-extension/manifest-file-extension.ts
+++ b/src/lib/rules/manifest-file-extension/manifest-file-extension.ts
@@ -45,7 +45,7 @@ const rule: IRuleBuilder = {
     },
     meta: {
         docs: {
-            category: 'PWA',
+            category: 'pwa',
             description: 'Use `.webmanifest` as the file extension for the web app manifest file',
             recommended: true
         },

--- a/src/lib/rules/manifest-is-valid/manifest-is-valid.ts
+++ b/src/lib/rules/manifest-is-valid/manifest-is-valid.ts
@@ -76,7 +76,7 @@ const rule: IRuleBuilder = {
     },
     meta: {
         docs: {
-            category: 'PWA',
+            category: 'pwa',
             description: 'Check if the content of the web app manifest is valid',
             recommended: true
         },

--- a/src/lib/rules/no-double-slash/no-double-slash.ts
+++ b/src/lib/rules/no-double-slash/no-double-slash.ts
@@ -52,7 +52,7 @@ const rule: IRuleBuilder = {
     },
     meta: {
         docs: {
-            category: 'Security',
+            category: 'security',
             description: 'Use https over //',
             recommended: true
         },

--- a/src/lib/rules/no-friendly-error-pages/no-friendly-error-pages.ts
+++ b/src/lib/rules/no-friendly-error-pages/no-friendly-error-pages.ts
@@ -30,7 +30,7 @@ const rule: IRuleBuilder = {
 
         const foundErrorPages = {};
 
-        const checkForErrorPages = (resource, networkData) => {
+        const checkForErrorPages = (resourceURL, resource, networkData) => {
 
             // Ignore requests to local files.
 
@@ -88,7 +88,7 @@ const rule: IRuleBuilder = {
             try {
                 const networkData = await context.fetchContent(url.resolve(baseURL, `.well-known/${Math.random()}`));
 
-                checkForErrorPages(null, networkData);
+                checkForErrorPages(target, null, networkData);
             } catch (e) {
                 // This will most likely fail because target is a local file.
                 debug(`Custom request to generate 404 response failed for: ${target}`);
@@ -112,7 +112,7 @@ const rule: IRuleBuilder = {
             for (const key of Object.keys(foundErrorPages)) {
                 const threshold = statusCodesWith512Threshold.includes(Number.parseInt(key)) ? 512 : 256;
 
-                context.report(null, null, `Response with statusCode ${key} had less than ${threshold} bytes`);
+                context.report(href, null, `Response with statusCode ${key} had less than ${threshold} bytes`);
             }
         };
 

--- a/src/tests/lib/collectors/_common.ts
+++ b/src/tests/lib/collectors/_common.ts
@@ -26,7 +26,7 @@ const testCollector = (collectorBuilder: ICollectorBuilder) => {
      */
     const events = [
         ['targetfetch::start', 'http://localhost/'],
-        ['targetfetch::end', null, {
+        ['targetfetch::end', 'http://localhost/', null, {
             request: { url: 'http://localhost/' },
             response: {
                 body: fs.readFileSync(path.join(__dirname, './fixtures/common/index.html'), 'utf8'),
@@ -50,7 +50,7 @@ const testCollector = (collectorBuilder: ICollectorBuilder) => {
         ['element::p'],
         ['traverse::end', 'http://localhost/'],
         ['fetch::start', 'http://localhost/script3.js'],
-        ['fetch::end', undefined, { //eslint-disable-line no-undefined
+        ['fetch::end', 'http://localhost/script3.js', undefined, { //eslint-disable-line no-undefined
             request: { url: 'http://localhost/script3.js' },
             response: {
                 body: fs.readFileSync(path.join(__dirname, './fixtures/common/script.js'), 'utf8'),
@@ -61,7 +61,7 @@ const testCollector = (collectorBuilder: ICollectorBuilder) => {
             }
         }],
         ['fetch::start', 'http://localhost/style.css'],
-        ['fetch::end', undefined, { //eslint-disable-line no-undefined
+        ['fetch::end', 'http://localhost/style.css', undefined, { //eslint-disable-line no-undefined
             request: { url: 'http://localhost/style.css' },
             response: {
                 body: fs.readFileSync(path.join(__dirname, './fixtures/common/style.css'), 'utf8'),


### PR DESCRIPTION
Fix #86 (although it uses `null` for now as `resource` cannot always be converted to `JSDOMAsyncHTMLElement`).