### PR TITLE
Fix: Allow additional keywords in `rel` value

### DIFF
--- a/packages/hint-x-content-type-options/tests/tests.ts
+++ b/packages/hint-x-content-type-options/tests/tests.ts
@@ -17,6 +17,7 @@ const generateInvalidValueMessage = (value: string = '') => {
 
 const htmlPageWithScript = generateHTMLPage(undefined, '<script src="test.js"></script>');
 const htmlPageWithStylesheet = generateHTMLPage('<link rel="stylesheet" href="test.css">');
+const htmlPageWithAlternateStylesheet = generateHTMLPage('<link rel="  alternate stylesheet " href="test.css">');
 
 // Tests.
 
@@ -38,6 +39,14 @@ const tests: Array<HintTest> = [
         reports: [{ message: noHeaderMessage }],
         serverConfig: {
             '/': htmlPageWithStylesheet,
+            '/test.css': ''
+        }
+    },
+    {
+        name: `Alternative stylesheet is served without 'X-Content-Type-Options' header`,
+        reports: [{ message: noHeaderMessage }],
+        serverConfig: {
+            '/': htmlPageWithAlternateStylesheet,
             '/test.css': ''
         }
     },


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

This change makes it so that cases such as `rel="alternate stylesheet"` are allowed.

See also: https://html.spec.whatwg.org/multipage/links.html#rel-alternate

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #1188

