### PR TITLE
Chore: Enable auto-merge greenkeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ env:
     # TRAVIS_API_TOKEN
     - secure: "IaW1CfeF12i16seRoO3tPQXw0IrF3ve/umcRpwCkmVgaxM0z/q5mJ+VCV25R67idqaGiSfVkdR5qb1q3q8eVKcMBhg/o6s4/7j3GGdm/5ixU5r8TOOfNUadsX2/e/pt4s5YE6+9NgSWshkwk81j9VBmmfQ1ClE0N0xS9uvjzn4YsZ7YSacrM02lEd5riPkVe0slxN0j0eGm50aum75MsPShM1WTGq9WdJyxd/Xpaia+2eBuiRCHu822dASLnoeVL6kyBmE4x86Ss17eR2VseaOS3XKRmFkdIDiPVO85B2EBaeqiyr4fHOqXTQm/WmWGCMSuzpQMRdksSNOCVrN/csmgajnhdye9f2kUdxTduu17TBcYzvkkoP2MRLglINcSCDHspDbI5177oIIBlE6nB9iawUWIIaiRATAmCBpllIGSA/zmvuztQM8YedjHA9E9o0yBXgyaFCHqz9N5fiZldKLU7do2OblPhwQoKzbUhs7+egpuVTnYp76NiqqipRV8gyCDjXCNWtXR/yba3UT5/3PIozL29mxxM41WIuhVhSXgVKhOzDSTYO5z8kB4S8L5dhVY9gLgXi0qnFU4d+Gsiy69lbZ9zXeK0occjMi/b0rkSOwovGmAZU2ArwUh7XRPbFZuCwxwaF/HBqaInsodRveuuOw7RbZh978kQKDf5J9g="
 
+    # GH_USER_NAME & GH_USER_EMAIL
+    - secure: "Woi9tmhZmvZ3vabbqeOZj/Pn56fcMMD3kbPd/Imu9cI75OWcasisUIMmQDGL4rPoKsnwQTOTewI83zybXNKRGEpmfZpvwuvl0CbL6Dk8jpPFY8RMGe5xkKTHCvZZCVdNvRRP6ylpn4WdUJkixCHtdYcFcKMaVufbur5fGTdNiu8FUEi5zzJFvy1D8DCV8qI5JAyKWiokRACtPaQ3C5Fj0oQGt+x5rbTLaesu+iTr3+2IwEruzlU+TbJQaMJAWGSb94LSqKVRX5v2buODI2zaY5Q9CaY5doSHT+k33xe+BsZW6J1A4WXoAWXxk5wklg6pQj9Zfq3HOSOr9QI08KC2/7joaXVKrHSo8ITKbpRl/AFCGxTfvfZM7b3AlfmikcWh2PfvvXktwbb2X5Gx5zmGGoIbt3v5IAsXNepRPz3tGsCaNz9x7WWiRpRznW9t1m342Q8gIiz6TfiXd/cWEsTck0kIXtuG2se9V5RLrmD2Ry10+Av1U88vvtfBXlPbA1fnnHbcjrtCcpC4qk1FzhclH/CR+qhhASUmW8D7jWJkpKVQZu6u2GG/HQj4WDUlq7R1zIpKlbSTd+MBDo+6nXle7Y2gqCfP63ij5l1PnRCLp0Q+scBMDz6RNsyq+2tV+I/0zLlrRzglGFkAp3yrrjfilwWm3u6mKf7iQPTTdRIGxs0="
+
     # Other
     - PACKAGE_BATCH_SIZE=2
 
@@ -110,6 +113,21 @@ jobs:
 
       script: ./.travis/trigger-site-update.sh
 
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    # Stage used for automatically merging Greenkeeper's commits
+    # that pass the tests.
+    #
+    # [!] Runs: Only for branches created by Greenkeeper.
+
+    - stage: greenkeeper-merge
+      if: type = push and branch =~ ^greenkeeper\/.*-.*$
+
+      node_js: lts/*
+      os: linux
+
+      script:
+      - ./.travis/set-up-ssh.sh && node ./.travis/greenkeeper-merge.js
 
 language: node_js
 

--- a/.travis/greenkeeper-merge.js
+++ b/.travis/greenkeeper-merge.js
@@ -1,0 +1,63 @@
+/*
+ * This script automatically merges the Greenkeeper's commit.
+ */
+
+const { exec, getLastCommitAuthorEmail, getLastCommitAuthorName, getLastCommitSubject, getLastCommitsWithSameMessage } = require('../scripts/utils');
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+const generateNewCommitMessage = (originalCommitMessage) => {
+    const regex = /.*update\s(.*)\sto version\s([\w.-]+)/gi;
+    const result = regex.exec(originalCommitMessage);
+
+    if (result) {
+        return `Chore: \\\`${result[1]}\\\` to \\\`v${result[2]}\\\``;
+    }
+
+    return null;
+};
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+const main = async () => {
+    const GIT_COMMIT_SUBJECT = await getLastCommitSubject();
+    const COMMITS_TO_SQUASH = await getLastCommitsWithSameMessage();
+    const NEW_COMMIT_MESSAGE = generateNewCommitMessage(GIT_COMMIT_SUBJECT);
+
+
+    const GIT_GREENKEEPER_BRANCH = process.env.TRAVIS_BRANCH; // eslint-disable-line no-process-env
+    const GIT_REPO_SLUG = process.env.TRAVIS_REPO_SLUG; // eslint-disable-line no-process-env
+    const GIT_USER_EMAIL = await getLastCommitAuthorEmail();
+    const GIT_USER_NAME = await getLastCommitAuthorName();
+
+    /*
+     * Ensure that things work as expected for shallow clones.
+     * (This is usually the case with CIs such as Travis)
+     */
+    await exec('Set remote', `git remote set-branches origin ${GIT_GREENKEEPER_BRANCH}`);
+
+    // Update local data.
+    await exec('Fetch remote', `git fetch`)
+
+    await exec('Configure the Git user name and email.',
+                `git config --global user.name "${GIT_USER_NAME}"
+                 git config --global user.email "${GIT_USER_EMAIL}"`);
+    // `install` step in travis does a yarn. If versions are different, yarn.lock is different so discard changes.
+    await exec('Discard yarn.lock', `git checkout yarn.lock`);
+
+    // greenkeeper updates each package in the monorepo with the same dependency in different commits: squash and update message
+    await exec('Commit changes and squash.', `git reset --soft HEAD~${COMMITS_TO_SQUASH} && git commit --message="${NEW_COMMIT_MESSAGE}"`);
+
+    await exec(`Update 'origin' remote.`, `git remote remove origin && git remote add origin git@github.com:${GIT_REPO_SLUG}.git`);
+    await exec('Fetch content from origin', 'git fetch origin');
+    await exec(`Switch to the 'master' branch.`, 'git checkout master');
+
+    const changes = await exec('List changed files', 'git status');
+    console.log(changes);
+
+    await exec(`Rebase '${GIT_GREENKEEPER_BRANCH}' branch into 'master'`, `git rebase ${GIT_GREENKEEPER_BRANCH}`);
+    await exec(`Push changes to 'master'.`, `git push git@github.com:${GIT_REPO_SLUG}.git master`);
+    await exec(`Delete '${GIT_GREENKEEPER_BRANCH}' branch.`, `git push git@github.com:${GIT_REPO_SLUG}.git :${GIT_GREENKEEPER_BRANCH}`);
+};
+
+main();

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,90 @@
+const shell = require('shelljs');
+const chalk = require('chalk');
+
+shell.config.silent = true;
+
+const shellExec = (cmd) => {
+    return new Promise((resolve, reject) => {
+        shell.exec(cmd, (code, stdout, stderr) => {
+            if (code === 0) {
+                return resolve({ code, stderr, stdout });
+            }
+
+            return reject({ code, stderr, stdout });
+        });
+    });
+};
+
+const exec = async (msg, cmd) => { // eslint-disable-line consistent-return
+
+    if (typeof cmd === 'function') {
+        try {
+            const result = await cmd();
+
+            console.log(chalk.green(`${msg}`));
+
+            return result && result.trim && result.trim();
+        } catch (e) {
+            console.error(chalk.red(`${msg}`));
+            console.error(e);
+
+            process.exit(1); // eslint-disable-line no-process-exit
+        }
+
+        return '';
+    }
+
+    try {
+        const { stdout } = await shellExec(cmd);
+
+        console.log(chalk.green(`${msg}`));
+        console.log(chalk.green(`   ${cmd}`));
+
+        return stdout.trim();
+    } catch ({ stderr }) {
+        console.error(chalk.red(`${msg}`));
+        console.log(chalk.green(`   ${cmd}`));
+        console.error(stderr);
+
+        process.exit(1); // eslint-disable-line no-process-exit
+    }
+};
+
+const getLastCommitsWithSameMessage = async () => {
+    const output = await exec('Get last number of commits with the same message', `git log --pretty=format:'%s' --max-count=70`);
+    const messages = output.trim().split('\n');
+    let same = true;
+    let commits = 0;
+
+    while (same && commits < messages.length) {
+        commits++;
+        same = messages[commits - 1] === messages[commits];
+    }
+
+    return commits;
+};
+
+const getLastCommitInfo = async (message, format) => {
+    // See: https://git-scm.com/docs/pretty-formats#_pretty_formats.
+    return await exec(message, `git show --no-patch --format=%${format} -1`);
+};
+
+const getLastCommitAuthorEmail = async () => {
+    return await getLastCommitInfo('Get author email for the last commit.', 'ae');
+};
+
+const getLastCommitAuthorName = async () => {
+    return await getLastCommitInfo('Get author name for the last commit.', 'an');
+};
+
+const getLastCommitSubject = async () => {
+    return await getLastCommitInfo('Get subject for the last commit.', 's');
+};
+
+module.exports = {
+    exec,
+    getLastCommitAuthorEmail,
+    getLastCommitAuthorName,
+    getLastCommitSubject,
+    getLastCommitsWithSameMessage
+};


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

The script `greenkeeper-merge.js` is executed as a job when all the
tests passed. `greenkeeper` does a commit per each package in the
monorepo that shares the same dependency. This scripts:

* Squashes all of those commits (takes all the commits from the end
  with the same message until one is different).
* Rebases the changes into master and pushes.

**NOTE**: The `install` step of `travis.yml` performs a `yarn`. If the
version is different, the generated `yarn.lock` file will be too. This
script discards any changes in the `yarn.lock` that originate in that
step (`greenkeeper` takes care of updating it).

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #938