### PR TITLE
Fix: Make `npm` package not include `npm-shrinkwrap.json` file

### DIFF
--- a/packages/configuration-progressive-web-apps/package.json
+++ b/packages/configuration-progressive-web-apps/package.json
@@ -19,9 +19,9 @@
     "index.json"
   ],
   "keywords": [
+    "progressive-web-apps",
     "pwa",
     "pwas",
-    "progressive-web-apps",
     "webhint",
     "webhint-configuration"
   ],

--- a/packages/configuration-web-recommended/package.json
+++ b/packages/configuration-web-recommended/package.json
@@ -40,6 +40,7 @@
     "a11y",
     "accessibility",
     "best-practices",
+    "compatibility",
     "interoperability",
     "lint",
     "performance",

--- a/packages/connector-chrome/package.json
+++ b/packages/connector-chrome/package.json
@@ -37,8 +37,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/connector-edge/package.json
+++ b/packages/connector-edge/package.json
@@ -21,7 +21,6 @@
   },
   "files": [
     "dist/src",
-    "npm-shrinkwrap.json",
     "scripts"
   ],
   "homepage": "https://webhint.io/",

--- a/packages/connector-jsdom/package.json
+++ b/packages/connector-jsdom/package.json
@@ -36,8 +36,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/connector-local/package.json
+++ b/packages/connector-local/package.json
@@ -37,8 +37,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/create-hint/package.json
+++ b/packages/create-hint/package.json
@@ -40,8 +40,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/create-hint/src/shared-templates/package.hbs
+++ b/packages/create-hint/src/shared-templates/package.hbs
@@ -29,8 +29,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],{{#if official}}
   "homepage": "https://webhint.io/",{{else}}
   "homepage": "",{{/if}}

--- a/packages/create-hintrc/package.json
+++ b/packages/create-hintrc/package.json
@@ -43,8 +43,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/create-parser/package.json
+++ b/packages/create-parser/package.json
@@ -40,8 +40,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/create-parser/src/shared-templates/package.hbs
+++ b/packages/create-parser/src/shared-templates/package.hbs
@@ -31,8 +31,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],{{#if official}}
   "homepage": "https://webhint.io/",{{else}}
   "homepage": "",{{/if}}

--- a/packages/formatter-codeframe/package.json
+++ b/packages/formatter-codeframe/package.json
@@ -35,8 +35,7 @@
   },
   "files": [
     "dist/src",
-    "images",
-    "npm-shrinkwrap.json"
+    "images"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/formatter-excel/package.json
+++ b/packages/formatter-excel/package.json
@@ -34,16 +34,15 @@
   },
   "files": [
     "dist/src",
-    "images",
-    "npm-shrinkwrap.json"
+    "images"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
+    "excel",
     "formatter",
-    "webhint-formatter",
+    "webhint",
     "webhint-excel",
-    "excel"
+    "webhint-formatter"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/formatter.js",

--- a/packages/formatter-html/package.json
+++ b/packages/formatter-html/package.json
@@ -40,8 +40,7 @@
   },
   "files": [
     "dist/src",
-    "images",
-    "npm-shrinkwrap.json"
+    "images"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/formatter-json/package.json
+++ b/packages/formatter-json/package.json
@@ -33,14 +33,13 @@
   },
   "files": [
     "dist/src",
-    "images",
-    "npm-shrinkwrap.json"
+    "images"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
+    "json",
     "webhint",
-    "webhint-formatter",
-    "json"
+    "webhint-formatter"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/formatter.js",

--- a/packages/formatter-stylish/package.json
+++ b/packages/formatter-stylish/package.json
@@ -36,8 +36,7 @@
   },
   "files": [
     "dist/src",
-    "images",
-    "npm-shrinkwrap.json"
+    "images"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/formatter-summary/package.json
+++ b/packages/formatter-summary/package.json
@@ -36,8 +36,7 @@
   },
   "files": [
     "dist/src",
-    "images",
-    "npm-shrinkwrap.json"
+    "images"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/hint-amp-validator/package.json
+++ b/packages/hint-amp-validator/package.json
@@ -31,8 +31,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/hint-apple-touch-icons/package.json
+++ b/packages/hint-apple-touch-icons/package.json
@@ -31,15 +31,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "apple-touch-icons",
     "apple-touch-icons-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-axe/package.json
+++ b/packages/hint-axe/package.json
@@ -31,15 +31,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "axe",
     "axe-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-babel-config/package.json
+++ b/packages/hint-babel-config/package.json
@@ -29,15 +29,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "babel-config-is-valid",
     "babel-config-is-valid-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-content-type/package.json
+++ b/packages/hint-content-type/package.json
@@ -31,15 +31,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "content-type",
     "content-type-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-disown-opener/package.json
+++ b/packages/hint-disown-opener/package.json
@@ -28,15 +28,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "disown-opener",
     "disown-opener-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-highest-available-document-mode/package.json
+++ b/packages/hint-highest-available-document-mode/package.json
@@ -28,15 +28,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "highest-available-document-mode",
     "highest-available-document-mode-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-html-checker/package.json
+++ b/packages/hint-html-checker/package.json
@@ -32,15 +32,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "html-checker",
     "html-checker-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-http-cache/package.json
+++ b/packages/hint-http-cache/package.json
@@ -28,15 +28,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "http-cache",
     "http-cache-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-http-compression/package.json
+++ b/packages/hint-http-compression/package.json
@@ -31,15 +31,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "http-compression",
     "http-compression-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-https-only/package.json
+++ b/packages/hint-https-only/package.json
@@ -28,16 +28,15 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
     "hint",
-    "webhint",
     "https-only",
-    "https-only-hint"
-  ],
+    "https-only-hint",
+    "webhint"
+  ]
   "license": "Apache-2.0",
   "main": "dist/src/hint.js",
   "name": "@hint/hint-https-only",

--- a/packages/hint-image-optimization-cloudinary/package.json
+++ b/packages/hint-image-optimization-cloudinary/package.json
@@ -34,15 +34,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "image-optimization-cloudinary",
-    "image-optimization-cloudinary-hint"
+    "image-optimization-cloudinary-hint",
+    "webhint",
+    "webhint-hint"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/hint.js",

--- a/packages/hint-manifest-app-name/package.json
+++ b/packages/hint-manifest-app-name/package.json
@@ -32,15 +32,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "manifest-app-name",
     "manifest-app-name-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-manifest-exists/package.json
+++ b/packages/hint-manifest-exists/package.json
@@ -29,15 +29,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "manifest-exists",
     "manifest-exists-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-manifest-file-extension/package.json
+++ b/packages/hint-manifest-file-extension/package.json
@@ -29,15 +29,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "manifest-file-extension",
     "manifest-file-extension-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-manifest-is-valid/package.json
+++ b/packages/hint-manifest-is-valid/package.json
@@ -33,16 +33,15 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
     "manifest-is-valid",
     "manifest-is-valid-hint",
     "webhint",
-    "webhint-recommended",
-    "webhint-hint"
+    "webhint-hint",
+    "webhint-recommended"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/hint.js",

--- a/packages/hint-meta-charset-utf-8/package.json
+++ b/packages/hint-meta-charset-utf-8/package.json
@@ -31,15 +31,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "meta-charset-utf-8",
     "meta-charset-utf-8-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-meta-theme-color/package.json
+++ b/packages/hint-meta-theme-color/package.json
@@ -32,14 +32,13 @@
   },
   "files": [
     "dist/src",
-    "images",
-    "npm-shrinkwrap.json"
+    "images"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
+    "meta-theme-color",
     "webhint",
-    "webhint-hint",
-    "meta-theme-color"
+    "webhint-hint"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/hint.js",

--- a/packages/hint-meta-viewport/package.json
+++ b/packages/hint-meta-viewport/package.json
@@ -31,15 +31,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "meta-viewport",
     "meta-viewport-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-minified-js/package.json
+++ b/packages/hint-minified-js/package.json
@@ -30,15 +30,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
     "hint",
-    "webhint",
     "minified-js",
-    "minified-js-hint"
+    "minified-js-hint",
+    "webhint"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/hint.js",

--- a/packages/hint-no-bom/package.json
+++ b/packages/hint-no-bom/package.json
@@ -27,16 +27,15 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
     "hint",
-    "webhint",
-    "webhint-hint",
     "no-bom",
-    "no-bom-hint"
+    "no-bom-hint",
+    "webhint",
+    "webhint-hint"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/hint.js",

--- a/packages/hint-no-broken-links/package.json
+++ b/packages/hint-no-broken-links/package.json
@@ -32,15 +32,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
     "hint",
-    "webhint",
     "no-broken-links",
-    "no-broken-links-hint"
+    "no-broken-links-hint",
+    "webhint"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/hint.js",

--- a/packages/hint-no-disallowed-headers/package.json
+++ b/packages/hint-no-disallowed-headers/package.json
@@ -28,15 +28,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "no-disallowed-headers",
     "no-disallowed-headers-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-no-friendly-error-pages/package.json
+++ b/packages/hint-no-friendly-error-pages/package.json
@@ -28,15 +28,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "no-friendly-error-pages",
     "no-friendly-error-pages-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-no-html-only-headers/package.json
+++ b/packages/hint-no-html-only-headers/package.json
@@ -28,15 +28,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "no-html-only-headers",
     "no-html-only-headers-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-no-http-redirects/package.json
+++ b/packages/hint-no-http-redirects/package.json
@@ -28,15 +28,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "no-http-redirects",
     "no-http-redirects-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-no-p3p/package.json
+++ b/packages/hint-no-p3p/package.json
@@ -28,15 +28,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "no-p3p",
-    "no-p3p-hint"
+    "no-p3p-hint",
+    "webhint",
+    "webhint-hint"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/hint.js",

--- a/packages/hint-no-protocol-relative-urls/package.json
+++ b/packages/hint-no-protocol-relative-urls/package.json
@@ -28,15 +28,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "no-protocol-relative-urls",
     "no-protocol-relative-urls-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-no-vulnerable-javascript-libraries/package.json
+++ b/packages/hint-no-vulnerable-javascript-libraries/package.json
@@ -37,15 +37,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist",
-    "npm-shrinkwrap.json"
+    "dist"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "no-vulnerable-javascript-libraries",
     "no-vulnerable-javascript-libraries-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-performance-budget/package.json
+++ b/packages/hint-performance-budget/package.json
@@ -29,14 +29,13 @@
   },
   "files": [
     "dist",
-    "npm-shrinkwrap.json"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "performance-budget",
     "performance-budget-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-sri/package.json
+++ b/packages/hint-sri/package.json
@@ -29,16 +29,15 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
     "hint",
-    "webhint",
-    "webhint-hint",
     "sri",
-    "sri-hint"
+    "sri-hint",
+    "webhint",
+    "webhint-hint"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/hint.js",

--- a/packages/hint-ssllabs/package.json
+++ b/packages/hint-ssllabs/package.json
@@ -32,15 +32,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist",
-    "npm-shrinkwrap.json"
+    "dist"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "ssllabs",
-    "ssllabs-hint"
+    "ssllabs-hint",
+    "webhint",
+    "webhint-hint"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/hint.js",

--- a/packages/hint-strict-transport-security/package.json
+++ b/packages/hint-strict-transport-security/package.json
@@ -29,15 +29,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist",
-    "npm-shrinkwrap.json"
+    "dist"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "strict-transport-security",
     "strict-transport-security-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-stylesheet-limits/package.json
+++ b/packages/hint-stylesheet-limits/package.json
@@ -29,15 +29,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
     "hint",
-    "webhint",
     "stylesheet-limits",
-    "stylesheet-limits-hint"
+    "stylesheet-limits-hint",
+    "webhint"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/hint.js",

--- a/packages/hint-typescript-config/package.json
+++ b/packages/hint-typescript-config/package.json
@@ -30,15 +30,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist",
-    "npm-shrinkwrap.json"
+    "dist"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "typescript-config-is-valid",
-    "typescript-config-is-valid-hint"
+    "typescript-config-is-valid-hint",
+    "webhint",
+    "webhint-hint"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/index.js",

--- a/packages/hint-validate-set-cookie-header/package.json
+++ b/packages/hint-validate-set-cookie-header/package.json
@@ -28,15 +28,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist",
-    "npm-shrinkwrap.json"
+    "dist"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-hint",
     "validate-set-cookie-header",
     "validate-set-cookie-header-hint",
+    "webhint",
+    "webhint-hint",
     "webhint-recommended"
   ],
   "license": "Apache-2.0",

--- a/packages/hint-webpack-config/package.json
+++ b/packages/hint-webpack-config/package.json
@@ -31,8 +31,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist",
-    "npm-shrinkwrap.json"
+    "dist"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/hint-x-content-type-options/package.json
+++ b/packages/hint-x-content-type-options/package.json
@@ -28,16 +28,15 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist",
-    "npm-shrinkwrap.json"
+    "dist"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
     "webhint",
     "webhint-hint",
+    "webhint-recommended",
     "x-content-type-options",
-    "x-content-type-options-hint",
-    "webhint-recommended"
+    "x-content-type-options-hint"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/hint.js",

--- a/packages/hint/package.json
+++ b/packages/hint/package.json
@@ -70,8 +70,7 @@
     ".hintrc",
     "dist/src",
     "dist/tests/helpers",
-    "docs",
-    "npm-shrinkwrap.json"
+    "docs"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/parser-babel-config/package.json
+++ b/packages/parser-babel-config/package.json
@@ -32,14 +32,13 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
+    "babel-config",
     "webhint",
-    "webhint-parser",
-    "babel-config"
+    "webhint-parser"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/parser.js",

--- a/packages/parser-css/package.json
+++ b/packages/parser-css/package.json
@@ -32,14 +32,13 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
+    "css",
     "webhint",
-    "webhint-parser",
-    "css"
+    "webhint-parser"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/parser.js",

--- a/packages/parser-html/package.json
+++ b/packages/parser-html/package.json
@@ -33,8 +33,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/parser-javascript/package.json
+++ b/packages/parser-javascript/package.json
@@ -32,14 +32,13 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
+    "javascript",
     "webhint",
-    "webhint-parser",
-    "javascript"
+    "webhint-parser"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/parser.js",

--- a/packages/parser-manifest/package.json
+++ b/packages/parser-manifest/package.json
@@ -30,15 +30,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "webhint",
-    "webhint-parser",
     "manifest",
-    "manifest-parser"
+    "manifest-parser",
+    "webhint",
+    "webhint-parser"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/parser.js",

--- a/packages/parser-typescript-config/package.json
+++ b/packages/parser-typescript-config/package.json
@@ -32,14 +32,13 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
+    "typescript-config",
     "webhint",
-    "webhint-parser",
-    "typescript-config"
+    "webhint-parser"
   ],
   "license": "Apache-2.0",
   "main": "dist/src/parser.js",

--- a/packages/parser-webpack-config/package.json
+++ b/packages/parser-webpack-config/package.json
@@ -29,8 +29,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [

--- a/packages/utils-connector-tools/package.json
+++ b/packages/utils-connector-tools/package.json
@@ -32,16 +32,15 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/src",
-    "npm-shrinkwrap.json"
+    "dist/src"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
     "connector",
-    "utils",
-    "tools",
     "hint",
     "hint-utils-connector-tools",
+    "tools",
+    "utils",
     "webhint"
   ],
   "license": "Apache-2.0",

--- a/packages/utils-create-server/package.json
+++ b/packages/utils-create-server/package.json
@@ -26,15 +26,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist",
-    "npm-shrinkwrap.json"
+    "dist"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "utils",
     "create-server",
     "hint",
     "hint-utils-create-server",
+    "utils",
     "webhint"
   ],
   "license": "Apache-2.0",

--- a/packages/utils-debugging-protocol-common/package.json
+++ b/packages/utils-debugging-protocol-common/package.json
@@ -22,16 +22,15 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist",
-    "npm-shrinkwrap.json"
+    "dist"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
     "connector",
-    "utils",
     "debugging protocol",
     "hint",
     "hint-utils-debugging-protocol-common",
+    "utils",
     "webhint"
   ],
   "license": "Apache-2.0",

--- a/packages/utils-tests-helpers/package.json
+++ b/packages/utils-tests-helpers/package.json
@@ -24,15 +24,14 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist",
-    "npm-shrinkwrap.json"
+    "dist"
   ],
   "homepage": "https://webhint.io/",
   "keywords": [
-    "utils",
-    "tests",
     "hint",
     "hint-utils-tests-helpers",
+    "tests",
+    "utils",
     "webhint"
   ],
   "license": "Apache-2.0",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -585,14 +585,6 @@ const npmPublish = (ctx) => {
     });
 };
 
-const npmRemoveDevDependencies = async (ctx) => {
-    /*
-     * Remove devDependencies, this will update `package-lock.json`.
-     * Need to do so they aren't published on the `npm` package.
-     */
-    await exec(`cd ${ctx.packagePath} && npm prune --production`);
-};
-
 const npmRemovePrivateField = (ctx) => {
     delete ctx.packageJSONFileContent.private;
     updateFile(ctx.packageJSONFilePath, `${JSON.stringify(ctx.packageJSONFileContent, null, 2)}\n`);
@@ -604,14 +596,6 @@ const npmRunBuildForRelease = async (ctx) => {
 
 const npmRunTests = async (ctx) => {
     await exec(`cd ${ctx.packagePath} && npm run test`);
-};
-
-const npmShrinkwrap = async (ctx) => {
-    /*
-     * (This is done because `npm` doesn't
-     *  publish the `package-lock` file)
-     */
-    await exec(`cd ${ctx.packagePath} && npm shrinkwrap`);
 };
 
 const npmUpdateVersion = async (ctx) => {
@@ -775,8 +759,6 @@ const getTasksForRelease = (packageName: string, packageJSONFileContent) => {
     tasks.push(
         newTask('Commit changes.', gitCommitBuildChanges),
         newTask('Tag new version.', gitTagNewVersion),
-        newTask('Remove `devDependencies`.', npmRemoveDevDependencies),
-        newTask('Create `npm-shrinkwrap.json` file.', npmShrinkwrap),
         newTask(`Publish on npm.`, npmPublish),
         newTask(`Push changes upstream.`, gitPush),
         newTask(`Create release.`, gitCreateRelease),
@@ -816,8 +798,6 @@ const getTaksForPrerelease = (packageName: string) => {
     }
 
     tasks.push(
-        newTask('Remove `devDependencies`.', npmRemoveDevDependencies),
-        newTask('Create `npm-shrinkwrap.json` file.', npmShrinkwrap),
         newTask(`Publish on npm.`, npmPublish),
         newTask(`Update \`${packageName}\` version number in other packages.`, updatePackageVersionNumberInOtherPackages)
     );
@@ -846,7 +826,6 @@ const getTasks = (packagePath: string) => {
             ctx.changelogFilePath = `${ctx.packagePath}/CHANGELOG.md`;
             ctx.packageJSONFilePath = `${ctx.packagePath}/package.json`;
             ctx.packageLockJSONFilePath = `${ctx.packagePath}/package-lock.json`;
-            ctx.shrinkwrapFilePath = `${ctx.packagePath}/npm-shrinkwrap.json`;
 
             ctx.packageJSONFileContent = packageJSONFileContent;
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
Even though `npm` recommends:

> The recommended use-case for `npm-shrinkwrap.json`  is applications deployed through the publishing process on the registry: for example, daemons and **command-line  tools** intended as global installs or devDependencies "

we found that this model did not work out for this project as:

> ... that would prevent end users from having control over  transitive dependency updates. "

See also: https://docs.npmjs.com/files/shrinkwrap.json