### PR TITLE
Fix: Remove unnecessary flags for chrome launcher

### DIFF
--- a/packages/connector-chrome/src/chrome-launcher.ts
+++ b/packages/connector-chrome/src/chrome-launcher.ts
@@ -133,7 +133,7 @@ export class CDPLauncher extends Launcher {
             if (isCI) {
                 this.chromeFlags.push('--headless', '--disable-gpu');
             } else if (process.env.DOCKER === 'true') { // eslint-disable-line no-process-env
-                this.chromeFlags.push('--headless', '--disable-gpu', '--no-sandbox');
+                this.chromeFlags.push('--headless');
             }
 
             const chrome: chromeLauncher.LaunchedChrome = await chromeLauncher.launch({


### PR DESCRIPTION
After some changes in the Docker container we don't need most of the flags to run chrome.
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
