### PR TITLE
Make Requester's `requiresDecoding` check for more generic patterns

### DIFF
--- a/src/lib/collectors/util/requester.ts
+++ b/src/lib/collectors/util/requester.ts
@@ -40,19 +40,11 @@ export class Requester {
         ['iso-8859-1', 'latin1']
     ])
     /** The content types we can decode. */
-    private static decodeableContentTypes: Array<string> = [
-        'application/javascript',
-        'application/json',
-        'application/x-javascript',
-        'application/xhtml+xml',
-        'application/xml',
-        'image/svg+xml',
-        'text/css',
-        'text/html',
-        'text/javascript',
-        'text/js',
-        'text/plain',
-        'text/xml'
+    private static decodeableContentTypes: Array<RegExp> = [
+        /application\/(?:javascript|json|x-javascript|xml)/i,
+        /application\/.*\+(?:json|xml)/i, // application/xhtml+xml
+        /image\/svg\+xml/i,
+        /text\/.*/i
     ]
 
     /** The valid status codes for redirects we follow. */
@@ -75,7 +67,7 @@ export class Requester {
         for (let i = 0; i < Requester.decodeableContentTypes.length && !requires; i++) {
             const ct = Requester.decodeableContentTypes[i];
 
-            requires = contentType.includes(ct);
+            requires = ct.test(contentType);
         }
 
         return requires;

--- a/tests/lib/collectors/utils/requester.ts
+++ b/tests/lib/collectors/utils/requester.ts
@@ -46,10 +46,22 @@ const supportedEncodings = [
     'windows-1251'
 ];
 
+const contentTypes = [
+    'application/javascript',
+    'application/json',
+    'application/x-javascript',
+    'application/xml',
+    'application/xhtml+xml',
+    'application/something+json',
+    'image/svg+xml',
+    'text/html',
+    'text/something'
+];
+
 /** This function verifies that we can decode the bytes for the expected `Content-Type`s
  * and the supported `charset`s, even when the server response is compressed.
  * */
-const testTextDecoding = async (t, encoding: string, useCompression: boolean) => {
+const testTextDecoding = async (t, encoding: string, contentType: string, useCompression: boolean) => {
     const { requester, server } = t.context;
     const originalBytes = iconv.encode(text, encoding);
     const transformedText = iconv.decode(originalBytes, encoding);
@@ -60,7 +72,7 @@ const testTextDecoding = async (t, encoding: string, useCompression: boolean) =>
             content,
             headers: {
                 'Content-Encoding': useCompression ? 'gzip' : 'identity',
-                'Content-Type': `text/html; charset=${encoding}`
+                'Content-Type': `${contentType}; charset=${encoding}`
             }
         }
     });
@@ -76,8 +88,10 @@ const testTextDecoding = async (t, encoding: string, useCompression: boolean) =>
 };
 
 supportedEncodings.forEach((encoding) => {
-    test(`requester handles ${encoding}`, testTextDecoding, encoding, false);
-    test(`requester handles ${encoding}`, testTextDecoding, encoding, true);
+    contentTypes.forEach((contentType) => {
+        test(`requester handles ${encoding}`, testTextDecoding, encoding, contentType, false);
+        test(`requester handles ${encoding}`, testTextDecoding, encoding, contentType, true);
+    });
 });
 
 // ------------------------------------------------------------------------------


### PR DESCRIPTION
Fix #121