### PR TITLE
Getting the position approximate of an element in the html

### DIFF
--- a/.sonarrc
+++ b/.sonarrc
@@ -2,7 +2,9 @@
     "collector": {
         "name": "cdp",
         "options": {
-            "waitFor": 100
+            "waitFor": 100,
+            "loadCompleteRetryInterval": 500,
+            "maxLoadWaitTime": 30000
         }
     },
     "formatter": "stylish",

--- a/docs/user-guide/collectors/cdp.md
+++ b/docs/user-guide/collectors/cdp.md
@@ -1,0 +1,40 @@
+# CDP
+
+The `CDP` collector uses the [Chrome Debugging
+Protocol](https://chromedevtools.github.io/devtools-protocol/) to
+communicate with the browser.
+
+## Configurations
+
+The following properties can be customized in your `.sonarrc` file, under the
+`options` property of the `collector`:
+
+* `maxLoadWaitTime` the max time in milliseconds the collector will wait for
+  the website to be ready before continuing. The default value is `30000`
+  milliseconds.
+* `loadCompleteRetryInterval` time in milliseconds the collector will wait
+  before checking again if the website is ready (all the resources are loaded
+  and no pending network requests). The default value is `500` milliseconds.
+  The maximum number of retries is defined by
+  `maxLoadWaitTime/loadCompleteRetryInterval`.
+  E.g.: `loadCompleteRetryInterval = 10000` and `maxLoadWaitTime = 30000` means
+  that at most there will be 3 retries () to check if everything is loaded
+  before continuing the execution.
+* `waitFor` time in milliseconds the collector will wait after the site is
+  ready before starting the DOM traversing. The default value is `5000`
+  milliseconds.
+
+The following is the default configuration:
+
+```json
+{
+    "collector": {
+        "name": "cdp",
+        "options": {
+            "waitFor": 5000,
+            "loadCompleteRetryInterval": 500,
+            "maxLoadWaitTime": 30000
+        }
+    }
+}
+```

--- a/src/lib/collectors/cdp/cdp-async-html.ts
+++ b/src/lib/collectors/cdp/cdp-async-html.ts
@@ -47,7 +47,7 @@ export class CDPAsyncHTMLDocument implements IAsyncHTMLDocument {
         });
     }
 
-    async pageHTML() {
+    async pageHTML(): Promise<string> {
         const { outerHTML } = await this._DOM.getOuterHTML({ nodeId: this._dom.nodeId });
 
         return outerHTML;

--- a/src/lib/collectors/jsdom/jsdom-async-html.ts
+++ b/src/lib/collectors/jsdom/jsdom-async-html.ts
@@ -21,7 +21,7 @@ export class JSDOMAsyncHTMLDocument implements IAsyncHTMLDocument {
         return Promise.resolve(elements);
     }
 
-    pageHTML() {
+    pageHTML(): Promise<string> {
         return Promise.resolve(this._document.children[0].outerHTML);
     }
 }

--- a/src/lib/collectors/jsdom/jsdom.ts
+++ b/src/lib/collectors/jsdom/jsdom.ts
@@ -455,8 +455,8 @@ class JSDOMCollector implements ICollector {
         return this._targetNetworkData.response.headers;
     }
 
-    get html(): string {
-        return this._targetNetworkData.response.body.content;
+    get html(): Promise<string> {
+        return this._document.pageHTML();
     }
 }
 

--- a/src/lib/rule-context.ts
+++ b/src/lib/rule-context.ts
@@ -87,25 +87,25 @@ export class RuleContext {
     }
 
     /** Reports a problem with the resource. */
-    public async report(resource: string, descriptor: IAsyncHTMLElement, message: string, location?: IProblemLocation, severity?: Severity) { //eslint-disable-line require-await
-        // let position = location;
+    public async report(resource: string, element: IAsyncHTMLElement, message: string, content?: string, location?: IProblemLocation, severity?: Severity) { //eslint-disable-line require-await
+        let position = location;
 
-        // if (!position && descriptor) {
-        //     position = await findProblemLocation(descriptor, { column: 0, line: 0 });
-        // }
+        if (element) {
+            position = await findProblemLocation(element, { column: 0, line: 0 }, content);
+        }
 
-        // if (position === null) {
-        //     position = {
-        //         column: null,
-        //         line: null
-        //     };
-        // }
+        if (position === null) {
+            position = {
+                column: null,
+                line: null
+            };
+        }
 
         this.sonar.report(
             this.id,
             severity || this.severity,
-            descriptor,
-            location,
+            element,
+            position,
             message,
             resource
         );

--- a/src/lib/rules/axe/axe.ts
+++ b/src/lib/rules/axe/axe.ts
@@ -66,7 +66,7 @@ const rule: IRuleBuilder = {
             try {
                 result = await context.evaluate(script);
             } catch (e) {
-                context.report(resource, null, `Error executing script: "${e.message}". Please try with another collector`, null, Severity.warning);
+                await context.report(resource, null, `Error executing script: "${e.message}". Please try with another collector`, null, null, Severity.warning);
                 debug('Error executing script %O', e);
 
                 return;
@@ -91,7 +91,7 @@ const rule: IRuleBuilder = {
                     const element = await getElement(node);
 
                     //TODO: find the right element here using node.target[0] ?
-                    context.report(resource, element, violation.help);
+                    await context.report(resource, element, violation.help);
 
                     return;
                 });

--- a/src/lib/rules/disallowed-headers/disallowed-headers.ts
+++ b/src/lib/rules/disallowed-headers/disallowed-headers.ts
@@ -33,12 +33,12 @@ const rule: IRuleBuilder = {
             disallowedHeaders = mergeIgnoreIncludeArrays(disallowedHeaders, ignoreHeaders, includeHeaders);
         };
 
-        const validate = (fetchEnd: IFetchEndEvent) => {
+        const validate = async (fetchEnd: IFetchEndEvent) => {
             const { element, resource } = fetchEnd;
             const headers = getIncludedHeaders(fetchEnd.response.headers, disallowedHeaders);
 
             if (headers.length > 0) {
-                context.report(resource, element, `Disallowed HTTP header${headers.length > 1 ? 's' : ''} found: ${headers.join(', ')}`);
+                await context.report(resource, element, `Disallowed HTTP header${headers.length > 1 ? 's' : ''} found: ${headers.join(', ')}`);
             }
         };
 

--- a/src/lib/rules/disown-opener/disown-opener.ts
+++ b/src/lib/rules/disown-opener/disown-opener.ts
@@ -78,9 +78,7 @@ const rule: IRuleBuilder = {
             });
 
             if (missingRelValues.length > 0) {
-                const location = await context.findInElement(element, hrefValue);
-
-                await context.report(resource, element, `Missing link type${missingRelValues.length === 1 ? '' : 's'} on \`${await element.outerHTML()}\`: ${missingRelValues.join(', ')}`, location);
+                await context.report(resource, element, `Missing link type${missingRelValues.length === 1 ? '' : 's'} on \`${await element.outerHTML()}\`: ${missingRelValues.join(', ')}`, hrefValue);
             }
         };
 

--- a/src/lib/rules/highest-available-document-mode/highest-available-document-mode.ts
+++ b/src/lib/rules/highest-available-document-mode/highest-available-document-mode.ts
@@ -152,7 +152,6 @@ const rule: IRuleBuilder = {
                     await context.report(resource, metaTag, `A 'X-UA-Compatible' meta tag was already specified`);
                 }
             }
-
         };
 
         const loadRuleConfigs = () => {
@@ -166,7 +165,7 @@ const rule: IRuleBuilder = {
             });
         };
 
-        const validate = (event: ITraverseEndEvent) => {
+        const validate = async (event: ITraverseEndEvent) => {
             const { resource } = event;
 
             // The following check don't make sense for local files.
@@ -175,7 +174,7 @@ const rule: IRuleBuilder = {
                 checkHeader(resource, context.pageHeaders);
             }
 
-            checkMetaTag(resource);
+            await checkMetaTag(resource);
         };
 
         loadRuleConfigs();

--- a/src/lib/rules/manifest-file-extension/manifest-file-extension.ts
+++ b/src/lib/rules/manifest-file-extension/manifest-file-extension.ts
@@ -34,9 +34,7 @@ const rule: IRuleBuilder = {
                 if (fileExtension !== standardManifestFileExtension) {
                     debug('Web app manifest file with invalid extension found');
 
-                    const location = await context.findInElement(element, fileExtension);
-
-                    await context.report(resource, element, `The file extension for the web app manifest file ('${href}') should be '${standardManifestFileExtension}' not '${fileExtension}'`, location);
+                    await context.report(resource, element, `The file extension for the web app manifest file ('${href}') should be '${standardManifestFileExtension}' not '${fileExtension}'`, fileExtension);
                 }
             }
         };

--- a/src/lib/rules/manifest-is-valid/manifest-is-valid.ts
+++ b/src/lib/rules/manifest-is-valid/manifest-is-valid.ts
@@ -19,7 +19,7 @@ const debug = d(__filename);
 const rule: IRuleBuilder = {
     create(context: RuleContext): IRule {
 
-        const manifestIsValid = (data: IManifestFetchEnd) => {
+        const manifestIsValid = async (data: IManifestFetchEnd) => {
             const { resource, response: { body: { content }, statusCode } } = data;
 
             if (statusCode !== 200) {
@@ -28,7 +28,7 @@ const rule: IRuleBuilder = {
 
             // null, empty string, etc. are not valid manifests
             if (!content) {
-                context.report(resource, null, `Web app manifest file is not a text file`);
+                await context.report(resource, null, `Web app manifest file is not a text file`);
                 debug('Web app manifest file is not a text file');
 
                 return;
@@ -39,7 +39,7 @@ const rule: IRuleBuilder = {
                 JSON.parse(content);
             } catch (e) {
                 debug('Failed to parse the web app manifest file');
-                context.report(resource, null, `Web app manifest file doesn't contain valid JSON`);
+                await context.report(resource, null, `Web app manifest file doesn't contain valid JSON`);
             }
         };
 

--- a/src/lib/rules/no-friendly-error-pages/no-friendly-error-pages.ts
+++ b/src/lib/rules/no-friendly-error-pages/no-friendly-error-pages.ts
@@ -133,7 +133,7 @@ const rule: IRuleBuilder = {
             for (const key of Object.keys(foundErrorPages)) {
                 const threshold = statusCodesWith512Threshold.includes(Number.parseInt(key)) ? 512 : 256;
 
-                context.report(href, null, `Response with statusCode ${key} had less than ${threshold} bytes`);
+                await context.report(href, null, `Response with statusCode ${key} had less than ${threshold} bytes`);
             }
         };
 

--- a/src/lib/rules/no-html-only-headers/no-html-only-headers.ts
+++ b/src/lib/rules/no-html-only-headers/no-html-only-headers.ts
@@ -66,14 +66,14 @@ const rule: IRuleBuilder = {
             return false;
         };
 
-        const checkHeaders = (fetchEnd: IFetchEndEvent) => {
+        const checkHeaders = async (fetchEnd: IFetchEndEvent) => {
             const { element, resource, response } = fetchEnd;
 
             if (!willBeTreatedAsHTML(response)) {
                 const headers = getIncludedHeaders(response.headers, unneededHeaders);
 
                 if (headers.length > 0) {
-                    context.report(resource, element, `Unneeded HTTP header${headers.length > 1 ? 's' : ''} found: ${headers.join(', ')}`);
+                    await context.report(resource, element, `Unneeded HTTP header${headers.length > 1 ? 's' : ''} found: ${headers.join(', ')}`);
                 }
             }
         };

--- a/src/lib/rules/no-protocol-relative-urls/no-protocol-relative-urls.ts
+++ b/src/lib/rules/no-protocol-relative-urls/no-protocol-relative-urls.ts
@@ -34,9 +34,7 @@ const rule: IRuleBuilder = {
             if (url.indexOf('//') === 0) {
                 debug('Protocol relative URL found');
 
-                const location = await context.findInElement(element, url);
-
-                await context.report(resource, element, `Protocol relative URL found: ${url}`, location);
+                await context.report(resource, element, `Protocol relative URL found: ${url}`, url);
             }
         };
 

--- a/src/lib/rules/ssllabs/ssllabs.ts
+++ b/src/lib/rules/ssllabs/ssllabs.ts
@@ -124,7 +124,7 @@ const rule: IRuleBuilder = {
                 host = await promise;
             } catch (e) {
                 debug(`Error getting data for ${resource} %O`, e);
-                context.report(resource, null, `Couldn't get results from SSL Labs for ${resource}.`);
+                await context.report(resource, null, `Couldn't get results from SSL Labs for ${resource}.`);
 
                 return;
             }
@@ -136,7 +136,7 @@ const rule: IRuleBuilder = {
 There might be something wrong with SSL Labs servers.`;
 
                 debug(msg);
-                context.report(resource, null, msg);
+                await context.report(resource, null, msg);
 
                 return;
             }

--- a/src/lib/rules/x-content-type-options/x-content-type-options.ts
+++ b/src/lib/rules/x-content-type-options/x-content-type-options.ts
@@ -17,18 +17,18 @@ import { RuleContext } from '../../rule-context'; // eslint-disable-line no-unus
 const rule: IRuleBuilder = {
     create(context: RuleContext): IRule {
 
-        const validate = (fetchEnd: IFetchEndEvent) => {
+        const validate = async (fetchEnd: IFetchEndEvent) => {
             const { element, resource, response } = fetchEnd;
             const headerValue = (response.headers && response.headers['x-content-type-options']);
 
             if (typeof headerValue === 'undefined') {
-                context.report(resource, element, `Resource served without the 'X-Content-Type-Options' HTTP response header`);
+                await context.report(resource, element, `Resource served without the 'X-Content-Type-Options' HTTP response header`);
 
                 return;
             }
 
             if (headerValue.toLowerCase() !== 'nosniff') {
-                context.report(resource, element, `Resource served with invalid value ('${headerValue}') for the 'X-Content-Type-Options' HTTP response header`);
+                await context.report(resource, element, `Resource served with invalid value ('${headerValue}') for the 'X-Content-Type-Options' HTTP response header`);
             }
         };
 

--- a/src/lib/sonar.ts
+++ b/src/lib/sonar.ts
@@ -43,7 +43,7 @@ export class Sonar extends EventEmitter {
         return this.collector.dom;
     }
 
-    get pageContent() {
+    get pageContent(): Promise<string> {
         return this.collector.html;
     }
 

--- a/src/lib/types/collector.ts
+++ b/src/lib/types/collector.ts
@@ -13,7 +13,7 @@ export interface ICollector {
     /** The original DOM of the resource collected. */
     dom: object;
     /** The original HTML of the resource collected. */
-    html: string;
+    html: Promise<string>;
     /** The headers from the response if applicable. */
     headers: object;
     /** Collects all the information for the given target. */

--- a/tests/lib/rules/manifest-file-extension/tests.ts
+++ b/tests/lib/rules/manifest-file-extension/tests.ts
@@ -14,7 +14,7 @@ const tests: Array<RuleTest> = [
         name: `Web app manifest file has incorrect file extension`,
         reports: [{
             message: `The file extension for the web app manifest file ('site.json') should be '.webmanifest' not '.json'`,
-            position: { column: 32, line: 1 }
+            position: { column: 40, line: 2 }
         }],
         serverConfig: generateHTMLPage(`<link rel="manifest" href="site.json">
         <link rel="stylesheet" href="style.css">`)

--- a/tests/lib/rules/no-protocol-relative-urls/tests.ts
+++ b/tests/lib/rules/no-protocol-relative-urls/tests.ts
@@ -22,7 +22,7 @@ const tests: Array<RuleTest> = [
         name: `'link' with initial // fails the rule`,
         reports: [{
             message: 'Protocol relative URL found: //site.webmanifest',
-            position: { column: 28, line: 1 }
+            position: { column: 36, line: 2 }
         }],
         serverConfig: generateHTMLPage('<link rel="manifest" href="//site.webmanifest">')
     },
@@ -42,7 +42,7 @@ const tests: Array<RuleTest> = [
         name: `'script' with initial // fails the rule`,
         reports: [{
             message: 'Protocol relative URL found: //script.js',
-            position: { column: 14, line: 1 }
+            position: { column: 22, line: 5 }
         }],
         serverConfig: generateHTMLPage(undefined, '<script src="//script.js"></script>')
     },
@@ -62,7 +62,7 @@ const tests: Array<RuleTest> = [
         name: `'a' with initial // fails the rule`,
         reports: [{
             message: 'Protocol relative URL found: //home',
-            position: { column: 10, line: 1 }
+            position: { column: 18, line: 5 }
         }],
         serverConfig: generateHTMLPage(undefined, '<a href="//home">home</a>')
     },

--- a/tests/lib/sonar.ts
+++ b/tests/lib/sonar.ts
@@ -438,7 +438,7 @@ test.serial('pageContent should return the HTML', async (t) => {
         }
     });
 
-    t.is(sonarObject.pageContent, html);
+    t.is(await sonarObject.pageContent, html);
 });
 
 test.serial(`pageHeaders should return the page's response headers`, async (t) => {


### PR DESCRIPTION
Due to JSDOM and CDP have a similar behavior with the property outerHTML. We are going to use it and we should let the users know that the posision is approximate not exactly. The "problem" is that not only the tags html and header are moved to the first line but there are other elements that also are moved when we use the outerHTML, but this property is the only way (AFAIK) to get the current HTML in an SPA.

Fix #63