### PR TITLE
Fix: Summary output with mixed warnings

### DIFF
--- a/packages/formatter-summary/src/formatter.ts
+++ b/packages/formatter-summary/src/formatter.ts
@@ -42,7 +42,11 @@ export default class SummaryFormatter implements IFormatter {
             return;
         }
 
-        const buildMessage = (count, type) => {
+        const buildMessage = (count, type): string => {
+            if (count === 0) {
+                return '';
+            }
+
             return `${count} ${type}${count === 1 ? '' : 's'}`;
         };
 
@@ -66,10 +70,18 @@ export default class SummaryFormatter implements IFormatter {
             const msgsBySeverity = _.groupBy(problems, 'severity');
             const errors = msgsBySeverity[Severity.error] ? msgsBySeverity[Severity.error].length : 0;
             const warnings = msgsBySeverity[Severity.warning] ? msgsBySeverity[Severity.warning].length : 0;
-            const color: typeof chalk = errors > 0 ? chalk.red : chalk.yellow;
-            const message = errors ? buildMessage(errors, 'error') : buildMessage(warnings, 'warning');
+            const red: typeof chalk = chalk.red;
+            const yellow: typeof chalk = chalk.yellow;
+            const line: Array<string> = [chalk.cyan(hintId)];
 
-            tableData.push([chalk.cyan(hintId), color(message)]);
+            if (errors > 0) {
+                line.push(red(buildMessage(errors, 'error')));
+            }
+            if (warnings > 0) {
+                line.push(yellow(buildMessage(warnings, 'warning')));
+            }
+
+            tableData.push(line);
 
             totalErrors += errors;
             totalWarnings += warnings;

--- a/packages/formatter-summary/tests/fixtures/list-of-problems.ts
+++ b/packages/formatter-summary/tests/fixtures/list-of-problems.ts
@@ -123,10 +123,38 @@ const summaryWarnings: Array<Problem> = [{
     sourceCode: ''
 }];
 
+const summaryErrorWarnings: Array<Problem> = [{
+    category: Category.other,
+    hintId: 'random-hint',
+    location: {
+        column: 10,
+        elementColumn: 10,
+        elementLine: 1,
+        line: 1
+    },
+    message: 'This is a problem in line 1 column 10',
+    resource: 'http://myresource.com/',
+    severity: Severity.error,
+    sourceCode: '<a href="//link.com">link</a>'
+},
+{
+    category: Category.other,
+    hintId: 'random-hint',
+    location: {
+        column: -1,
+        line: -1
+    },
+    message: 'This is a problem without line in myresource',
+    resource: 'http://myresource.com/',
+    severity: Severity.warning,
+    sourceCode: ''
+}];
+
 const noproblems: Array<Problem> = [];
 
 export {
     noproblems,
+    summaryErrorWarnings,
     summarySameNumberOfErrors,
     summaryProblems,
     summaryWarnings

--- a/packages/formatter-summary/tests/tests.ts
+++ b/packages/formatter-summary/tests/tests.ts
@@ -79,3 +79,19 @@ test(`Summary formatter sorts by name if same number of errors`, (t) => {
     t.is(log.args[0][0], tableString);
     t.is(log.args[1][0], chalk.red.bold(`${logSymbols.error.trim()} Found a total of 2 errors and 0 warnings`));
 });
+
+test(`Summary formatter prints errors and warnings for a hint that reports both`, (t) => {
+    const log = t.context.logger.log;
+    const tableData = [];
+
+    const formatter = new SummaryFormatter();
+
+    formatter.format(problems.summaryErrorWarnings);
+
+    tableData.push([chalk.cyan('random-hint'), chalk.red(`1 error`), chalk.yellow(`1 warning`)]);
+
+    const tableString = table(tableData);
+
+    t.is(log.args[0][0], tableString);
+    t.is(log.args[1][0], chalk.red.bold(`${logSymbols.error.trim()} Found a total of 1 error and 1 warning`));
+});


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- [x] Added/Updated related tests.

## Short description of the change(s)

Fix #1272

![summary output](https://user-images.githubusercontent.com/606594/45070160-d590ac00-b084-11e8-8818-4034fc246e4e.png)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
