### PR TITLE
Fix: Redirects doesn't return the right hops on circular redirects

### DIFF
--- a/packages/utils-connector-tools/src/redirects.ts
+++ b/packages/utils-connector-tools/src/redirects.ts
@@ -37,11 +37,27 @@ export class RedirectManager {
         while (this._redirects.has(targetUrl)) {
             targetUrl = this._redirects.get(targetUrl)!; // The `has` check above means this exists.
 
-            if (hops.includes(targetUrl)) {
-                break;
-            }
+            /*
+             * In some edgy cases the redirect ends in the
+             * same url that it starts.
+             *
+             * http://url1 => http://url2
+             * http://url2 => http://url3
+             * http://url3 => http://url1
+             *
+             * In these cases, the hop returned should contain
+             * the first url too:
+             *
+             * ['http://url1', 'http://url2', 'http://url3']
+             */
+
+            const finish = hops.includes(targetUrl);
 
             hops.unshift(targetUrl);
+
+            if (finish) {
+                break;
+            }
         }
         hops.pop();
 

--- a/packages/utils-connector-tools/tests/redirects.ts
+++ b/packages/utils-connector-tools/tests/redirects.ts
@@ -49,4 +49,22 @@ test(`redirectManager returns the expected number of hops for a single redirect`
     ]);
 });
 
+test(`redirectManager returns the expected number of hops for a circular redirect`, (t) => {
+    const redirects = t.context.redirects;
+
+    redirects.add('http://hop2.com', 'http://hop1.com');
+    redirects.add('http://hop3.com', 'http://hop2.com');
+    redirects.add('http://hop4.com', 'http://hop3.com');
+    redirects.add('http://hop1.com', 'http://hop4.com');
+
+    const hops = redirects.calculate('http://hop1.com');
+
+    t.deepEqual(hops, [
+        'http://hop1.com',
+        'http://hop2.com',
+        'http://hop3.com',
+        'http://hop4.com'
+    ]);
+});
+
 // TODO: test(`redirectManager supports multiple redirects for the same target`, (t)=>{});


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
