### PR TITLE
Fix: Scope tslib check to only run if `.tsconfig` exists

### DIFF
--- a/packages/hint-typescript-config/src/import-helpers.ts
+++ b/packages/hint-typescript-config/src/import-helpers.ts
@@ -54,6 +54,6 @@ export default class TypeScriptConfigImportHelpers implements IHint {
         };
 
         context.on('parse::typescript-config::end', validate);
-        context.on('scan::end', validateTslibInstalled);
+        context.on('parse::typescript-config::end', validateTslibInstalled);
     }
 }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] ~Added/Updated related documentation.~
- [ ] ~Added/Updated related tests.~

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Prevents this hint from raising an error when not using TypeScript.