### PR TITLE
Fix: Category for hint `no-broken-links`

### DIFF
--- a/packages/hint-no-broken-links/src/hint.ts
+++ b/packages/hint-no-broken-links/src/hint.ts
@@ -28,7 +28,7 @@ const debug: debug.IDebugger = d(__filename);
 export default class NoBrokenLinksHint implements IHint {
     public static readonly meta: HintMetadata = {
         docs: {
-            category: Category.other,
+            category: Category.performance,
             description: `Hint to flag broken links in the page`
         },
         id: 'no-broken-links',


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
