### PR TITLE
New: CSS Parser

### DIFF
--- a/packages/hint/docs/contributor-guide/getting-started/events.md
+++ b/packages/hint/docs/contributor-guide/getting-started/events.md
@@ -9,6 +9,8 @@ their signature, and the `interface` they implement.
 * [`fetch::end::<resource-type>`](#fetchendresource-type)
 * [`fetch::error`](#fetcherrorresource-type)
 * [`fetch::start`](#fetchstartresource-type)
+* [`parse::css`](#parsecss)
+* [`parse::javascript`](#parsejavascript)
 * [`scan::end`](#scanend)
 * [`scan::start`](#scanstart)
 * [`traverse::down`](#traversedown)
@@ -84,6 +86,24 @@ to start
 ```ts
 type FetchStart {
     /** The URL to download */
+    resource: string;
+}
+```
+
+## `parse::css`
+
+Event is emitted **when** the `CSS parser` has finished parsing a
+CSS resource (a file or a `<style>` tag).
+
+**Format:**
+
+```ts
+type StyleParse {
+    /** The root of a PostCSS AST generated from the stylesheet. */
+    ast: Root;
+    /** The raw stylesheet code. */
+    code: string;
+    /** The URL of the resource. */
     resource: string;
 }
 ```

--- a/packages/hint/docs/contributor-guide/getting-started/events.md
+++ b/packages/hint/docs/contributor-guide/getting-started/events.md
@@ -237,4 +237,4 @@ type CanEvaluateScript {
 
 [nodeName docs]: https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeName
 [postcss]: https://postcss.org/
-[postcss-walk]: http://api.postcss.org/Container.html#walk
+[postcss-walk]: https://api.postcss.org/Container.html#walk

--- a/packages/hint/docs/contributor-guide/getting-started/events.md
+++ b/packages/hint/docs/contributor-guide/getting-started/events.md
@@ -93,7 +93,8 @@ type FetchStart {
 ## `parse::css`
 
 Event is emitted **when** the `CSS parser` has finished parsing a
-CSS resource (a file or a `<style>` tag).
+CSS resource (a file or a `<style>` tag). Includes a [PostCSS][postcss] AST.
+See the [PostCSS `walk*` APIs][postcss-walk] for help navigating the AST.
 
 **Format:**
 
@@ -235,3 +236,5 @@ type CanEvaluateScript {
 <!-- Link labels: -->
 
 [nodeName docs]: https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeName
+[postcss]: https://postcss.org/
+[postcss-walk]: http://api.postcss.org/Container.html#walk

--- a/packages/parser-css/LICENSE.txt
+++ b/packages/parser-css/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright JS Foundation and other contributors, https://js.foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/parser-css/README.md
+++ b/packages/parser-css/README.md
@@ -1,12 +1,12 @@
-# JavaScript parser (`@hint/parser-javascript`)
+# CSS parser (`@hint/parser-css`)
 
-The `javascript` parser is built on top of `ESLint` so hints can
-analyze `JavaScript` files.
+The `css` parser is built on top of [PostCSS][postcss] so hints can
+analyze `CSS` files.
 
 To use it you will have to install it via `npm`:
 
 ```bash
-npm install @hint/parser-javascript
+npm install @hint/parser-css
 ```
 
 Note: You can make `npm` install it as a `devDependency` using the
@@ -23,20 +23,22 @@ And then activate it via the [`.hintrc`][hintrc] configuration file:
     "hints": {
         ...
     },
-    "parsers": ["javascript"],
+    "parsers": ["css"],
     ...
 }
 ```
 
 ## Events emitted
 
-This `parser` emits the event `parse::javascript`, of type `IScriptParse`
+This `parser` emits the event `parse::css`, of type `StyleParse`
 which has the following information:
 
-* `resource`: the parsed resource. If the JavaScript is in a `script tag`
-  and not a file, the value will be `Internal javascript`.
-* `sourceCode`: a `eslint` `SourceCode` object.
+* `ast`: a PostCSS `Root` object containing the AST.
+* `code`: a string containing the raw stylesheet source code.
+* `resource`: the parsed resource. If the CSS is in a `style tag`
+  and not a file, the value will be `Inline CSS`.
 
 <!-- Link labels: -->
 
 [hintrc]: https://webhint.io/docs/user-guide/further-configuration/hintrc-formats/
+[postcss]: https://postcss.org/

--- a/packages/parser-css/README.md
+++ b/packages/parser-css/README.md
@@ -1,0 +1,42 @@
+# JavaScript parser (`@hint/parser-javascript`)
+
+The `javascript` parser is built on top of `ESLint` so hints can
+analyze `JavaScript` files.
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @hint/parser-javascript
+```
+
+Note: You can make `npm` install it as a `devDependency` using the
+`--save-dev` parameter, or to install it globally, you can use the
+`-g` parameter. For other options see [`npm`'s
+documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.hintrc`][hintrc] configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "hints": {
+        ...
+    },
+    "parsers": ["javascript"],
+    ...
+}
+```
+
+## Events emitted
+
+This `parser` emits the event `parse::javascript`, of type `IScriptParse`
+which has the following information:
+
+* `resource`: the parsed resource. If the JavaScript is in a `script tag`
+  and not a file, the value will be `Internal javascript`.
+* `sourceCode`: a `eslint` `SourceCode` object.
+
+<!-- Link labels: -->
+
+[hintrc]: https://webhint.io/docs/user-guide/further-configuration/hintrc-formats/

--- a/packages/parser-css/README.md
+++ b/packages/parser-css/README.md
@@ -34,6 +34,7 @@ This `parser` emits the event `parse::css`, of type `StyleParse`
 which has the following information:
 
 * `ast`: a PostCSS `Root` object containing the AST.
+  See the [PostCSS `walk*` APIs][postcss-walk] for help navigating the AST.
 * `code`: a string containing the raw stylesheet source code.
 * `resource`: the parsed resource. If the CSS is in a `style tag`
   and not a file, the value will be `Inline CSS`.
@@ -42,3 +43,4 @@ which has the following information:
 
 [hintrc]: https://webhint.io/docs/user-guide/further-configuration/hintrc-formats/
 [postcss]: https://postcss.org/
+[postcss-walk]: http://api.postcss.org/Container.html#walk

--- a/packages/parser-css/README.md
+++ b/packages/parser-css/README.md
@@ -1,6 +1,6 @@
 # CSS parser (`@hint/parser-css`)
 
-The `css` parser is built on top of [PostCSS][postcss] so hints can
+The `CSS` parser is built on top of [PostCSS][postcss] so hints can
 analyze `CSS` files.
 
 To use it you will have to install it via `npm`:
@@ -30,7 +30,7 @@ And then activate it via the [`.hintrc`][hintrc] configuration file:
 
 ## Events emitted
 
-This `parser` emits the event `parse::css`, of type `StyleParse`
+This `parser` emits the event `parse::css` of type `StyleParse`
 which has the following information:
 
 * `ast`: a PostCSS `Root` object containing the AST.
@@ -43,4 +43,4 @@ which has the following information:
 
 [hintrc]: https://webhint.io/docs/user-guide/further-configuration/hintrc-formats/
 [postcss]: https://postcss.org/
-[postcss-walk]: http://api.postcss.org/Container.html#walk
+[postcss-walk]: https://api.postcss.org/Container.html#walk

--- a/packages/parser-css/package.json
+++ b/packages/parser-css/package.json
@@ -1,0 +1,70 @@
+{
+  "ava": {
+    "failFast": false,
+    "files": [
+      "dist/tests/**/*.js"
+    ],
+    "timeout": "1m"
+  },
+  "dependencies": {
+    "postcss": "^7.0.1"
+  },
+  "description": "webhint parser needed to analyze CSS files",
+  "devDependencies": {
+    "ava": "^0.25.0",
+    "cpx": "^1.5.0",
+    "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-markdown": "^1.0.0-beta.7",
+    "eslint-plugin-typescript": "^0.12.0",
+    "hint": "^3.0.0-beta.4",
+    "markdownlint-cli": "^0.11.0",
+    "npm-link-check": "^2.0.0",
+    "npm-run-all": "^4.1.2",
+    "nyc": "^12.0.2",
+    "proxyquire": "2.0.0",
+    "rimraf": "^2.6.2",
+    "sinon": "^6.1.4",
+    "typescript": "^2.9.2",
+    "typescript-eslint-parser": "^16.0.1"
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "files": [
+    "dist/src",
+    "npm-shrinkwrap.json"
+  ],
+  "homepage": "https://webhint.io/",
+  "keywords": [
+    "webhint",
+    "webhint-parser",
+    "css"
+  ],
+  "license": "Apache-2.0",
+  "main": "dist/src/parser.js",
+  "name": "@hint/parser-css",
+  "nyc": {
+    "extends": "../../.nycrc"
+  },
+  "peerDependencies": {
+    "hint": "^3.0.0-beta.4"
+  },
+  "repository": "webhintio/hint",
+  "scripts": {
+    "build": "npm run clean && npm-run-all build:*",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
+    "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
+    "build:ts": "tsc",
+    "clean": "rimraf dist",
+    "lint": "npm-run-all lint:*",
+    "lint:js": "eslint . --cache --ext js --ext md --ext ts --ignore-path ../../.eslintignore --report-unused-disable-directives",
+    "lint:md": "markdownlint --ignore CHANGELOG.md *.md",
+    "test": "npm run lint && npm run build && npm run test-only",
+    "test-only": "nyc ava",
+    "watch": "npm run build && npm-run-all --parallel -c watch:*",
+    "watch:assets": "npm run build:assets -- -w --no-initial",
+    "watch:test": "ava --watch",
+    "watch:ts": "npm run build:ts -- --watch"
+  },
+  "version": "1.0.0-beta.0"
+}

--- a/packages/parser-css/package.json
+++ b/packages/parser-css/package.json
@@ -49,6 +49,7 @@
   "peerDependencies": {
     "hint": "^3.0.0-beta.4"
   },
+  "private": true,
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
@@ -66,5 +67,5 @@
     "watch:test": "ava --watch",
     "watch:ts": "npm run build:ts -- --watch"
   },
-  "version": "1.0.0-beta.0"
+  "version": "1.0.0"
 }

--- a/packages/parser-css/src/parser.ts
+++ b/packages/parser-css/src/parser.ts
@@ -39,7 +39,6 @@ export default class CSSParser extends Parser {
         await this.emitCSS(code, resource);
     }
 
-
     private isCSSType(element: IAsyncHTMLElement) {
         const type = element.getAttribute('type');
 

--- a/packages/parser-css/src/parser.ts
+++ b/packages/parser-css/src/parser.ts
@@ -1,5 +1,6 @@
 import * as postcss from 'postcss';
 
+import * as logger from 'hint/dist/src/lib/utils/logging';
 import { IAsyncHTMLElement, ElementFound, FetchEnd, Parser } from 'hint/dist/src/lib/types';
 import { StyleParse } from './types';
 import { Engine } from 'hint/dist/src/lib/engine';
@@ -28,7 +29,7 @@ export default class CSSParser extends Parser {
             await this.engine.emitAsync(`parse::${this.name}::end`, styleData);
 
         } catch (err) {
-            console.log(`Error parsing code: ${code} - ${err}`);
+            logger.error(`Error parsing code: ${code} - ${err}`);
         }
     }
 

--- a/packages/parser-css/src/parser.ts
+++ b/packages/parser-css/src/parser.ts
@@ -1,11 +1,12 @@
 import * as postcss from 'postcss';
 
 import * as logger from 'hint/dist/src/lib/utils/logging';
+import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
 import { IAsyncHTMLElement, ElementFound, FetchEnd, Parser } from 'hint/dist/src/lib/types';
 import { StyleParse } from './types';
 import { Engine } from 'hint/dist/src/lib/engine';
 
-const styleContentRegex: RegExp = /^<style[^>]*>([\s\S]*)<\/style>$/;
+const styleContentRegex: RegExp = /^<style[^>]*>([\s\S]*)<\/style\s*>$/;
 
 export default class CSSParser extends Parser {
     public constructor(engine: Engine) {
@@ -41,8 +42,15 @@ export default class CSSParser extends Parser {
     }
 
     private isCSSType(element: IAsyncHTMLElement) {
-        const type = element.getAttribute('type');
+        const type = normalizeString(element.getAttribute('type'));
 
+        /*
+         * From: https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block
+         *
+         * If element's type attribute is present and its value is neither
+         * the empty string nor an ASCII case-insensitive match for
+         * "text/css", then return.
+         */
         return !type || type === 'text/css';
     }
 

--- a/packages/parser-css/src/parser.ts
+++ b/packages/parser-css/src/parser.ts
@@ -1,0 +1,68 @@
+import * as postcss from 'postcss';
+
+import { IAsyncHTMLElement, ElementFound, FetchEnd, Parser } from 'hint/dist/src/lib/types';
+import { StyleParse } from './types';
+import { Engine } from 'hint/dist/src/lib/engine';
+
+const styleContentRegex: RegExp = /^<style[^>]*>([\s\S]*)<\/style>$/;
+
+export default class CSSParser extends Parser {
+    public constructor(engine: Engine) {
+        super(engine, 'css');
+
+        engine.on('fetch::end::css', this.parseCSS.bind(this));
+        engine.on('element::style', this.parseStyleTag.bind(this));
+    }
+
+    private async emitCSS(code: string, resource: string) {
+
+        try {
+            const ast = postcss.parse(code, { from: resource });
+
+            const styleData: StyleParse = {
+                ast,
+                code,
+                resource
+            };
+
+            await this.engine.emitAsync(`parse::${this.name}::end`, styleData);
+
+        } catch (err) {
+            console.log(`Error parsing code: ${code} - ${err}`);
+        }
+    }
+
+    private async parseCSS(fetchEnd: FetchEnd) {
+        const code = fetchEnd.response.body.content;
+        const resource = fetchEnd.resource;
+
+        await this.emitCSS(code, resource);
+    }
+
+
+    private isCSSType(element: IAsyncHTMLElement) {
+        const type = element.getAttribute('type');
+
+        return !type || type === 'text/css';
+    }
+
+    private getStyleContent(styleTagText) {
+        const match = styleTagText.match(styleContentRegex);
+
+        return match[1].trim();
+    }
+
+    private async parseStyleTag(elementFound: ElementFound) {
+        const element: IAsyncHTMLElement = elementFound.element;
+
+        if (!this.isCSSType(element)) {
+            // Ignore if it is not CSS.
+            return;
+        }
+
+        const code = this.getStyleContent(await element.outerHTML());
+        const resource: string = 'Inline CSS';
+
+        await this.emitCSS(code, resource);
+    }
+}

--- a/packages/parser-css/src/types.ts
+++ b/packages/parser-css/src/types.ts
@@ -1,0 +1,14 @@
+import { Event } from 'hint/dist/src/lib/types/events';
+import { Root } from 'postcss';
+
+/** The object emitted by the `css` parser */
+export type StyleParse = Event & {
+    /**
+     * The PostCSS AST generated from the stylesheet.
+     * Typically the `walk*` APIs will be used for rules.
+     * http://api.postcss.org/Container.html#walk
+     */
+    ast: Root;
+    /** The raw stylesheet source code */
+    code: string;
+};

--- a/packages/parser-css/tests/basic-tests.ts
+++ b/packages/parser-css/tests/basic-tests.ts
@@ -1,0 +1,51 @@
+import * as sinon from 'sinon';
+import test from 'ava';
+import { EventEmitter2 } from 'eventemitter2';
+import { Rule, Declaration } from 'postcss';
+import * as CSSParser from '../src/parser';
+import { StyleParse } from '../src/types';
+
+const postcss = { parse() { } };
+const element = { getAttribute() { }, outerHTML() { } };
+
+test.beforeEach((t) => {
+    t.context.element = element;
+    t.context.engine = new EventEmitter2({
+        delimiter: '::',
+        maxListeners: 0,
+        wildcard: true
+    });
+});
+
+test.serial('We should provide a correct AST when parsing CSS.', async (t) => {
+    const sandbox = sinon.createSandbox();
+    const parser = new CSSParser.default(t.context.engine); // eslint-disable-line new-cap,no-unused-vars
+    const parseObject = {};
+    const code = '.foo { color: #fff }';
+    const style = `<style>  ${code}  </style>`;
+
+    sandbox.spy(t.context.engine, 'emitAsync');
+    sandbox.stub(postcss, 'parse').returns(parseObject);
+
+    sandbox.stub(element, 'outerHTML').resolves(style);
+    sandbox.stub(element, 'getAttribute')
+        .onFirstCall()
+        .returns('text/css');
+
+    await t.context.engine.emitAsync('element::style', { element });
+
+    const args = t.context.engine.emitAsync.args[1];
+    const data= args[1] as StyleParse;
+    const root = data.ast;
+    const rule = root.first as Rule;
+    const declaration = rule.first as Declaration;
+
+    t.is(args[0], 'parse::css::end');
+    t.is(rule.selector, '.foo');
+    t.is(declaration.prop, 'color');
+    t.is(declaration.value, '#fff');
+    t.is(args[1].code, code);
+    t.is(args[1].resource, 'Inline CSS');
+
+    sandbox.restore();
+});

--- a/packages/parser-css/tests/interface-tests.ts
+++ b/packages/parser-css/tests/interface-tests.ts
@@ -70,7 +70,6 @@ test.serial('If a style tag is inline CSS, then we should parse the stylesheet a
     sandbox.restore();
 });
 
-
 test.serial('If fetch::end::css is received, then we should parse the stylesheet and emit a parse::css::end event', async (t) => {
     const sandbox = sinon.createSandbox();
     const parser = new CSSParser.default(t.context.engine); // eslint-disable-line new-cap,no-unused-vars

--- a/packages/parser-css/tests/interface-tests.ts
+++ b/packages/parser-css/tests/interface-tests.ts
@@ -1,0 +1,102 @@
+import * as proxyquire from 'proxyquire';
+import * as sinon from 'sinon';
+import test from 'ava';
+import { EventEmitter2 } from 'eventemitter2';
+
+const postcss = { parse() { } };
+const element = { getAttribute() { }, outerHTML() { } };
+
+proxyquire('../src/parser', { postcss });
+
+import * as CSSParser from '../src/parser';
+
+test.beforeEach((t) => {
+    t.context.postcss = postcss;
+    t.context.element = element;
+    t.context.engine = new EventEmitter2({
+        delimiter: '::',
+        maxListeners: 0,
+        wildcard: true
+    });
+});
+
+test.serial('If a style tag is not CSS, then nothing should happen', async (t) => {
+    const sandbox = sinon.createSandbox();
+    const parser = new CSSParser.default(t.context.engine); // eslint-disable-line new-cap,no-unused-vars
+
+    sandbox.spy(postcss, 'parse');
+    sandbox.stub(element, 'getAttribute')
+        .onFirstCall()
+        .returns('text/less');
+
+    await t.context.engine.emitAsync('element::style', { element });
+
+    t.true(t.context.element.getAttribute.calledOnce);
+    t.is(t.context.element.getAttribute.args[0][0], 'type');
+    t.false(t.context.postcss.parse.called);
+
+    sandbox.restore();
+});
+
+test.serial('If a style tag is inline CSS, then we should parse the stylesheet and emit a parse::css::end event', async (t) => {
+    const sandbox = sinon.createSandbox();
+    const parser = new CSSParser.default(t.context.engine); // eslint-disable-line new-cap,no-unused-vars
+    const parseObject = {};
+    const code = '.foo { color: #fff }';
+    const style = `<style>  ${code}  </style>`;
+
+    sandbox.spy(t.context.engine, 'emitAsync');
+    sandbox.stub(postcss, 'parse').returns(parseObject);
+
+    sandbox.stub(element, 'outerHTML').resolves(style);
+    sandbox.stub(element, 'getAttribute')
+        .onFirstCall()
+        .returns('text/css');
+
+    await t.context.engine.emitAsync('element::style', { element });
+
+    t.true(t.context.element.getAttribute.calledOnce);
+    t.is(t.context.element.getAttribute.args[0][0], 'type');
+    t.true(t.context.postcss.parse.calledOnce);
+    t.is(t.context.postcss.parse.args[0][0], code);
+    t.true(t.context.engine.emitAsync.calledTwice);
+
+    const args = t.context.engine.emitAsync.args[1];
+
+    t.is(args[0], 'parse::css::end');
+    t.is(args[1].code, code);
+    t.is(args[1].resource, 'Inline CSS');
+
+    sandbox.restore();
+});
+
+
+test.serial('If fetch::end::css is received, then we should parse the stylesheet and emit a parse::css::end event', async (t) => {
+    const sandbox = sinon.createSandbox();
+    const parser = new CSSParser.default(t.context.engine); // eslint-disable-line new-cap,no-unused-vars
+    const parseObject = {};
+    const code = '.foo { color: #fff }';
+
+    sandbox.spy(t.context.engine, 'emitAsync');
+    sandbox.stub(postcss, 'parse').returns(parseObject);
+
+    await t.context.engine.emitAsync('fetch::end::css', {
+        resource: 'styles.css',
+        response: {
+            body: { content: code },
+            mediaType: 'text/css'
+        }
+    });
+
+    t.true(t.context.postcss.parse.calledOnce);
+    t.is(t.context.postcss.parse.args[0][0], code);
+    t.true(t.context.engine.emitAsync.calledTwice);
+
+    const args = t.context.engine.emitAsync.args[1];
+
+    t.is(args[0], 'parse::css::end');
+    t.is(args[1].code, code);
+    t.is(args[1].resource, 'styles.css');
+
+    sandbox.restore();
+});

--- a/packages/parser-css/tsconfig.json
+++ b/packages/parser-css/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "outDir": "dist"
+    },
+    "exclude": [
+        "dist",
+        "node_modules"
+    ],
+    "extends": "../../tsconfig.json",
+    "include": [
+        "src/**/*.ts",
+        "tests/**/*.ts"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6047,6 +6047,14 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
+postcss@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.1.tgz#db20ca4fc90aa56809674eea75864148c66b67fa"
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
+
 prebuild-install@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-3.0.0.tgz#0fd5b2c48ffcf4ceefa64d04a4c5a328d79ad66c"


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

Fix #1115. Built on top of PostCSS. The `ast` property on `StyleParse`
references the PostCSS AST types to enable type validation and
autocomplete when writing rules. Currently only supports CSS, but
support for LESS and SASS can be added in the future using
existing PostCSS plugins.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
