### PR TITLE
Improvements to stylish formatter

### DIFF
--- a/tests/lib/formatters/fixtures/list-of-problems.ts
+++ b/tests/lib/formatters/fixtures/list-of-problems.ts
@@ -42,26 +42,26 @@ const multipleproblemsandresources: Array<IProblem> = [{
     severity: Severity.warning
 },
 {
-    column: 1,
-    line: 10,
-    message: 'This is a problem in line 10',
+    column: -1,
+    line: -1,
+    message: 'This is a problem without line in myresource',
     resource: 'http://myresource.com/',
     ruleId: 'random-rule',
     severity: Severity.warning
 },
 {
-    column: 1,
-    line: 5,
-    message: 'This is a problem in line 5',
-    resource: 'http://myresource2.com/',
+    column: -1,
+    line: -1,
+    message: 'This is a problem without line',
+    resource: 'http://myresource2.com/this/resource/is/really/really/long/resources/image/imagewithalongname.jpg',
     ruleId: 'random-rule',
     severity: Severity.error
 },
 {
-    column: 1,
-    line: 1,
-    message: 'This is a problem in line 1 column 1',
-    resource: 'http://myresource2.com/',
+    column: -1,
+    line: -1,
+    message: 'This is another problem without line',
+    resource: 'http://myresource2.com/this/resource/is/really/really/long/resources/image/imagewithalongname.jpg',
     ruleId: 'random-rule',
     severity: Severity.warning
 }];

--- a/tests/lib/formatters/stylish.ts
+++ b/tests/lib/formatters/stylish.ts
@@ -31,12 +31,12 @@ test(`Stylish formatter prints a table and a summary for each resource`, (t) => 
     stylish.format(problems.multipleproblemsandresources);
 
     const log = t.context.logger.log;
-    let problem = problems.multipleproblemsandresources[0];
+    let problem = problems.multipleproblemsandresources[1];
     let tableData = [];
 
-    tableData.push([chalk.yellow('Warning'), problem.message, problem.ruleId]);
-    problem = problems.multipleproblemsandresources[1];
-    tableData.push([chalk.yellow('Warning'), problem.message, problem.ruleId]);
+    tableData.push(['', '', chalk.yellow('Warning'), problem.message, problem.ruleId]);
+    problem = problems.multipleproblemsandresources[0];
+    tableData.push([`line ${problem.line}`, `col ${problem.column}`, chalk.yellow('Warning'), problem.message, problem.ruleId]);
 
     let tableString = table(tableData);
 
@@ -44,13 +44,13 @@ test(`Stylish formatter prints a table and a summary for each resource`, (t) => 
     t.is(log.args[1][0], tableString);
     t.is(log.args[2][0], chalk.yellow.bold(`\u2716 Found 0 errors and 2 warnings`));
     t.is(log.args[3][0], '');
-    t.is(log.args[4][0], chalk.cyan('http://myresource2.com/'));
+    t.is(log.args[4][0], chalk.cyan('http://myresource2.com/this/resource/i.../resources/image/imagewithalongname.jpg'));
 
     tableData = [];
-    problem = problems.multipleproblemsandresources[3];
-    tableData.push([chalk.yellow('Warning'), problem.message, problem.ruleId]);
     problem = problems.multipleproblemsandresources[2];
     tableData.push([chalk.red('Error'), problem.message, problem.ruleId]);
+    problem = problems.multipleproblemsandresources[3];
+    tableData.push([chalk.yellow('Warning'), problem.message, problem.ruleId]);
     tableString = table(tableData);
 
     t.is(log.args[5][0], tableString);


### PR DESCRIPTION
Stylish formatter now show the line and column of an error when the error is in an element of the dom.

Fix #229