### PR TITLE
Change `response.body` into an object

### DIFF
--- a/src/lib/collectors/cdp/cdp.ts
+++ b/src/lib/collectors/cdp/cdp.ts
@@ -191,11 +191,14 @@ class CDPCollector implements ICollector {
             },
             resource: resourceUrl,
             response: {
-                body: resourceBody,
+                body: {
+                    content: resourceBody,
+                    contentEncoding: null,
+                    rawContent: null,
+                    rawResponse: null
+                },
                 headers: resourceHeaders,
                 hops,
-                rawBody: null,
-                rawBodyResponse: null,
                 statusCode: 200,
                 url: params.response.url
             }
@@ -307,11 +310,14 @@ class CDPCollector implements ICollector {
                 url: href
             },
             response: {
-                body,
+                body: {
+                    content: body,
+                    contentEncoding: null,
+                    rawContent: null,
+                    rawResponse: null
+                },
                 headers: normalizeHeaders(response.headers),
                 hops: [], // TODO: populate
-                rawBody: null,
-                rawBodyResponse: null, // Add original compressed bytes here (originalBytes).
                 statusCode: response.statusCode,
                 url: href
             }

--- a/src/lib/collectors/jsdom/jsdom.ts
+++ b/src/lib/collectors/jsdom/jsdom.ts
@@ -97,11 +97,14 @@ class JSDOMCollector implements ICollector {
                 url: targetPath
             },
             response: {
-                body,
+                body: {
+                    content: body,
+                    contentEncoding: null,
+                    rawContent: null,
+                    rawResponse: null
+                },
                 headers: null,
                 hops: [],
-                rawBody: null,
-                rawBodyResponse: null,
                 statusCode: null,
                 url: targetPath
             }
@@ -181,7 +184,7 @@ class JSDOMCollector implements ICollector {
             // can be converted to `JSDOMAsyncHTMLElement`.
             await this._server.emitAsync('fetch::end', fetchEndEvent);
 
-            return callback(null, resourceNetworkData.response.body);
+            return callback(null, resourceNetworkData.response.body.content);
         } catch (err) {
             const fetchError: IFetchErrorEvent = {
                 element: new JSDOMAsyncHTMLElement(resource.element),
@@ -272,7 +275,7 @@ class JSDOMCollector implements ICollector {
                     SkipExternalResources: false
                 },
                 headers: that._headers,
-                html: that._targetNetworkData.response.body,
+                html: that._targetNetworkData.response.body.content,
                 resourceLoader: that.resourceLoader.bind(that)
             });
         });
@@ -314,7 +317,7 @@ class JSDOMCollector implements ICollector {
         return this._targetNetworkData.response.headers;
     }
     get html(): string {
-        return this._targetNetworkData.response.body;
+        return this._targetNetworkData.response.body.content;
     }
 }
 

--- a/src/lib/collectors/utils/requester.ts
+++ b/src/lib/collectors/utils/requester.ts
@@ -145,11 +145,14 @@ export class Requester {
                         url: hops[0] || uri
                     },
                     response: {
-                        body,
+                        body: {
+                            content: body,
+                            contentEncoding: charset,
+                            rawContent: rawBody,
+                            rawResponse: rawBodyResponse
+                        },
                         headers: response.headers,
                         hops,
-                        rawBody,
-                        rawBodyResponse,
                         statusCode: response.statusCode,
                         url: uri
                     }
@@ -158,7 +161,7 @@ export class Requester {
                 return resolve(networkData);
             })
                 /* This will allow us to get the raw response's body, handy if it is compressed.
-                    See: https://github.com/request/request#examples for more info
+                   See: https://github.com/request/request/tree/6f286c81586a90e6a9d97055f131fdc68e523120#examples.
                  */
                 .on('response', (response) => {
                     response

--- a/src/lib/interfaces/network.ts
+++ b/src/lib/interfaces/network.ts
@@ -6,18 +6,25 @@ export interface IRequest {
     url: string;
 }
 
+export interface IResponseBody {
+    /** The uncompressed response's body. A `string` if text, otherwise a `Buffer`. */
+    content: string | Buffer;
+    /** The encoding of the response's body. */
+    contentEncoding: string;
+    /** The uncompressed bytes of the response's body. */
+    rawContent: Buffer;
+    /** The original bytes of the body. They could be compressed or not. */
+    rawResponse: Buffer;
+}
+
 /** Response data from fetching an item using a collector. */
 export interface IResponse {
-    /** The uncompressed response's body. A `string` if text, otherwise a `Buffer`. */
-    body: string;
-    /** The uncompressed bytes of the response's body. */
-    rawBody: Buffer;
+    /** The content of the body sent by the server in different forms. */
+    body: IResponseBody;
     /** The headers sent by the server. */
     headers: any;
     /** All the intermediate urls from the initial request until we got the response (if any). */
     hops: Array<string>;
-    /** The original bytes of the body. They could be compressed or not. */
-    rawBodyResponse: Buffer;
     /** The status code of the response. */
     statusCode: number;
     /** The url that returned the data. When in a redirect it will be the final one and not the initiator. */

--- a/src/lib/rules/manifest-is-valid/manifest-is-valid.ts
+++ b/src/lib/rules/manifest-is-valid/manifest-is-valid.ts
@@ -58,8 +58,13 @@ const rule: IRuleBuilder = {
                     // Validate the content of the web app manifest file.
 
                     try {
-                        JSON.parse(body);
-                        // TODO: Add more complex web app manifest file validation.
+                        if (typeof body.content === 'string') {
+                            // TODO: Add more complex web app manifest file validation.
+                            JSON.parse(body.content);
+                        } else {
+                            context.report(resource, element, `Web app manifest file is not a text file`);
+                            debug('Web app manifest file is not a text file');
+                        }
                     } catch (e) {
                         debug('Failed to parse the web app manifest file');
                         context.report(resource, element, `Web app manifest file doesn't contain valid JSON`);

--- a/src/lib/rules/no-friendly-error-pages/no-friendly-error-pages.ts
+++ b/src/lib/rules/no-friendly-error-pages/no-friendly-error-pages.ts
@@ -46,7 +46,9 @@ const rule: IRuleBuilder = {
             //
             // See: https://github.com/MicrosoftEdge/Sonar/issues/89
 
-            const size = Buffer.byteLength(response.body, 'utf8');
+            // TODO: replace the following with:
+            // const size = response.body.rawContent.length;
+            const size = Buffer.byteLength(<string>response.body.content, 'utf8');
 
             // This rule doesn't care about individual responses, only
             // if, in general, for a certain error response the size

--- a/src/lib/rules/no-protocol-relative-urls/no-protocol-relative-urls.ts
+++ b/src/lib/rules/no-protocol-relative-urls/no-protocol-relative-urls.ts
@@ -20,7 +20,6 @@ const debug = d(__filename);
 const rule: IRuleBuilder = {
     create(context: RuleContext): IRule {
 
-
         const validate = async (data: IElementFoundEvent) => {
             const { element, resource } = data;
             const html = await element.outerHTML();

--- a/tests/lib/collectors/_common.ts
+++ b/tests/lib/collectors/_common.ts
@@ -29,7 +29,12 @@ const testCollector = (collectorBuilder: ICollectorBuilder) => {
             resource: 'http://localhost/',
             request: { url: 'http://localhost/' },
             response: {
-                body: fs.readFileSync(path.join(__dirname, './fixtures/common/index.html'), 'utf8'),
+                body: {
+                    content: fs.readFileSync(path.join(__dirname, './fixtures/common/index.html'), 'utf8'),
+                    contentEncoding: null,
+                    rawContent: null,
+                    rawResponse: null
+                },
                 hops: [],
                 statusCode: 200,
                 url: 'http://localhost/'
@@ -63,7 +68,12 @@ const testCollector = (collectorBuilder: ICollectorBuilder) => {
             resource: 'http://localhost/script.js',
             request: { url: 'http://localhost/script3.js' },
             response: {
-                body: fs.readFileSync(path.join(__dirname, './fixtures/common/script.js'), 'utf8'),
+                body: {
+                    content: fs.readFileSync(path.join(__dirname, './fixtures/common/script.js'), 'utf8'),
+                    contentEncoding: null,
+                    rawContent: null,
+                    rawResponse: null
+                },
                 hops: ['http://localhost/script3.js',
                     'http://localhost/script2.js'],
                 statusCode: 200,
@@ -84,7 +94,12 @@ const testCollector = (collectorBuilder: ICollectorBuilder) => {
             resource: 'http://localhost/style.css',
             request: { url: 'http://localhost/style.css' },
             response: {
-                body: fs.readFileSync(path.join(__dirname, './fixtures/common/style.css'), 'utf8'),
+                body: {
+                    content: fs.readFileSync(path.join(__dirname, './fixtures/common/style.css'), 'utf8'),
+                    contentEncoding: null,
+                    rawContent: null,
+                    rawResponse: null
+                },
                 hops: [],
                 statusCode: 200,
                 url: 'http://localhost/style.css'

--- a/tests/lib/rules/manifest-is-valid/tests.ts
+++ b/tests/lib/rules/manifest-is-valid/tests.ts
@@ -82,6 +82,14 @@ const tests: Array<RuleTest> = [
         }
     },
     {
+        name: `Web app manifest is specified and it's a binary file`,
+        reports: [{ message: `Web app manifest file is not a text file` }],
+        serverConfig: {
+            '/': htmlWithManifestSpecified,
+            '/site.webmanifest': { headers: { 'Content-Type': 'image/png' } }
+        }
+    },
+    {
         name: `Web app manifest is specified and request for file fails`,
         serverConfig: {
             '/': htmlWithManifestSpecified,


### PR DESCRIPTION
Make `response.body` an object containing all the variations of the response content:


```js
 body: {
    content: string | Buffer
    contentEncoding: string
    rawContent: Buffer
    rawResponse: Buffer
 }
```

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref https://github.com/MicrosoftEdge/Sonar/commit/9a3c94d6d8e34ea11fb4b5c6563380cf1d04f592
Fix #120