### PR TITLE
Fix: Stop listening to network request after `waitFor`

### DIFF
--- a/packages/connector-chrome/src/chrome-launcher.ts
+++ b/packages/connector-chrome/src/chrome-launcher.ts
@@ -25,14 +25,16 @@ export class CDPLauncher extends Launcher {
     private userDataDir: string | boolean;
     private chromeFlags: Array<string>;
 
-    public constructor(options: LauncherOptions) {
+    public constructor(options?: LauncherOptions) {
         super(options);
 
         this.chromeFlags = options && options.flags || ['--no-default-browser-check'];
         // `userDataDir` is a property in `chrome-launcher`: https://github.com/GoogleChrome/chrome-launcher#launch-options
         /* istanbul ignore next */
-        this.userDataDir = typeof options.defaultProfile === 'boolean' && options.defaultProfile ? false : '';
-        this.port = options.port;
+        this.userDataDir = options && typeof options.defaultProfile === 'boolean' && options.defaultProfile ?
+            false :
+            '';
+        this.port = options && options.port;
     }
 
     /** If a browser is already running, it returns its pid. Otherwise return value is -1.  */

--- a/packages/hint/docs/user-guide/concepts/connectors.md
+++ b/packages/hint/docs/user-guide/concepts/connectors.md
@@ -59,10 +59,9 @@ with the values you want to modify:
 The following is the list of shared configurations for all `connector`s:
 
 * `waitFor` time in milliseconds the connector will wait after the site is
-  ready before starting the DOM traversing. The default value is `1000`
-  milliseconds.
-
-The default value is `1000`.
+  ready before starting the DOM traversing and stop listening to any
+  network request. By default, it will wait until the network is somehow
+  "quiet" even though more requests could be processed after DOM traversing.
 
 Depending on the `connector`, other configurations may be available.
 

--- a/packages/utils-debugging-protocol-common/src/debugging-protocol-connector.ts
+++ b/packages/utils-debugging-protocol-common/src/debugging-protocol-connector.ts
@@ -91,8 +91,7 @@ export class Connector implements IConnector {
              * and onRequestWillBeSent events from the default url opened when you create a new tab in Edge.
              */
             tabUrl: 'https://empty.webhint.io/',
-            useTabUrl: false,
-            waitFor: 1000
+            useTabUrl: false
         };
 
         this._server = engine;
@@ -761,7 +760,13 @@ export class Connector implements IConnector {
                 // Sometimes we receive the `onLoadEvent` before the response of the target. See: https://github.com/webhintio/hint/issues/1158
                 await this._waitForTarget;
 
-                await delay(this._options.waitFor);
+                if (this._options.waitFor) {
+                    await delay(this._options.waitFor);
+
+                    // Stop receiving network related events. Useful for pages that do not stop sending telemetry.
+                    this._client.Network.disable();
+                }
+
                 const { DOM } = this._client;
                 const event: Event = { resource: this._finalHref };
 
@@ -769,8 +774,6 @@ export class Connector implements IConnector {
                 await this._dom.load();
 
                 await this.processPendingResponses();
-
-
                 /*
                  * If the target is not an HTML we don't need to
                  * traverse it.


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- ~~Added/Updated related tests.~~

## Short description of the change(s)

The debugging protocol still received network requests after (or
during) processing the DOM. This was more obvious in large sites
with analytics and ads.

With this change the connector stops listening to any `Network`
events after waiting for the specified `waitFor` value.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
