### PR TITLE
Build: Remove `-b` flag from `build-release` npm script

### DIFF
--- a/packages/connector-edge/package.json
+++ b/packages/connector-edge/package.json
@@ -46,7 +46,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/connector-jsdom/package.json
+++ b/packages/connector-jsdom/package.json
@@ -66,7 +66,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/connector-local/package.json
+++ b/packages/connector-local/package.json
@@ -55,7 +55,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/create-hint/src/shared-templates/package.hbs
+++ b/packages/create-hint/src/shared-templates/package.hbs
@@ -68,7 +68,7 @@
   "repository": "",{{/if}}
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/extension-vscode/package.json
+++ b/packages/extension-vscode/package.json
@@ -59,7 +59,7 @@
   },
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/formatter-codeframe/package.json
+++ b/packages/formatter-codeframe/package.json
@@ -62,7 +62,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/formatter-excel/package.json
+++ b/packages/formatter-excel/package.json
@@ -61,7 +61,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/formatter-html/package.json
+++ b/packages/formatter-html/package.json
@@ -66,7 +66,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/formatter-json/package.json
+++ b/packages/formatter-json/package.json
@@ -58,7 +58,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/formatter-stylish/package.json
+++ b/packages/formatter-stylish/package.json
@@ -63,7 +63,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/formatter-summary/package.json
+++ b/packages/formatter-summary/package.json
@@ -62,7 +62,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-amp-validator/package.json
+++ b/packages/hint-amp-validator/package.json
@@ -53,7 +53,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-apple-touch-icons/package.json
+++ b/packages/hint-apple-touch-icons/package.json
@@ -54,7 +54,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-axe/package.json
+++ b/packages/hint-axe/package.json
@@ -53,7 +53,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-babel-config/package.json
+++ b/packages/hint-babel-config/package.json
@@ -52,7 +52,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-content-type/package.json
+++ b/packages/hint-content-type/package.json
@@ -54,7 +54,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-disown-opener/package.json
+++ b/packages/hint-disown-opener/package.json
@@ -50,7 +50,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-highest-available-document-mode/package.json
+++ b/packages/hint-highest-available-document-mode/package.json
@@ -50,7 +50,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-html-checker/package.json
+++ b/packages/hint-html-checker/package.json
@@ -54,7 +54,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-http-cache/package.json
+++ b/packages/hint-http-cache/package.json
@@ -50,7 +50,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-http-compression/package.json
+++ b/packages/hint-http-compression/package.json
@@ -54,7 +54,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-https-only/package.json
+++ b/packages/hint-https-only/package.json
@@ -49,7 +49,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-image-optimization-cloudinary/package.json
+++ b/packages/hint-image-optimization-cloudinary/package.json
@@ -55,7 +55,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-manifest-app-name/package.json
+++ b/packages/hint-manifest-app-name/package.json
@@ -55,7 +55,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-manifest-exists/package.json
+++ b/packages/hint-manifest-exists/package.json
@@ -52,7 +52,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-manifest-file-extension/package.json
+++ b/packages/hint-manifest-file-extension/package.json
@@ -52,7 +52,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-manifest-is-valid/package.json
+++ b/packages/hint-manifest-is-valid/package.json
@@ -57,7 +57,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-meta-charset-utf-8/package.json
+++ b/packages/hint-meta-charset-utf-8/package.json
@@ -54,7 +54,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-meta-theme-color/package.json
+++ b/packages/hint-meta-theme-color/package.json
@@ -53,7 +53,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-meta-viewport/package.json
+++ b/packages/hint-meta-viewport/package.json
@@ -53,7 +53,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-minified-js/package.json
+++ b/packages/hint-minified-js/package.json
@@ -51,7 +51,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-no-bom/package.json
+++ b/packages/hint-no-bom/package.json
@@ -49,7 +49,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-no-broken-links/package.json
+++ b/packages/hint-no-broken-links/package.json
@@ -52,7 +52,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-no-disallowed-headers/package.json
+++ b/packages/hint-no-disallowed-headers/package.json
@@ -50,7 +50,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-no-friendly-error-pages/package.json
+++ b/packages/hint-no-friendly-error-pages/package.json
@@ -50,7 +50,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-no-html-only-headers/package.json
+++ b/packages/hint-no-html-only-headers/package.json
@@ -50,7 +50,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-no-http-redirects/package.json
+++ b/packages/hint-no-http-redirects/package.json
@@ -50,7 +50,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-no-p3p/package.json
+++ b/packages/hint-no-p3p/package.json
@@ -49,7 +49,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-no-protocol-relative-urls/package.json
+++ b/packages/hint-no-protocol-relative-urls/package.json
@@ -50,7 +50,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-no-vulnerable-javascript-libraries/package.json
+++ b/packages/hint-no-vulnerable-javascript-libraries/package.json
@@ -65,7 +65,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-performance-budget/package.json
+++ b/packages/hint-performance-budget/package.json
@@ -51,7 +51,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-sri/package.json
+++ b/packages/hint-sri/package.json
@@ -51,7 +51,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-ssllabs/package.json
+++ b/packages/hint-ssllabs/package.json
@@ -53,7 +53,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-strict-transport-security/package.json
+++ b/packages/hint-strict-transport-security/package.json
@@ -51,7 +51,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-stylesheet-limits/package.json
+++ b/packages/hint-stylesheet-limits/package.json
@@ -49,7 +49,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-typescript-config/package.json
+++ b/packages/hint-typescript-config/package.json
@@ -52,7 +52,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-validate-set-cookie-header/package.json
+++ b/packages/hint-validate-set-cookie-header/package.json
@@ -50,7 +50,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-webpack-config/package.json
+++ b/packages/hint-webpack-config/package.json
@@ -55,7 +55,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint-x-content-type-options/package.json
+++ b/packages/hint-x-content-type-options/package.json
@@ -50,7 +50,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/hint/package.json
+++ b/packages/hint/package.json
@@ -115,7 +115,7 @@
   "scripts": {
     "ava": "ava",
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/parser-babel-config/package.json
+++ b/packages/parser-babel-config/package.json
@@ -57,7 +57,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/parser-css/package.json
+++ b/packages/parser-css/package.json
@@ -57,7 +57,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/parser-html/package.json
+++ b/packages/parser-html/package.json
@@ -58,7 +58,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/parser-javascript/package.json
+++ b/packages/parser-javascript/package.json
@@ -58,7 +58,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/parser-manifest/package.json
+++ b/packages/parser-manifest/package.json
@@ -58,7 +58,7 @@
     "build": "npm run clean && npm-run-all build:*",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "clean": "rimraf dist",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint . --cache --ext js --ext md --ext ts --ignore-path ../../.eslintignore --report-unused-disable-directives",

--- a/packages/parser-typescript-config/package.json
+++ b/packages/parser-typescript-config/package.json
@@ -59,7 +59,7 @@
     "build": "npm run clean && npm-run-all build:*",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "clean": "rimraf dist",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint . --cache --ext js --ext md --ext ts --ignore-path ../../.eslintignore --report-unused-disable-directives",

--- a/packages/parser-webpack-config/package.json
+++ b/packages/parser-webpack-config/package.json
@@ -56,7 +56,7 @@
     "build": "npm run clean && npm-run-all build:*",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "clean": "rimraf dist",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint . --cache --ext js --ext md --ext ts --ignore-path ../../.eslintignore --report-unused-disable-directives",

--- a/packages/utils-connector-tools/package.json
+++ b/packages/utils-connector-tools/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "ava": "ava",
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/utils-create-server/package.json
+++ b/packages/utils-create-server/package.json
@@ -45,7 +45,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/utils-debugging-protocol-common/package.json
+++ b/packages/utils-debugging-protocol-common/package.json
@@ -43,7 +43,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/utils-tests-helpers/package.json
+++ b/packages/utils-tests-helpers/package.json
@@ -42,7 +42,7 @@
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run clean && npm-run-all build:*",
-    "build-release": "npm run clean && npm run build:assets && tsc -b --inlineSourceMap false --removeComments true",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",


### PR DESCRIPTION
`-b` is unneeded (we are using `npm i`) for `build-release` and also using it generates:

```
error TS5072: Unknown build option '--inlineSourceMap'.
error TS5072: Unknown build option '--removeComments'.
```