### PR TITLE
Send `element` on `fetch::end` + refactor and document events

### DIFF
--- a/.sonarrc
+++ b/.sonarrc
@@ -1,6 +1,6 @@
 {
     "collector": {
-        "name": "jsdom",
+        "name": "cdp",
         "options": {
             "waitFor": 100
         }

--- a/docs/developer-guide/events/list-of-events.md
+++ b/docs/developer-guide/events/list-of-events.md
@@ -1,0 +1,155 @@
+# List of events emitted by a collector
+
+`collector`s communicate via events. The following is a list of all the events
+commont to all `collector`s, with their signature and the `interface` they implement.
+
+## `targetfetch::start`
+
+* **When?** When the `collector` is about to start the request to fetch the `target`.
+* **Format**
+```typescript
+export interface IFetchStartEvent {
+    /** The url to download */
+    resource: string;
+}
+```
+* **Remarks:** The event is the same for [`fetch::start`](#fetch::start)
+
+## `targetfetch::end`
+
+* **When?** When the `collector` has finished downloading the `html` of the `target`.
+* **Format**
+```typescript
+export interface IFetchEndEvent {
+    /** The element that initiated the request. */
+    element: IAsyncHTMLElement;
+    /** The url of the target. */
+    resource: string;
+    /** The request made to fetch the target. */
+    request: IRequest;
+    /** The response sent while fetching the target. */
+    response: IResponse;
+}
+```
+* **Remarks:** The event is the same for [`fetch::end`](#fetch::end). In this case `element` will be null.
+
+## `targetfetch::error`
+
+* **When?** When the `collector` has found a problem downloading the `html` of the `target`.
+* **Format**
+```typescript
+export interface IFetchErrorEvent {
+    /** The url of the target. */
+    resource: string;
+    /** The element that initiated the request. */
+    element: IAsyncHTMLElement;
+    /** The error found. */
+    error: any;
+}
+```
+* **Remarks:** The event is the same for [`fetch::error`](#fetch::error). In this case `element` will be null.
+
+## `fetch::start`
+* **When?** When the `collector` is about to start the request to fetch the `target`.
+* **Format**
+```typescript
+export interface IFetchStartEvent {
+    /** The url to download */
+    resource: string;
+}
+```
+* **Remarks:** The event is the same for [`targetfetch::start`](#targetfetch::start).
+
+## `fetch::end`
+
+* **When?** When the `collector` has finished downloading the content of a `resource` (`js`, `css`, `image`, etc.).
+* **Format**
+```typescript
+export interface IFetchEndEvent {
+    /** The element that initiated the request. */
+    element: IAsyncHTMLElement;
+    /** The url of the target */
+    resource: string;
+    /** The request made to fetch the target. */
+    request: IRequest;
+    /** The response sent while fetching the target. */
+    response: IResponse;
+}
+```
+* **Remarks:** The event is the same for [`targetfetch::end`](#targetfetch::end).
+
+## `fetch::error`
+
+* **When?** When the `collector` has found a problem downloading the content of a `resource`.
+* **Format**
+```typescript
+export interface IFetchErrorEvent {
+    /** The url of the target. */
+    resource: string;
+    /** The element that initiated the request. */
+    element: IAsyncHTMLElement;
+    /** The error found. */
+    error: any;
+}
+```
+* **Remarks:** The event is the same for [`targetfetch::error`](#targetfetch::error).
+
+## `traverse::start`
+
+* **When?** When the `collector` is going to start traversing the DOM.
+* **Format**
+```typescript
+export interface ITraverseStartEvent {
+    /** The url of the target. */
+    resource: string;
+}
+```
+
+## `traverse::end`
+
+* **When?** When the `collector` has finished traversing the DOM entirely.
+* **Format**
+```typescript
+export interface ITraverseEndEvent {
+    /** The url of the target. */
+    resource: string;
+}
+```
+
+## `traverse::down`
+
+* **When?** When the `collector` is traversing and starts visiting the children
+of a node.
+* **Format**
+```typescript
+export interface ITraverseDownEvent {
+    /** The url of the target. */
+    resource: string;
+}
+```
+
+## `traverse::up`
+
+* **When?** When the `collector` has finsihed visting the children of a node and goes to the next one.
+
+* **Format**
+```typescript
+export interface ITraverseUpEvent {
+    /** The url of the target. */
+    resource: string;
+}
+```
+
+## `element::typeofelement`
+
+* **When?** When the `collector` visits an element in the DOM when traversing it. `XXXX` is the `nodeType` lower cased.
+
+* **Format**
+```typescript
+export interface IElementFoundEvent {
+    /** The uri of the resource firing this event. */
+    resource: string;
+    /** The visited element. */
+    element: IAsyncHTMLElement;
+}
+```

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm run clean && npm-run-all build:*",
     "clean": "rimraf dist",
     "lint": "eslint --ext ts src/ --ext md . --ignore-pattern dist/*",
-    "site": "node dist/bin/sonar --debug",
+    "site": "node dist/bin/sonar",
     "test": "npm run lint && npm run clean && npm run build && nyc ava",
     "watch": "npm run build && npm-run-all --parallel -c watch:*",
     "watch:ts": "npm run build:ts -- --watch",

--- a/src/lib/collectors/cdp/cdp-async-html.ts
+++ b/src/lib/collectors/cdp/cdp-async-html.ts
@@ -33,8 +33,14 @@ export class CDPAsyncHTMLDocument implements IAsyncHTMLDocument {
     // Public methods
     // ------------------------------------------------------------------------------
 
-    async querySelectorAll(selector: string) {
-        const { nodeIds } = await this._DOM.querySelectorAll({ nodeId: 1, selector });
+    async querySelectorAll(selector: string): Promise<Array<CDPAsyncHTMLElement>> {
+        let nodeIds;
+
+        try {
+            nodeIds = (await this._DOM.querySelectorAll({ nodeId: 1, selector })).nodeIds;
+        } catch (e) {
+            return [];
+        }
 
         return nodeIds.map((nodeId) => {
             return new CDPAsyncHTMLElement(this._nodes.get(nodeId), this, this._DOM); // eslint-disable-line no-use-before-define

--- a/src/lib/interfaces/events.ts
+++ b/src/lib/interfaces/events.ts
@@ -1,21 +1,63 @@
 import { IAsyncHTMLElement } from './asynchtml';
+import { IRequest, IResponse } from './network';
 
-/** The object emited by a collector on `fetch::end` */
-export interface IFetchEndEvent {
-    /** The uri of the resource firing this event */
+
+/** The object emited by a collector on `targetfetch::start` or `fetch::start`. */
+export interface IFetchStartEvent {
+    /** The url to download. */
     resource: string;
-    /** The HTMLElement that started the fetch */
-    element: HTMLElement;
-    /** The content of target in the url or href of element */
-    content: string;
-    /** The headers of the response */
-    headers: object;
 }
 
-/** The object emited by a collector on `element::TYPEOFELEMENT` */
-export interface IElementFoundEvent {
-    /** The uri of the resource firing this event */
+/** The object emited by a collector on `targetfetch::end` or `fetch::start`. */
+export interface IFetchEndEvent {
+    /** The element that initiated the request. */
+    element: IAsyncHTMLElement;
+    /** The url of the target. */
     resource: string;
-    /** The HTMLElement found */
+    /** The request made to fetch the target. */
+    request: IRequest;
+    /** The response sent while fetching the target. */
+    response: IResponse;
+}
+
+/** The object emitted by a collector on `targetfetch::error` or `fetch::error` */
+export interface IFetchErrorEvent {
+    /** The url of the target. */
+    resource: string;
+    /** The element that initiated the request. */
+    element: IAsyncHTMLElement;
+    /** The error found. */
+    error: any;
+}
+
+/** The object emitted by a collector on `traverse::start` */
+export interface ITraverseStartEvent {
+    /** The url of the target. */
+    resource: string;
+}
+
+/** The object emitted by a collector on `traverse::end` */
+export interface ITraverseEndEvent {
+    /** The url of the target. */
+    resource: string;
+}
+
+/** The object emitted by a collector on `traverse::up` */
+export interface ITraverseUpEvent {
+    /** The url of the target. */
+    resource: string;
+}
+
+/** The object emitted by a collector on `traverse::down` */
+export interface ITraverseDownEvent {
+    /** The url of the target. */
+    resource: string;
+}
+
+/** The object emited by a collector on `element::typeofelement`. */
+export interface IElementFoundEvent {
+    /** The uri of the resource firing this event. */
+    resource: string;
+    /** The visited element. */
     element: IAsyncHTMLElement;
 }

--- a/src/lib/rules/disallowed-headers/disallowed-headers.ts
+++ b/src/lib/rules/disallowed-headers/disallowed-headers.ts
@@ -6,7 +6,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-import { IAsyncHTMLElement, IElementFoundEvent, IRule, IRuleBuilder, INetworkData } from '../../interfaces'; // eslint-disable-line no-unused-vars
+import { IFetchEndEvent, IRule, IRuleBuilder } from '../../interfaces'; // eslint-disable-line no-unused-vars
 import { RuleContext } from '../../rule-context'; // eslint-disable-line no-unused-vars
 
 // ------------------------------------------------------------------------------
@@ -64,11 +64,12 @@ const rule: IRuleBuilder = {
             return headersFound;
         };
 
-        const validate = (resourceURL: string, element: IAsyncHTMLElement, networkData: INetworkData) => {
-            const headers = findDisallowedHeaders(networkData.response.headers);
+        const validate = (fetchEnd: IFetchEndEvent) => {
+            const { element, resource } = fetchEnd;
+            const headers = findDisallowedHeaders(fetchEnd.response.headers);
 
             if (headers.length > 0) {
-                context.report(resourceURL, element, `Disallowed HTTP header${headers.length > 1 ? 's' : ''} found: ${headers.join(', ')}`);
+                context.report(resource, element, `Disallowed HTTP header${headers.length > 1 ? 's' : ''} found: ${headers.join(', ')}`);
             }
         };
 

--- a/src/lib/rules/manifest-exists/manifest-exists.ts
+++ b/src/lib/rules/manifest-exists/manifest-exists.ts
@@ -9,7 +9,7 @@
 
 import * as url from 'url';
 
-import { IElementFoundEvent, IRule, IRuleBuilder } from '../../interfaces'; // eslint-disable-line no-unused-vars
+import { IElementFoundEvent, ITraverseEndEvent, IRule, IRuleBuilder } from '../../interfaces'; // eslint-disable-line no-unused-vars
 import { RuleContext } from '../../rule-context'; // eslint-disable-line no-unused-vars
 import { ruleDebug } from '../../util/rule-helpers';
 
@@ -89,7 +89,7 @@ const rule: IRuleBuilder = {
                         await context.report(resource, element, `Web app manifest file could not be fetched (status code: ${statusCode})`);
                     }
 
-                // Check if fetching/reading the file failed.
+                    // Check if fetching/reading the file failed.
 
                 } catch (e) {
                     debug('Failed to fetch the web app manifest file');

--- a/src/tests/lib/collectors/fixtures/common/index.html
+++ b/src/tests/lib/collectors/fixtures/common/index.html
@@ -5,7 +5,7 @@
         <script>
             var a = 'a';
         </script>
-        <script src="http://localhost/script3.js"></script>
+        <script src="/script3.js"></script>
         <style>
             h1 {
                 font-size: 2em;

--- a/src/tests/lib/rules/manifest-exists/tests.ts
+++ b/src/tests/lib/rules/manifest-exists/tests.ts
@@ -12,7 +12,6 @@ const htmlWithManifestSpecified =
         <link rel="manifest" href="site.webmanifest">
     </head>
     <body>
-
     </body>
 </html>`;
 


### PR DESCRIPTION
* Send `IAsyncHTMLElement` on `fetch::end` and `fetch::error` in `JSDOM` and `CDP`
and add tests to to `_commont.ts`
* Refactor + document `fetch::start` and `fetch::end` events
* Refactor + document `fetch::error` and `targetfetch::error` events
* Refactor + document `traverse::start` and `traverse::end` events
* Refactor + document `traverse::up` and `traverse::down` events
* Refactor + document `element::typeofelement`

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #101
Fix #98