### PR TITLE
New: Change `hint-axe` to `HintScope.any`

### DIFF
--- a/packages/hint-axe/src/hint.ts
+++ b/packages/hint-axe/src/hint.ts
@@ -65,9 +65,8 @@ export default class AxeHint implements IHint {
         }],
         /*
          * axe can not analize a file itself, it needs a connector.
-         * TODO: Change to any once the local connector has jsdom.
          */
-        scope: HintScope.site
+        scope: HintScope.any
     }
 
     public constructor(context: HintContext) {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Now that `connector-local` uses `jsdom` it can support hints which
need to evaluate script in the context of the page (e.g. `hint-axe`).

Other hints with `HintScope.site` still need to remain that way as
they look at HTTP headers or rely on external resources being
loaded.