### PR TITLE
Fix nodeId

### DIFF
--- a/src/lib/collectors/cdp/cdp-async-html.ts
+++ b/src/lib/collectors/cdp/cdp-async-html.ts
@@ -37,7 +37,7 @@ export class CDPAsyncHTMLDocument implements IAsyncHTMLDocument {
         let nodeIds;
 
         try {
-            nodeIds = (await this._DOM.querySelectorAll({ nodeId: 1, selector })).nodeIds;
+            nodeIds = (await this._DOM.querySelectorAll({ nodeId: this._dom.nodeId, selector })).nodeIds;
         } catch (e) {
             return [];
         }


### PR DESCRIPTION
Fix #275

Use nodeId from `this._dom` instead of a static number.

I still can't reproduce the error, even though I've tried multiple times :(. But I found [this thread](https://github.com/cyrus-and/chrome-remote-interface/issues/37) that encounters a similar issue. And the explanation is as below

> I think the cause is that the lifespan of a unique DOM node identifier is not, as one would imagine, static, i.e., it gets regenerated every time chrome.DOM.getDocument is executed and of course between two consecutive sessions.

So using `this._dom.nodeId` instead of `1` should fix it if that's the problem.


