### PR TITLE
Fix: Remove duplicate values when extending config

### DIFF
--- a/packages/hint/src/lib/config.ts
+++ b/packages/hint/src/lib/config.ts
@@ -88,7 +88,16 @@ const composeConfig = (userConfig: UserConfig) => {
         return composeConfig(loadedConfiguration);
     });
 
-    const finalConfig = merge({}, ...configurations, userConfig);
+    const finalConfig: UserConfig = merge({}, ...configurations, userConfig);
+
+    // Otherwise the output could be double or we could trigger double events
+    if (finalConfig.formatters) {
+        finalConfig.formatters = Array.from(new Set(finalConfig.formatters));
+    }
+
+    if (finalConfig.parsers) {
+        finalConfig.parsers = Array.from(new Set(finalConfig.parsers));
+    }
 
     return finalConfig;
 };

--- a/packages/hint/tests/lib/config.ts
+++ b/packages/hint/tests/lib/config.ts
@@ -212,10 +212,11 @@ test.serial(`if the configuration file contains an extends property, it should c
 
     sandbox.stub(resourceLoader, 'loadConfiguration').returns(exts);
 
-    const configuration = config.Configuration.fromFilePath(path.join(__dirname, './fixtures/valid/withextends.json'), { watch: false } as CLIOptions);
+    const configuration: UserConfig = config.Configuration.fromFilePath(path.join(__dirname, './fixtures/valid/withextends.json'), { watch: false } as CLIOptions);
 
     t.is((configuration.connector as ConnectorConfig).name, 'chrome');
     t.is(configuration.hints['disallowed-headers'], 'error');
+    t.is(configuration.formatters.length, 1);
 });
 
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- [x] Added/Updated related tests.

## Short description of the change(s)

Use only unique values for `formatters` and `parsers` when calculating
the final configuration of an `extends`.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #1273

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
