### PR TITLE
Fix: Use `abab` to convert base64 to text

### DIFF
--- a/packages/utils-debugging-protocol-common/package.json
+++ b/packages/utils-debugging-protocol-common/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@hint/utils-connector-tools": "^1.0.5",
+    "abab": "^2.0.0",
     "chrome-remote-interface": "^0.26.1",
     "lodash": "^4.17.11"
   },

--- a/packages/utils-debugging-protocol-common/src/debugging-protocol-connector.ts
+++ b/packages/utils-debugging-protocol-common/src/debugging-protocol-connector.ts
@@ -18,6 +18,7 @@ import { promisify } from 'util';
 import * as cdp from 'chrome-remote-interface';
 import { Crdp } from 'chrome-remote-debug-protocol';
 import { compact, filter } from 'lodash';
+import { atob } from 'abab';
 
 import { CDPAsyncHTMLDocument, AsyncHTMLElement } from './cdp-async-html';
 import { getContentTypeData, getType } from 'hint/dist/src/lib/utils/content-type';


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

Use the package `abab` because `atob` is not part of node.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
