### PR TITLE
Fix: Disable hints that are currently noisy when run locally

### DIFF
--- a/packages/configuration-development/index.json
+++ b/packages/configuration-development/index.json
@@ -8,6 +8,7 @@
         "summary"
     ],
     "hints": {
+        "apple-touch-icons": "off",
         "axe": "error",
         "babel-config/is-valid": "error",
         "disown-opener": "error",
@@ -25,7 +26,7 @@
         "typescript-config/target": "error",
         "webpack-config/is-installed": "error",
         "webpack-config/is-valid": "error",
-        "webpack-config/module-esnext-typescript": "error",
+        "webpack-config/module-esnext-typescript": "off",
         "webpack-config/modules/false-babel": "error",
         "webpack-config/no-devtool-in-prod": "error"
     },


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] ~~Added/Updated related documentation.~~
- [ ] ~~Added/Updated related tests.~~

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Disabling `hint-apple-touch-icons` because it is not aware of if
the project is a PWA or not (needs to check for a manifest).

Disabling `webpack-config/module-esnext-typescript` because it
requires loading both the webpack and typescript configs at the
same time to work (which doesn't currently happen in vscode).

These can be re-enabled once the affected hints are updated.