### PR TITLE
ssllabs use the final url when there is a redirect

### DIFF
--- a/src/lib/collectors/cdp/cdp.ts
+++ b/src/lib/collectors/cdp/cdp.ts
@@ -414,19 +414,23 @@ class CDPCollector implements ICollector {
 
             this._dom = new CDPAsyncHTMLDocument(DOM);
 
-            await this._dom.load();
+            try {
+                await this._dom.load();
 
-            while (this._pendingResponseReceived.length) {
-                await this._pendingResponseReceived.shift()();
+                while (this._pendingResponseReceived.length) {
+                    await this._pendingResponseReceived.shift()();
+                }
+
+                await this._server.emitAsync('traverse::start', event);
+                await this.traverseAndNotify(this._dom.root);
+                await this._server.emitAsync('traverse::end', event);
+
+                await this._server.emitAsync('scan::end', event);
+            } catch (err) {
+                return callback(err);
             }
 
-            await this._server.emitAsync('traverse::start', event);
-            await this.traverseAndNotify(this._dom.root);
-            await this._server.emitAsync('traverse::end', event);
-
-            await this._server.emitAsync('scan::end', event);
-
-            setTimeout(callback, 1000); //HACK: need to check if there is any pending request, wait for it and timeout after a few seconds
+            return setTimeout(callback, 1000); //HACK: need to check if there is any pending request, wait for it and timeout after a few seconds
         };
     }
 
@@ -475,6 +479,12 @@ class CDPCollector implements ICollector {
         })();
     }
 
+    private delay = (millisecs) => {
+        return new Promise((resolve) => {
+            setTimeout(resolve, millisecs);
+        });
+    };
+
     public async close() {
         debug('Closing browsers used by CDP');
 
@@ -490,6 +500,11 @@ class CDPCollector implements ICollector {
 
         try {
             this._client.close();
+            /* we need this delay overall because in test if we close the client
+             * and at the same time the next test try to open a new tab
+             * then an error is thrown.
+             */
+            await this.delay(300);
         } catch (e) {
             debug(`Couldn't close the client properly`);
         }

--- a/src/lib/rules/ssllabs/ssllabs.ts
+++ b/src/lib/rules/ssllabs/ssllabs.ts
@@ -13,7 +13,7 @@
 import * as pify from 'pify';
 
 import { debug as d } from '../../utils/debug';
-import { IScanStartEvent, IScanEndEvent, IRule, IRuleBuilder } from '../../types'; // eslint-disable-line no-unused-vars
+import { ITargetFetchEnd, IScanEndEvent, IRule, IRuleBuilder } from '../../types'; // eslint-disable-line no-unused-vars
 import { RuleContext } from '../../rule-context'; // eslint-disable-line no-unused-vars
 
 const debug = d(__filename);
@@ -87,8 +87,17 @@ const rule: IRuleBuilder = {
             };
         };
 
-        const start = (data: IScanStartEvent) => {
+        const start = (data: ITargetFetchEnd) => {
             const { resource } = data;
+
+            if (!resource.startsWith('https://')) {
+                const message = `${resource} doesn't support HTTPS.`;
+
+                debug(message);
+                context.report(resource, null, message);
+
+                return;
+            }
 
             /* HACK: Need to do a require here in order to be capable of mocking
                 when testing the rule and `import` doesn't work here. */
@@ -103,6 +112,10 @@ const rule: IRuleBuilder = {
 
         const end = async (data: IScanEndEvent): Promise<any> => {
             const { resource } = data;
+
+            if (!promise) {
+                return;
+            }
 
             debug(`Waiting for SSL Labs results for ${resource}`);
             let host;
@@ -133,9 +146,13 @@ There might be something wrong with SSL Labs servers.`;
 
         loadRuleConfig();
 
+        /* We are using targetfetch::end instead of scan::start or targetfetch::start
+         * because the ssllabs API doesn't follow the redirects so we need to use the
+         * final url i.e. http://edge.ms
+         */
         return {
             'scan::end': end,
-            'scan::start': start
+            'targetfetch::end': start
         };
     },
     meta: {

--- a/tests/helpers/rule-runner.ts
+++ b/tests/helpers/rule-runner.ts
@@ -7,7 +7,7 @@ import * as url from 'url';
 import { test } from 'ava'; // eslint-disable-line no-unused-vars
 import * as retry from 'async-retry';
 
-import { ids as collectors} from './collectors';
+import { ids as collectors } from './collectors';
 import { createServer } from './test-server';
 import { IElementFoundEvent, INetworkData, IRule, IRuleBuilder } from '../../src/lib/types'; // eslint-disable-line no-unused-vars
 import { RuleTest } from './rule-test-type'; // eslint-disable-line no-unused-vars


### PR DESCRIPTION
The sslabs API doesn't follow the redirects, so I have change the event when the rule starts scanning the url to the event `targetfetch::end`. In this event we already receive the final url.
Fix #196