### PR TITLE
Make `disown-opener` rule use `targetedBrowsers`

### DIFF
--- a/docs/user-guide/rules/disown-opener.md
+++ b/docs/user-guide/rules/disown-opener.md
@@ -1,8 +1,10 @@
 # Require external links to disown opener (`disown-opener`)
 
-`disown-opener` warns against not using `rel="noopener noreferrer"`
-on `a` and `area` elements that have `target="_blank"` and link to
-other origins.
+`disown-opener` warns against not specifying the `rel` attribute
+with both the `noopener` and `noreferrer` values (or only `noopener`
+if all the [targeted browsers](../index.md#browser-configuration)
+support it) on `a` and `area` elements that have `target="_blank"`
+and link to other origins.
 
 ## Why is this important?
 
@@ -33,7 +35,7 @@ Links that have `target="_blank"`, such as
 
   In Chromium based browser, using `ref="noopener"` (or
   [`rel="noreferrer"`](https://blog.chromium.org/2009/12/links-that-open-in-new-processes.html)
-  for older version), and thus, preventing the `window.opener` reference
+  for older versions), and thus, preventing the `window.opener` reference
   from being set, allows new pages to be opened in their own process.
 
   Edge is not affected by this.
@@ -42,8 +44,10 @@ Notes:
 
 * Not all browsers [support](http://caniuse.com/#feat=rel-noopener)
   `rel="noopener"`, so in order to ensure that things work as expected
-  in all browsers, for the time being, this rule requires
-  `rel="noopener noreferrer"`.
+  in as many browsers as possible, by default, the rule requires both
+  the `noopener` and `noreferrer` values to be specified. However, if
+  all the [targeted browsers](../index.md#browser-configuration) support
+  `noopener`, only `noopener` will be required.
 
 * The reason why the rule does not check the same origin links by
   default is because:
@@ -58,7 +62,8 @@ Notes:
   section to see how the rule can be made to also check same origin
   links.
 
-* [`noopener` and `noreferrer` only work for `a` and `area` elements](https://html5sec.org/#143).
+* [`noopener` and `noreferrer` only work for `a` and `area`
+  elements](https://html5sec.org/#143).
 
 * In the future there may be a [CSP valueless
   property](https://github.com/w3c/webappsec/issues/139) property that
@@ -66,9 +71,12 @@ Notes:
 
 ## What does the rule check?
 
-By default, the rule checks if `rel="noopener noreferrer"` was specified
-on `a` and `area` elements that have `target="_blank"` and link to other
-origins.
+By default, the rule checks if the `rel` attribute was specified with
+both the `noopener` and `noreferrer` values on `a` and `area` elements
+that have `target="_blank"` and link to other origins.
+
+If the [targeted browsers are specified](#can-the-rule-be-configured),
+based on their support, the rule might only require the `noopener` value.
 
 Let's presume the original page is `https://example1.com`.
 
@@ -151,6 +159,11 @@ should also include `rel="noopener noreferrer"`.
     "includeSameOriginURLs": true
 }]
 ```
+
+Also, note that this rule takes into consideration the [targeted
+browsers](../index.md#browser-configuration), and if all of them
+support the `noopener` value, the rule won't require the `noreferrer`
+value.
 
 ## Further Reading
 

--- a/docs/user-guide/rules/highest-available-document-mode.md
+++ b/docs/user-guide/rules/highest-available-document-mode.md
@@ -230,10 +230,10 @@ X-UA-Compatible: ie=edge
 }]
 ```
 
-Also, this rule takes into consideration the specified
-`targetedBrowsers`, and if Internet Explorer 8/9/10 aren't among
-them, will suggest removing the `meta` tag or/and not sending the
-HTTP response header.
+Also, note that this rule takes into consideration the [targeted
+browsers](../index.md#browser-configuration), and if Internet Explorer
+8/9/10 aren't among them, it will suggest removing the `meta` tag or/and
+not sending the HTTP response header.
 
 ## Further Reading
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "axe-core": "^2.2.2",
     "browserslist": "^2.1.4",
+    "caniuse-api": "^2.0.0",
     "canvas-prebuilt": "^1.6.0-canvas.5",
     "chalk": "^1.1.3",
     "chrome-remote-interface": "^0.23.2",

--- a/src/lib/utils/misc.ts
+++ b/src/lib/utils/misc.ts
@@ -44,10 +44,12 @@ const isLocalFile = (resource: string): boolean => {
     return hasProtocol(resource, 'file:');
 };
 
-/** Remove whitespace from both ends of a string and lowercase it. */
-const normalizeString = (value: string) => {
+/** Remove whitespace from both ends of a string and lowercase it.
+ *  If `defaultValue` is provided, it will return it if the return
+ *  value would be `null`. */
+const normalizeString = (value: string, defaultValue?: string) => {
     if (typeof value === 'undefined' || value === null) {
-        return null;
+        return typeof defaultValue !== 'undefined' ? defaultValue : null;
     }
 
     return value.toLowerCase().trim();

--- a/tests/lib/rules/disown-opener/tests.ts
+++ b/tests/lib/rules/disown-opener/tests.ts
@@ -11,7 +11,7 @@ import * as ruleRunner from '../../../helpers/rule-runner';
 const ruleName = getRuleName(__dirname);
 
 const generateMissingMessage = (value: string, linkTypes: Array<string>): string => {
-    return `'${cutString(value, 100)}' is missing link ${pluralize('type', linkTypes.length)} '${linkTypes.join('\', \'')}'`;
+    return `'${cutString(value, 100)}' is missing 'rel' ${pluralize('value', linkTypes.length)} '${linkTypes.join('\', \'')}'`;
 };
 
 const testsForDefaults: Array<RuleTest> = [
@@ -128,11 +128,11 @@ const testsForDefaults: Array<RuleTest> = [
     // 'target="_blank"', 'noopener', and 'noreferrer'
 
     {
-        name: `'a' with 'href="https://example.com"' has 'target="_blank"' and 'noreferrer'`,
+        name: `'a' with 'href="https://example.com"' has 'target="_blank"', 'noopener', and noreferrer'`,
         serverConfig: { '/': generateHTMLPage(undefined, `<a href="https://example.com" target="_blank" rel="noopener noreferrer">test</a>`) }
     },
     {
-        name: `'map' with href="https://example.com" has 'target="_blank"' and 'noreferrer'`,
+        name: `'map' with href="https://example.com" has 'target="_blank"', 'noopener', and noreferrer'`,
         serverConfig: {
             '/': generateHTMLPage(undefined, `
                     <img src="test.png" width="10" height="10" usemap="#test">
@@ -143,7 +143,19 @@ const testsForDefaults: Array<RuleTest> = [
     }
 ];
 
-const testsForConfigs: Array<RuleTest> = [
+const testsForBrowsersListConfig: Array<RuleTest> = [
+    {
+        name: `'a' with 'href="https://example.com"' has 'target="_blank"', and 'noopener' is supported by all targeted browsers`,
+        reports: [{ message: generateMissingMessage('<a href="https://example.com" id="test" class="t … test4 test5 test5 test6" target="_blank">test</a>', ['noopener']) }],
+        serverConfig: { '/': generateHTMLPage(undefined, `<a href="https://example.com" id="test" class="test1 test2 test3 test4 test5 test5 test6" target="_blank">test</a>`) }
+    },
+    {
+        name: `'a' with 'href="https://example.com"' has 'target="_blank"', 'noopener', and 'noreferrer', and 'noopener' is supported by all targeted browsers`,
+        serverConfig: { '/': generateHTMLPage(undefined, `<a href="https://example.com" target="_blank" rel="noopener noreferrer">test</a>`) }
+    }
+];
+
+const testsForIncludeSameOriginURLsConfig: Array<RuleTest> = [
     {
         name: `'a' with 'href=""' has 'target="_blank"'`,
         reports: [{ message: generateMissingMessage('<a href="" target="_blank">test</a>', ['noopener', 'noreferrer']) }],
@@ -178,4 +190,5 @@ const testsForConfigs: Array<RuleTest> = [
 ];
 
 ruleRunner.testRule(ruleName, testsForDefaults);
-ruleRunner.testRule(ruleName, testsForConfigs, { ruleOptions: { includeSameOriginURLs: true } });
+ruleRunner.testRule(ruleName, testsForBrowsersListConfig, { browserslist: ['Firefox >= 52'] });
+ruleRunner.testRule(ruleName, testsForIncludeSameOriginURLsConfig, { ruleOptions: { includeSameOriginURLs: true } });


### PR DESCRIPTION
Make `disown-opener` rule require the `rel` attribute to contain the `noreferrer` value only when the targeted browsers don't all support the `noopener` value.