### PR TITLE
Fix: Avoid exception if resource is not compressed

### DIFF
--- a/packages/hint-performance-budget/package.json
+++ b/packages/hint-performance-budget/package.json
@@ -9,6 +9,7 @@
   "description": "hint that that checks if a page passes a set performance budget",
   "devDependencies": {
     "@hint/utils-tests-helpers": "^1.0.1",
+    "@types/debug": "^0.0.31",
     "ava": "^0.25.0",
     "cpx": "^1.5.0",
     "eslint": "^5.6.1",

--- a/packages/hint-performance-budget/tests/tests-http.ts
+++ b/packages/hint-performance-budget/tests/tests-http.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { gzipSync } from 'zlib';
 
 import generateHTMLPage from 'hint/dist/src/lib/utils/misc/generate-html-page';
 import { getHintPath } from 'hint/dist/src/lib/utils/hint-helpers';
@@ -39,7 +40,16 @@ const generateServerConfig = (imageCount: number, redirects = false) => {
         }
     }
 
-    serverConfig['/'] = generateHTMLPage('', generateBody(imageCount));
+    const html = generateHTMLPage('', generateBody(imageCount));
+    const compressed = gzipSync(Buffer.from(html, 'utf-8'));
+
+    serverConfig['/'] = {
+        content: compressed,
+        headers: {
+            'content-encoding': 'gzip',
+            'content-type': 'text/html'
+        }
+    };
 
     return serverConfig;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,6 +278,11 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.30.tgz#dc1e40f7af3b9c815013a7860e6252f6352a84df"
   integrity sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==
 
+"@types/debug@^0.0.31":
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.31.tgz#bac8d8aab6a823e91deb7f79083b2a35fa638f33"
+  integrity sha512-LS1MCPaQKqspg7FvexuhmDbWUhE2yIJ+4AgVIyObfc06/UKZ8REgxGNjZc82wPLWmbeOm7S+gSsLgo75TanG4A==
+
 "@types/ejs@^2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@types/ejs/-/ejs-2.6.0.tgz#56502bca6e2e1b4cf9351918ca76cdaa93fe3b6c"


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- [x] Added/Updated related tests.

## Short description of the change(s)

Check if the resource has the `content-enconding` header with a
value that can be processed. If not, use the resource's size
already available instead of trying to get the `rawResponse`.

This avoids going through the `exception` path in resources such
as images and thus improving the speed of the rule.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
