### PR TITLE
Fix: TypeScript build when using npm

### DIFF
--- a/packages/create-hint/package.json
+++ b/packages/create-hint/package.json
@@ -11,6 +11,7 @@
   },
   "description": "webhint's hint initializer package",
   "devDependencies": {
+    "@types/node": "10.9.1",
     "ava": "^0.25.0",
     "cpx": "^1.5.0",
     "eslint": "^5.7.0",

--- a/packages/create-hint/src/create-hint.ts
+++ b/packages/create-hint/src/create-hint.ts
@@ -167,7 +167,7 @@ class HintPackage {
  * ------------------------------------------------------------------------------
  */
 
-const mkdirpAsync = promisify(mkdirp);
+const mkdirpAsync = promisify(mkdirp) as (dir: string) => Promise<void>;
 /** Name of the package to use as a template. */
 const TEMPLATE_PATH = './templates';
 const SHARED_TEMPLATE_PATH = './shared-templates';

--- a/packages/create-parser/package.json
+++ b/packages/create-parser/package.json
@@ -12,6 +12,7 @@
   "description": "webhint's parser initializer package",
   "devDependencies": {
     "@types/inquirer": "^0.0.43",
+    "@types/node": "10.9.1",
     "ava": "^0.25.0",
     "cpx": "^1.5.0",
     "eslint": "^5.7.0",

--- a/packages/create-parser/src/new-parser.ts
+++ b/packages/create-parser/src/new-parser.ts
@@ -141,7 +141,7 @@ class NewParser {
  * Constants and Private functions.
  * ------------------------------------------------------------------------------
  */
-const mkdirpAsync = promisify(mkdirp);
+const mkdirpAsync = promisify(mkdirp) as (dir: string) => Promise<void>;
 const eventList: Array<string> = Object.keys(events);
 const TEMPLATE_PATH: string = './templates';
 const SHARED_TEMPLATE_PATH = './shared-templates';


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~ Added/Updated related tests.~~

## Short description of the change(s)

There are 2 issues:

1. The `applicationInsights` package uses an old version that causes
   some trouble with the types they are using and thus failing the
   build.
   Explicitely adding `@types/node` fixes the issue with this package.
2. TypeScript doesn't understand correctly `promisify`d functions. This
   adds the right type to `mkdirpAsync`.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #1422

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
