### PR TITLE
Fix: Update references to --init

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,7 @@ Run the following command:
 npx hint https://example.com
 ```
 
-This will start the wizard to create a `.hintrc` file, and then
-analyze `https://example.com`.
-
-**Windows users**: Currently [`npx` has an issue in this
-platform](https://github.com/npm/npm/issues/17869).
+This will analyze `https://example.com` using the default configuration.
 
 ### Installing `webhint` globally
 
@@ -36,7 +32,7 @@ Create a `.hintrc` file by running this command and following the
 instructions:
 
 ```bash
-hint --init
+npm create hintrc
 ```
 
 Scan a website:

--- a/packages/hint/README.md
+++ b/packages/hint/README.md
@@ -14,11 +14,7 @@ Run the following command:
 npx hint https://example.com
 ```
 
-This will start the wizard to create a `.hintrc` file, and then
-analyze `https://example.com`.
-
-**Windows users**: Currently [`npx` has an issue in this
-platform](https://github.com/npm/npm/issues/17869).
+This will analyze `https://example.com` using the default configuration.
 
 ### Installing `webhint` globally
 
@@ -30,7 +26,7 @@ Create a `.hintrc` file by running this command and following the
 instructions:
 
 ```bash
-hint --init
+npm create hintrc
 ```
 
 Scan a website:

--- a/packages/hint/docs/user-guide/concepts/configurations.md
+++ b/packages/hint/docs/user-guide/concepts/configurations.md
@@ -11,7 +11,7 @@ as well.
 To use a `configuration`, you have to:
 
 1. After installing `webhint`, install a configuration package. When running
-   `--init`, the wizard will list you the official configuration packages but
+   `npm create hintrc`, the wizard will list you the official configuration packages but
    you can search on `npm`. Any package `@hint/configuration-` or
    `webhint-configuration-` should be a valid candidate.
 2. Once installed, update your `.hintrc` to use it (this step is not needed

--- a/packages/hint/docs/user-guide/index.md
+++ b/packages/hint/docs/user-guide/index.md
@@ -6,6 +6,10 @@ If you want to have an idea of what `webhint` does and you
 have an updated version of `npm` (v5.2.0) and [Node LTS (v8.9.2)
 or later][nodejs] you can use the following command:
 
+```bash
+npm hint https://example.com
+```
+
 Alternatively, you can install it locally with:
 
 ```bash
@@ -13,16 +17,16 @@ npm install -g --engine-strict hint
 ```
 
 You can also install it as a `devDependency` if you prefer not to
-have it globally.
+have it globally (which is the team's preferred option).
 
 The next thing that `webhint` needs is a `.hintrc` file. By
 default, `webhint` will look for this file first in the current
 folder and then in the user's home directory.
 
-The fastest and easiest way to create one is by using the flag `--init`:
+The fastest and easiest way to create one is by running:
 
 ```bash
-hint --init
+npm create hintrc
 ```
 
 This command will start a wizard that will ask you a series of


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

We no longer have the `--init` option, this PR updates the code to use `npm create hintrc`.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
