### PR TITLE
Chore: Disable `composite` when building with webpack

### DIFF
--- a/packages/create-hint/tsconfig-webpack.json
+++ b/packages/create-hint/tsconfig-webpack.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "alwaysStrict": true,
+        "composite": false,
         "declaration": false,
         "inlineSourceMap": false,
         "removeComments": true,

--- a/packages/create-hintrc/tsconfig-webpack.json
+++ b/packages/create-hintrc/tsconfig-webpack.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "alwaysStrict": true,
+        "composite": false,
         "declaration": false,
         "inlineSourceMap": false,
         "removeComments": true,

--- a/packages/create-parser/tsconfig-webpack.json
+++ b/packages/create-parser/tsconfig-webpack.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "alwaysStrict": true,
+        "composite": false,
         "declaration": false,
         "inlineSourceMap": false,
         "removeComments": true,


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

Fix  #1428
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
