### PR TITLE
Fix: Validate only if resource is HTTP(s)

### DIFF
--- a/packages/hint-strict-transport-security/src/hint.ts
+++ b/packages/hint-strict-transport-security/src/hint.ts
@@ -9,7 +9,7 @@ import { HintContext } from 'hint/dist/src/lib/hint-context';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 import { IAsyncHTMLElement, Response, FetchEnd, IHint, NetworkData, HintMetadata } from 'hint/dist/src/lib/types';
 import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
-import isDataURI from 'hint/dist/src/lib/utils/network/is-data-uri';
+import isRegularProtocol from 'hint/dist/src/lib/utils/network/is-regular-protocol';
 
 const debug = d(__filename);
 
@@ -162,8 +162,8 @@ export default class StrictTransportSecurityHint implements IHint {
         const validate = async (fetchEnd: FetchEnd) => {
             const { element, resource, response }: { element: IAsyncHTMLElement, resource: string, response: Response } = fetchEnd;
 
-            if (isDataURI(resource)) {
-                debug(`Check does not apply for data URIs`);
+            if (!isRegularProtocol(resource)) {
+                debug(`Check does not apply for non HTTP(s) URIs`);
 
                 return;
             }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

When using a debugging protocol connector in some websites we were trying to analyze `blob:` URIs.
This PR makes sure we only validate HTTP(s)
 
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
