### PR TITLE
Fix/cdp favicon

### DIFF
--- a/packages/utils-debugging-protocol-common/src/cdp-async-html.ts
+++ b/packages/utils-debugging-protocol-common/src/cdp-async-html.ts
@@ -17,7 +17,7 @@ export class CDPAsyncHTMLDocument implements IAsyncHTMLDocument {
     /** outerHTML of the page. */
     private _outerHTML: string;
 
-    public constructor(DOM) {
+    public constructor(DOM: Crdp.DOMClient) {
         this._DOM = DOM;
     }
 
@@ -56,6 +56,8 @@ export class CDPAsyncHTMLDocument implements IAsyncHTMLDocument {
         try {
             nodeIds = (await this._DOM.querySelectorAll({ nodeId: this._dom.nodeId, selector })).nodeIds;
         } catch (e) {
+            debug(e);
+
             return [];
         }
 
@@ -120,6 +122,14 @@ export class CDPAsyncHTMLDocument implements IAsyncHTMLDocument {
         return this._dom;
     }
 }
+
+export const createCDPAsyncHTMLDocument = async (DOM: Crdp.DOMClient) => {
+    const dom = new CDPAsyncHTMLDocument(DOM);
+
+    await dom.load();
+
+    return dom;
+};
 
 /** An implementation of AsyncHTMLElement on top of the Chrome Debugging Protocol */
 export class AsyncHTMLElement implements IAsyncHTMLElement {

--- a/packages/utils-debugging-protocol-common/src/debugging-protocol-connector.ts
+++ b/packages/utils-debugging-protocol-common/src/debugging-protocol-connector.ts
@@ -19,7 +19,7 @@ import { compact, filter } from 'lodash';
 import { atob } from 'abab';
 import { Crdp } from 'chrome-remote-debug-protocol';
 
-import { CDPAsyncHTMLDocument, AsyncHTMLElement } from './cdp-async-html';
+import { createCDPAsyncHTMLDocument, CDPAsyncHTMLDocument, AsyncHTMLElement } from './cdp-async-html';
 import { getContentTypeData, getType } from 'hint/dist/src/lib/utils/content-type';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 import * as logger from 'hint/dist/src/lib/utils/logging';
@@ -770,8 +770,7 @@ export class Connector implements IConnector {
                 const { DOM } = this._client;
                 const event: Event = { resource: this._finalHref };
 
-                this._dom = new CDPAsyncHTMLDocument(DOM);
-                await this._dom.load();
+                this._dom = await createCDPAsyncHTMLDocument(DOM);
 
                 await this.processPendingResponses();
                 /*

--- a/packages/utils-debugging-protocol-common/src/debugging-protocol-connector.ts
+++ b/packages/utils-debugging-protocol-common/src/debugging-protocol-connector.ts
@@ -504,6 +504,21 @@ export class Connector implements IConnector {
 
         eventName = `${eventName}::${getType(response.mediaType)}`;
 
+        /*
+         * If there is no `waitFor` property we could be downloading the favicon twice:
+         *
+         * 1. Browser automatically at the end of all the network requests
+         * 2. The connector via `getFavicon`
+         *
+         * `getFavicon` will change `_faviconLoaded` to true as soon as it is called
+         * so if the browser does this request on its own we can ignore it.
+         */
+        if (hasAttributeWithValue(data.element, 'link', 'rel', 'icon') && this._faviconLoaded) {
+            this._requests.delete(params.requestId);
+
+            return;
+        }
+
         if (hasAttributeWithValue(data.element, 'link', 'rel', 'icon')) {
             this._faviconLoaded = true;
         }
@@ -789,6 +804,8 @@ export class Connector implements IConnector {
                 await this._server.emitAsync('can-evaluate::script', event);
 
                 if (!this._faviconLoaded) {
+                    this._faviconLoaded = true;
+
                     const faviconElement = (await this._dom.querySelectorAll('link[rel~="icon"]'))[0];
 
                     await this.getFavicon(faviconElement);


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

This fixes an scenario where we could receive a network event while we were calling `dom.load()` and thus never find the associated element that originated the request.

Also fixes an scenario where we could get the favicon events multiple times (once requested by the connector and another by the browser).

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
