### PR TITLE
New: Pass content to `engine.executeOn`

### DIFF
--- a/packages/connector-local/src/connector.ts
+++ b/packages/connector-local/src/connector.ts
@@ -98,7 +98,7 @@ export default class LocalConnector implements IConnector {
          */
         const uri: url.URL = getAsUri(target);
         const filePath: string = asPathString(uri);
-        const content: NetworkData = await this.fetchContent(filePath, options);
+        const content: NetworkData = await this.fetchContent(filePath, null, options);
         const event: FetchEnd = {
             element: null,
             request: content.request,
@@ -304,7 +304,7 @@ export default class LocalConnector implements IConnector {
 
             // Ignore options.content when matching multiple files
             if (options && options.content) {
-                delete options.content;
+                options.content = null;
             }
         }
 

--- a/packages/connector-local/tests/tests.ts
+++ b/packages/connector-local/tests/tests.ts
@@ -92,6 +92,28 @@ test.serial(`If target is a file (text), 'content' is setted`, async (t) => {
     sandbox.restore();
 });
 
+test.serial(`If content is passed, it is used instead of the file`, async (t) => {
+    const testContent = '"Test Content";';
+
+    const fileUri = getAsUri(path.join(__dirname, 'fixtures', 'no-watch', 'script.js'));
+
+    const sandbox = sinon.createSandbox();
+
+    sandbox.stub(t.context.isFile, 'default').returns(true);
+    sandbox.spy(t.context.engine, 'emitAsync');
+
+    const connector = new LocalConnector(t.context.engine as any, {});
+
+    await connector.collect(fileUri, testContent);
+
+    const event = t.context.engine.emitAsync.args[2][1];
+
+    t.is(typeof event.response.body.content, 'string');
+    t.not(event.response.body.content, testContent);
+
+    sandbox.restore();
+});
+
 test.serial(`If target is a file (image), 'content' is empty`, async (t) => {
     const fileUri = getAsUri(path.join(__dirname, 'fixtures', 'no-watch', 'stylish-output.png'));
 

--- a/packages/connector-local/tests/tests.ts
+++ b/packages/connector-local/tests/tests.ts
@@ -109,7 +109,7 @@ test.serial(`If content is passed, it is used instead of the file`, async (t) =>
     const event = t.context.engine.emitAsync.args[2][1];
 
     t.is(typeof event.response.body.content, 'string');
-    t.not(event.response.body.content, testContent);
+    t.is(event.response.body.content, testContent);
 
     sandbox.restore();
 });

--- a/packages/hint/src/lib/engine.ts
+++ b/packages/hint/src/lib/engine.ts
@@ -281,13 +281,13 @@ export class Engine extends EventEmitter {
     }
 
     /** Runs all the configured hints on a target */
-    public async executeOn(target: url.URL): Promise<Array<Problem>> {
+    public async executeOn(target: url.URL, content?: string): Promise<Array<Problem>> {
 
         const start: number = Date.now();
 
         debug(`Starting the analysis on ${target.href}`);
 
-        await this.connector.collect(target);
+        await this.connector.collect(target, content);
 
         debug(`Total runtime ${Date.now() - start}`);
 

--- a/packages/hint/src/lib/engine.ts
+++ b/packages/hint/src/lib/engine.ts
@@ -17,7 +17,7 @@ import { remove } from 'lodash';
 
 import { debug as d } from './utils/debug';
 import { getSeverity } from './config/config-hints';
-import { IAsyncHTMLElement, IConnector, NetworkData, UserConfig, Event, Problem, ProblemLocation, IHint, HintConfig, Severity, IHintConstructor, IConnectorConstructor, Parser, IFormatter, HintResources } from './types';
+import { IAsyncHTMLElement, IConnector, IFetchOptions, NetworkData, UserConfig, Event, Problem, ProblemLocation, IHint, HintConfig, Severity, IHintConstructor, IConnectorConstructor, Parser, IFormatter, HintResources } from './types';
 import * as logger from './utils/logging';
 import { HintContext } from './hint-context';
 import { HintScope } from './enums/hintscope';
@@ -281,13 +281,13 @@ export class Engine extends EventEmitter {
     }
 
     /** Runs all the configured hints on a target */
-    public async executeOn(target: url.URL, content?: string): Promise<Array<Problem>> {
+    public async executeOn(target: url.URL, options?: IFetchOptions): Promise<Array<Problem>> {
 
         const start: number = Date.now();
 
         debug(`Starting the analysis on ${target.href}`);
 
-        await this.connector.collect(target, content);
+        await this.connector.collect(target, options);
 
         debug(`Total runtime ${Date.now() - start}`);
 

--- a/packages/hint/src/lib/types/connector.ts
+++ b/packages/hint/src/lib/types/connector.ts
@@ -17,7 +17,7 @@ export interface IConnector {
     /** The headers from the response if applicable. */
     headers?: object;
     /** Collects all the information for the given target. */
-    collect(target: url.URL): Promise<any>;
+    collect(target: url.URL, content?: string): Promise<any>;
     /** Releases any used resource and/or browser. */
     close(): Promise<void>;
     /** Download an external resource using ` customHeaders` if needed. */

--- a/packages/hint/src/lib/types/connector.ts
+++ b/packages/hint/src/lib/types/connector.ts
@@ -17,15 +17,21 @@ export interface IConnector {
     /** The headers from the response if applicable. */
     headers?: object;
     /** Collects all the information for the given target. */
-    collect(target: url.URL, content?: string): Promise<any>;
+    collect(target: url.URL, options?: IFetchOptions): Promise<any>;
     /** Releases any used resource and/or browser. */
     close(): Promise<void>;
     /** Download an external resource using ` customHeaders` if needed. */
-    fetchContent?(target: url.URL | string, customHeaders?: object): Promise<NetworkData>;
+    fetchContent?(target: url.URL | string, customHeaders?: object, options?: IFetchOptions): Promise<NetworkData>;
     /** Evaluates the given JavaScript `code` asynchronously in the target. */
     evaluate?(code: string): Promise<any>;
     /** Finds all the nodes that match the given query. */
     querySelectorAll?(query: string): Promise<Array<IAsyncHTMLElement>>;
+}
+
+/** Additional detail for calls to `connect` and `fetchContent` on `IConnector`. */
+export interface IFetchOptions {
+    /** The content to analyze. Overrides fetching content from the provided target. */
+    content?: string;
 }
 
 export type BrowserInfo = {

--- a/packages/hint/tests/lib/engine.ts
+++ b/packages/hint/tests/lib/engine.ts
@@ -19,7 +19,7 @@ eventEmitter.EventEmitter2.prototype.emitAsync = () => {
 proxyquire('../../src/lib/engine', { eventemitter2: eventEmitter });
 
 import { Engine } from '../../src/lib/engine';
-import { HintResources, IFormatter, IConnector, IHint, HintMetadata, Problem } from '../../src/lib/types';
+import { HintResources, IFormatter, IConnector, IFetchOptions, IHint, HintMetadata, Problem } from '../../src/lib/types';
 import { Category } from '../../src/lib/enums/category';
 
 class FakeConnector implements IConnector {
@@ -884,8 +884,8 @@ test.serial('executeOn should forward content if provided', async (t) => {
             this.server = server;
         }
 
-        public collect(target: url.URL, content?: string) {
-            this.server.report('1', Category.other, 1, 'node', { column: 1, line: 1 }, content, target.href);
+        public collect(target: url.URL, options?: IFetchOptions) {
+            this.server.report('1', Category.other, 1, 'node', { column: 1, line: 1 }, options && options.content, target.href);
 
             return Promise.resolve(target);
         }
@@ -913,7 +913,7 @@ test.serial('executeOn should forward content if provided', async (t) => {
 
     const localUrl = new url.URL('http://localhost/');
 
-    const result = await engineObject.executeOn(localUrl, testContent);
+    const result = await engineObject.executeOn(localUrl, { content: testContent });
 
     t.is(result[0].message, testContent);
 });


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Needed for #1254 to support validating files with unsaved changes.
Includes enhancing the local connector to use passed content.
Implemented via an options object to simplify consumption/maintenance.
New tests added for both `Engine` and `LocalConnector` to validate behavior.
