### PR TITLE
Fix: Handle base[href] tags

### DIFF
--- a/packages/hint-no-broken-links/src/hint.ts
+++ b/packages/hint-no-broken-links/src/hint.ts
@@ -42,10 +42,10 @@ export default class NoBrokenLinksHint implements IHint {
         const requester = new Requester(options);
         const brokenStatusCodes = [404, 410, 500, 503];
 
-        /** Stores the elements with their urls which have been collected while traversing the page. */
+        /** Stores the elements with their URLs which have been collected while traversing the page. */
         const collectedElementsWithUrls: [ IAsyncHTMLElement, string[] ][] = [];
 
-        /** Stores the urls and it's response status codes */
+        /** Stores the URLs and it's response status codes */
         const fetchedUrls: any[] = [];
 
         /** Returns an array with all the URLs in the given `srcset` attribute or an empty string if none. */

--- a/packages/hint-no-broken-links/src/hint.ts
+++ b/packages/hint-no-broken-links/src/hint.ts
@@ -43,10 +43,10 @@ export default class NoBrokenLinksHint implements IHint {
         const brokenStatusCodes = [404, 410, 500, 503];
 
         /** Stores the elements with their URLs which have been collected while traversing the page. */
-        const collectedElementsWithUrls: [ IAsyncHTMLElement, string[] ][] = [];
+        const collectedElementsWithURLs: [ IAsyncHTMLElement, string[] ][] = [];
 
         /** Stores the URLs and it's response status codes */
-        const fetchedUrls: any[] = [];
+        const fetchedURLs: any[] = [];
 
         /** Returns an array with all the URLs in the given `srcset` attribute or an empty string if none. */
         const parseSrcSet = (srcset: string): Array<string> => {
@@ -68,7 +68,7 @@ export default class NoBrokenLinksHint implements IHint {
          * When DNS resolution fails, it will be handled here (ex : https://thissitedoesnotexist.com/ )
          */
         const handleRejection = (error: any, url: string, element: IAsyncHTMLElement) => {
-            debug(`Error accessing {$absoluteUrl}. ${JSON.stringify(error)}`);
+            debug(`Error accessing {$absoluteURL}. ${JSON.stringify(error)}`);
 
             return context.report(url, element, 'Broken link found (domain not found).');
         };
@@ -76,7 +76,7 @@ export default class NoBrokenLinksHint implements IHint {
         /**
          * The callback to handle success handler returned from the `head` method
          * We will check the response status againist the brokenStatusCodes list
-         * and report if it exist there. We will also add it to the fetchedUrls
+         * and report if it exist there. We will also add it to the fetchedURLs
          * so that duplicate requests will not be made if 2 links have the same href value
          */
         const handleSuccess = (networkData: NetworkData, url: string, element: IAsyncHTMLElement) => {
@@ -88,18 +88,18 @@ export default class NoBrokenLinksHint implements IHint {
                 return context.report(url, element, `Broken link found (${brokenStatusCodes[statusIndex]} response).`);
             }
 
-            fetchedUrls.push({ status: networkData.response.statusCode, url });
+            fetchedURLs.push({ status: networkData.response.statusCode, url });
 
             return Promise.resolve();
         };
 
         /**
-         * Checks a URL against the fetchedUrls array and return the entry if it exist
+         * Checks a URL against the fetchedURLs array and return the entry if it exist
          * The entry has 2 properties, the `url` and the `statusCode`
          */
-        const getFetchedUrl = (url: string) => {
+        const getFetchedURL = (url: string) => {
 
-            const filteredItems = fetchedUrls.filter((value) => {
+            const filteredItems = fetchedURLs.filter((value) => {
                 return value.url === url;
             });
 
@@ -135,18 +135,18 @@ export default class NoBrokenLinksHint implements IHint {
                 urls.push(...srcset);
             }
 
-            collectedElementsWithUrls.push([element, urls]);
+            collectedElementsWithURLs.push([element, urls]);
         };
 
         /**
          * Handler for fetch::end::* event.
-         * We will store the request url and response status code in fetchedUrls array
+         * We will store the request url and response status code in fetchedURLs array
          */
         const validateFetchEnd = (fetchEnd: any) => {
-            fetchedUrls.push({ statusCode: fetchEnd.response.statusCode, url: fetchEnd.resource });
+            fetchedURLs.push({ statusCode: fetchEnd.response.statusCode, url: fetchEnd.resource });
         };
 
-        const createResourceUrl = async (resource: string) => {
+        const createResourceURL = async (resource: string) => {
             const pageDOM: IAsyncHTMLDocument = context.pageDOM as IAsyncHTMLDocument;
             const baseTags: Array<IAsyncHTMLElement> = await pageDOM.querySelectorAll('base');
             const hrefAttribute = (baseTags.length === 0) ? null : baseTags[0].getAttribute('href');
@@ -154,26 +154,26 @@ export default class NoBrokenLinksHint implements IHint {
             return (hrefAttribute === null) ? new URL(resource) : new URL(hrefAttribute, new URL(resource));
         };
 
-        const createReports = (element: IAsyncHTMLElement, urls: Array<string>, resourceUrl: URL): Array<Promise<void>> => {
+        const createReports = (element: IAsyncHTMLElement, urls: Array<string>, resourceURL: URL): Array<Promise<void>> => {
             return urls.map((url) => {
-                const fullUrl = (new URL(url, resourceUrl)).toString();
-                const fetched = getFetchedUrl(fullUrl);
+                const fullURL = (new URL(url, resourceURL)).toString();
+                const fetched = getFetchedURL(fullURL);
 
                 if (fetched) {
                     const statusIndex = brokenStatusCodes.indexOf(fetched.statusCode);
 
                     if (statusIndex > -1) {
-                        return context.report(fullUrl, null, `Broken link found (${brokenStatusCodes[statusIndex]} response).`);
+                        return context.report(fullURL, null, `Broken link found (${brokenStatusCodes[statusIndex]} response).`);
                     }
                 } else {
                     // An element which was not present in the fetch end results
                     return requester
-                        .get(fullUrl)
+                        .get(fullURL)
                         .then((value: NetworkData) => {
-                            return handleSuccess(value, fullUrl, element);
+                            return handleSuccess(value, fullURL, element);
                         })
                         .catch((error: any) => {
-                            return handleRejection(error, fullUrl, element);
+                            return handleRejection(error, fullURL, element);
                         });
                 }
 
@@ -181,11 +181,11 @@ export default class NoBrokenLinksHint implements IHint {
             });
         };
 
-        const validateCollectedUrls = async (event: TraverseEnd) => {
-            const resourceUrl = await createResourceUrl(event.resource);
+        const validateCollectedURLs = async (event: TraverseEnd) => {
+            const resourceURL = await createResourceURL(event.resource);
 
-            const reports: Array<Promise<void>> = collectedElementsWithUrls.reduce<Promise<void>[]>((accumulatedReports, [element, urls]) => {
-                return [...accumulatedReports, ...createReports(element, urls, resourceUrl)];
+            const reports: Array<Promise<void>> = collectedElementsWithURLs.reduce<Promise<void>[]>((accumulatedReports, [element, urls]) => {
+                return [...accumulatedReports, ...createReports(element, urls, resourceURL)];
             }, []);
 
             await Promise.all(reports);
@@ -201,6 +201,6 @@ export default class NoBrokenLinksHint implements IHint {
         context.on('element::track', collectElementSrcs);
         context.on('element::object', collectElementSrcs);
         context.on('fetch::end::*', validateFetchEnd);
-        context.on('traverse::end', validateCollectedUrls);
+        context.on('traverse::end', validateCollectedURLs);
     }
 }

--- a/packages/hint-no-broken-links/src/hint.ts
+++ b/packages/hint-no-broken-links/src/hint.ts
@@ -153,7 +153,7 @@ export default class NoBrokenLinksHint implements IHint {
             const hrefAttribute = (baseTags.length === 0) ? null : baseTags[0].getAttribute('href');
 
             const reports: Array<Promise<void>> = collectedElementsWithUrls.reduce<Promise<void>[]>((accumulatedReports, [element, urls]) => {
-                return [...accumulatedReports, ...urls.map(async (url) => {
+                return [...accumulatedReports, ...urls.map((url) => {
                     const isRelativeUrl = (!url.startsWith('/') && URL.parse(url).hostname === null);
                     const fullUrl = (isRelativeUrl && hrefAttribute !== null) ?
                         URL.resolve(resource, hrefAttribute + url) :
@@ -169,7 +169,7 @@ export default class NoBrokenLinksHint implements IHint {
                         }
                     } else {
                         // An element which was not present in the fetch end results
-                        return await requester
+                        return requester
                             .get(fullUrl)
                             .then((value: NetworkData) => {
                                 return handleSuccess(value, fullUrl, element);

--- a/packages/hint-no-broken-links/tests/tests.ts
+++ b/packages/hint-no-broken-links/tests/tests.ts
@@ -178,6 +178,16 @@ const tests: Array<HintTest> = [
             '/1.mp4': {status: 404},
             '/2.png': {status: 404}
         }
+    },
+    {
+        name: `This test should fail as it has a link with 404 href value(absolute with base tag)`,
+        reports: [
+            { message: `Broken link found (404 response).`}
+        ],
+        serverConfig: {
+            '/': {content: generateHTMLPage('<base href="nested/">', bodyWithValidRelativeLink)},
+            '/nested/about': {status: 404}
+        }
     }
 ];
 

--- a/packages/hint-no-broken-links/tests/tests.ts
+++ b/packages/hint-no-broken-links/tests/tests.ts
@@ -83,7 +83,7 @@ const tests: Array<HintTest> = [
         }
     },
     {
-        name: `This test should pass as it has a link a valid link (when resolved with the base tag)`,
+        name: `This test should pass as it has a valid link (when resolved with the base tag)`,
         serverConfig: {
             '/': {content: generateHTMLPage('<base href="nested/">', bodyWithValidRelativeLink)},
             '/nested/about': {content: 'My about page content'}

--- a/packages/hint-no-broken-links/tests/tests.ts
+++ b/packages/hint-no-broken-links/tests/tests.ts
@@ -14,6 +14,10 @@ const bodyWithImageSource = `<div>
 <img src='https://webhint.io/static/images/next-arrow-c558ba3f13.svg'/>
 </div>`;
 
+const bodyWithValidRelativeLink = `<div>
+<a href='about'>About</a>
+</div>`;
+
 const bodyWithBrokenLinks = `<div>
 <a href='https://example.com/404'>Example</a>
 </div>`;
@@ -70,6 +74,20 @@ const tests: Array<HintTest> = [
     {
         name: `This test should pass as it has an img with valid src value(absolute)`,
         serverConfig: generateHTMLPage('', bodyWithImageSource)
+    },
+    {
+        name: `This test should pass as it has links with valid href values and a base tag which gets not used`,
+        serverConfig: {
+            '/': {content: generateHTMLPage('<base href="nested/">', bodyWithValidLinks)},
+            '/about': {content: 'My about page content'}
+        }
+    },
+    {
+        name: `This test should pass as it has a link a valid link (when resolved with the base tag)`,
+        serverConfig: {
+            '/': {content: generateHTMLPage('<base href="nested/">', bodyWithValidRelativeLink)},
+            '/nested/about': {content: 'My about page content'}
+        }
     },
     {
         name: `This test should fail as it has a link with 404 href value(absolute)`,


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

I discovered a bug in the "no-broken-links" hint, which causes it to ignore a base tag with an href value when resolving relative URLs.

I put together a fix which works when testing it with a site hosted on GitHub pages. However I was not able to add any tests as I couldn't get the tests to work in the first place. I followed the guide on the website. (https://webhint.io/docs/contributor-guide/getting-started/development-environment/)

Are the tests currently broken or am I doing something wrong?