### PR TITLE
Chore: Fix `file:` url handling in connector-local

### DIFF
--- a/packages/connector-local/src/connector.ts
+++ b/packages/connector-local/src/connector.ts
@@ -103,24 +103,12 @@ export default class LocalConnector implements IConnector {
     }
 
     private async fetchData(target: string, options?: IFetchOptions): Promise<FetchEnd> {
-        /*
-         * target can have one of these forms:
-         *   - /path/to/file
-         *   - C:/path/to/file
-         *   - file:///path/to/file
-         *   - file:///C:/path/to/file
-         *
-         * That's why we need to parse it to an URL
-         * and then get the path string.
-         */
-        const uri: url.URL = getAsUri(target);
-        const filePath: string = asPathString(uri);
-        const content: NetworkData = await this.fetchContent(filePath, null, options);
+        const content: NetworkData = await this.fetchContent(target, null, options);
 
         return {
             element: null,
             request: content.request,
-            resource: url.format(getAsUri(filePath)),
+            resource: url.format(getAsUri(target)),
             response: content.response
         };
     }
@@ -269,7 +257,19 @@ export default class LocalConnector implements IConnector {
      * ------------------------------------------------------------------------------
      */
 
-    public async fetchContent(filePath: string, headers?: object, options?: IFetchOptions): Promise<NetworkData> {
+    public async fetchContent(target: string, headers?: object, options?: IFetchOptions): Promise<NetworkData> {
+        /*
+         * target can have one of these forms:
+         *   - /path/to/file
+         *   - C:/path/to/file
+         *   - file:///path/to/file
+         *   - file:///C:/path/to/file
+         *
+         * That's why we need to parse it to an URL
+         * and then get the path string.
+         */
+        const uri: url.URL = getAsUri(target);
+        const filePath: string = asPathString(uri);
         const rawContent: Buffer = options && options.content ? Buffer.from(options.content) : await readFileAsBuffer(filePath);
         const contentType = getContentTypeData(null, filePath, null, rawContent);
         let content = '';
@@ -295,7 +295,7 @@ export default class LocalConnector implements IConnector {
                 hops: [],
                 mediaType: contentType.mediaType,
                 statusCode: 200,
-                url: filePath
+                url: url.format(uri)
             }
         };
     }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Moves path determination into `fetchContent` instead of
`fetchData`. This fixes `hint-no-bom` by ensuring `file:` urls can be
handled here.

Also ensures `response.url` in the `fetch::end::*` event includes
`file:`. This fixes `hint-highest-available-document-mode` where
`isLocalFile` was incorrectly returning `false`.
