### PR TITLE
Add canvas as a peer dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 /.nyc_output/
 /.vscode/
+/build/
 /coverage/
 /dist/
 /doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       script:
         - ./.travis/check-links.sh && ./.travis/trigger-site-update.sh
 
-    # 2. Build used for running the tests for Sonar on Ubuntu.
+    # 2. Build used for running the tests for sonar on Ubuntu.
 
     - os: linux
       dist: trusty
@@ -34,22 +34,31 @@ matrix:
         apt:
           sources:
             - google-chrome
+            - ubuntu-toolchain-r-test
           packages:
             - google-chrome-stable
+            - libcairo2-dev
+            - libjpeg8-dev
+            - libpango1.0-dev
+            - libgif-dev
+            - g++-4.9
       before_script:
         - export DISPLAY=:99.0
         - sh -e /etc/init.d/xvfb start
         - sleep 3
+      env:
+        - CXX=g++-4.9
       node_js:
         - node
       script:
         - npm run test-on-travis
 
-    # 3. Build used for running the tests for Sonar on macOS.
+    # 3. Build used for running the tests for sonar on macOS.
 
     - os: osx
       osx_image: xcode8.3
       before_install:
+        - brew install pkg-config cairo libpng jpeg giflib
         - brew cask install google-chrome
       node_js:
         - node

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "axe-core": "^2.2.2",
     "browserslist": "^2.1.4",
+    "canvas": "^1.6.5",
     "chalk": "^1.1.3",
     "chrome-remote-interface": "^0.23.0",
     "debug": "^2.6.8",


### PR DESCRIPTION
For JSDOM to download images we need canvas or canvas-prebuilt as a
peerDependency. canvas-prebuild doesn't support node 8 yet so using
canvas in the mean time.

**Windows users**: [Install all dependencies using
cholatey](https://github.com/Automattic/node-canvas/wiki/Installation---Windows#install-with-chocolate)
if you don't have them already except the GTK one. Manually download
the file and unzip it in C:\GTK so it compiles.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #241