### PR TITLE
Fix: Get `outerHTML` just if debug is enabled.

### DIFF
--- a/packages/hint-no-protocol-relative-urls/src/hint.ts
+++ b/packages/hint-no-protocol-relative-urls/src/hint.ts
@@ -39,9 +39,12 @@ export default class NoProtocolRelativeUrlsHint implements IHint {
 
         const validate = async (data: ElementFound) => {
             const { element, resource }: { element: IAsyncHTMLElement, resource: string } = data;
-            const html: string = await element.outerHTML();
 
-            debug(`Analyzing link\n${cutString(html, 50)}`);
+            if (debug.enabled) {
+                const html: string = await element.outerHTML();
+
+                debug(`Analyzing link\n${cutString(html, 50)}`);
+            }
 
             /*
              * We need to use getAttribute to get the exact value.


### PR DESCRIPTION
Fix #1408

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
