### PR TITLE
Ignore network errors when closing JSDOM collector

### DIFF
--- a/src/lib/collectors/jsdom/jsdom.ts
+++ b/src/lib/collectors/jsdom/jsdom.ts
@@ -387,7 +387,15 @@ class JSDOMCollector implements ICollector {
     }
 
     public close() {
-        this._window.close();
+        try {
+            this._window.close();
+        } catch (e) {
+            // We could have some pending network requests and this could fail.
+            // Because the process is going to end so we don't care if this fails.
+            // https://github.com/MicrosoftEdge/Sonar/issues/203
+            debug(`Exception ignored while closing JSDOM collector (most likely pending network requests)`);
+            debug(e);
+        }
 
         return Promise.resolve();
     }


### PR DESCRIPTION
Fix #203