### PR TITLE
Fix: Hide report in HTML Formatter when the status is `error`

### DIFF
--- a/packages/formatter-html/src/views/partials/scan-error-message.ejs
+++ b/packages/formatter-html/src/views/partials/scan-error-message.ejs
@@ -1,6 +1,5 @@
 <div id="scan-error" class="scan-error">
     <p>
-        There was an error and we were only able to partially complete the scan. View the results below or
-        <% if(result.isScanner) { %><a href="/scanner/">perform another scan</a><% } else { %>run webhint again<% } %>.
+        There was an error and we were not able to complete the scan. <% if(result.isScanner) { %><a href="/scanner/">Perform another scan</a><% } else { %>Run webhint again<% } %>.
     <p>
 </div>

--- a/packages/formatter-html/src/views/partials/scan-result.ejs
+++ b/packages/formatter-html/src/views/partials/scan-result.ejs
@@ -11,11 +11,11 @@
         <div class="scan-overview--details">
             <div class="scan-overview--warnings">
                 <p class="scan-overview__subheader">warnings</p>
-                <p class="scan-overview__body--red" id="total-warnings"><%= result.warnings %></p>
+                <p class="scan-overview__body--red" id="total-warnings"><%= result.status !== 'error' ? result.warnings : '-'; %></p>
             </div>
             <div class="scan-overview--errors">
                 <p class="scan-overview__subheader">errors</p>
-                <p class="scan-overview__body--red" id="total-errors"><%= result.errors %></p>
+                <p class="scan-overview__body--red" id="total-errors"><%= result.status !== 'error' ? result.errors : '-'; %></p>
             </div>
             <div class="scan-overview--time">
                 <p class="scan-overview__subheader">scan time</p>
@@ -42,7 +42,8 @@
             <% } %>
         </div>
     </div>
-    <div class="layout layout--fifths">
+    <% if(result.status !== 'error') { %>
+    <div class="layout layout--fifths" id="categories-summary">
         <% result.categories.forEach((category) => { -%>
         <div class="module">
             <div class="rule-tile <% if (category.errors !== 0 || category.warnings !== 0) { %>rule-tile--failed<% } else if (utils.noPending(category)) { %>rule-tile--passed<% } %>">
@@ -62,9 +63,10 @@
         </div>
         <% }) %>
     </div>
+    <% } %>
     <% if (result.status === 'error') { %>
         <%- include('scan-error-message', { result }) %>
-    <% } %>
+    <% } else { %>
     <section id="results-container" class="section container" role="main" aria-labelledby="errors-warnings" aria-live="polite">
         <h2 id="errors-warnings">Errors &amp; Warnings</h2>
         <div class="layout layout--sidebar--alt">
@@ -96,6 +98,7 @@
             </div>
         </div>
     </section>
+    <% } %>
     <section class="section container">
         <p class="subtitle">Have an issue or problem with the scanner?</p>
         <p>File an issue on


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
