### PR TITLE
New: Upgrade to `jsdom` `v13`

### DIFF
--- a/packages/connector-jsdom/package.json
+++ b/packages/connector-jsdom/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "@hint/utils-connector-tools": "^1.0.8",
-    "canvas-prebuilt": "^1.6.11",
-    "jsdom": "^12.2.0",
+    "canvas": "^2.0.0",
+    "jsdom": "^13.0.0",
     "mutationobserver-shim": "^0.3.2",
     "node-pre-gyp": "^0.11.0",
     "whatwg-fetch": "^3.0.0"

--- a/packages/connector-jsdom/package.json
+++ b/packages/connector-jsdom/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@hint/utils-connector-tools": "^1.0.8",
-    "canvas": "^2.0.0",
     "jsdom": "^13.0.0",
     "mutationobserver-shim": "^0.3.2",
     "node-pre-gyp": "^0.11.0",
@@ -59,6 +58,9 @@
   "name": "@hint/connector-jsdom",
   "nyc": {
     "extends": "../../.nycrc"
+  },
+  "optionalDependencies": {
+    "canvas": "^2.0.1"
   },
   "peerDependencies": {
     "hint": "^3.4.14"

--- a/packages/parser-html/package.json
+++ b/packages/parser-html/package.json
@@ -7,7 +7,7 @@
     "timeout": "1m"
   },
   "dependencies": {
-    "jsdom": "^12.2.0"
+    "jsdom": "^13.0.0"
   },
   "description": "webhint parser needed to analyze HTML files",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2276,12 +2276,13 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000899:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000903.tgz#86d46227759279b3db345ddbe778335dbba9e858"
   integrity sha512-T1XVJEpGCoaq7MDw7/6hCdYUukmSaS+1l/OQJkLtw7Cr2+/+d67tNGKEbyiqf7Ck8x6EhNFUxjYFXXka0N/w5g==
 
-canvas-prebuilt@^1.6.11:
-  version "1.6.11"
-  resolved "https://registry.yarnpkg.com/canvas-prebuilt/-/canvas-prebuilt-1.6.11.tgz#9b37071aa0ddd4f7c2b4a9e279b63fb2dc30db9b"
-  integrity sha512-ayBAayYLgFbGBX+cwtOzM4iEQP4XB5DuBbtjgvAwQ66/FMzSR7DhlCqtDZIq9UBbpFCb1QpyDgUNVclHDdBixg==
+canvas@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.0.1.tgz#267649ac4c9876de992fb2361252304b599b3e93"
+  integrity sha512-aVESjDBMXGRL+aZqjFtxMVOg8KzHhNcKIscoeC8OROccmApKOriHsnySxq228Kc+3tzB9Qc6tzD4ukp9Zjwz1Q==
   dependencies:
-    node-pre-gyp "^0.10.0"
+    nan "^2.11.1"
+    node-pre-gyp "^0.11.0"
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -5760,10 +5761,10 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsdom@^12.2.0:
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-12.2.0.tgz#7cf3f5b5eafd47f8f09ca52315d367ff6e95de23"
-  integrity sha512-QPOggIJ8fquWPLaYYMoh+zqUmdphDtu1ju0QGTitZT1Yd8I5qenPpXM1etzUegu3MjVp8XPzgZxdn8Yj7e40ig==
+jsdom@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-13.0.0.tgz#f1df2411b714a4e08d1bdc343c0a0889c688210f"
+  integrity sha512-Kmq4ASMNkgpY+YufE322EnIKoiz0UWY2DRkKlU7d5YrIW4xiVRhWFrZV1fr6w/ZNxQ50wGAH5gGRzydgnmkkvw==
   dependencies:
     abab "^2.0.0"
     acorn "^6.0.2"
@@ -5784,6 +5785,7 @@ jsdom@^12.2.0:
     symbol-tree "^3.2.2"
     tough-cookie "^2.4.3"
     w3c-hr-time "^1.0.1"
+    w3c-xmlserializer "^1.0.0"
     webidl-conversions "^4.0.2"
     whatwg-encoding "^1.0.5"
     whatwg-mimetype "^2.2.0"
@@ -6833,7 +6835,7 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-nan@^2.9.2:
+nan@^2.11.1, nan@^2.9.2:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
   integrity sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==
@@ -10050,6 +10052,15 @@ w3c-hr-time@^1.0.1:
   integrity sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
   dependencies:
     browser-process-hrtime "^0.1.2"
+
+w3c-xmlserializer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-1.0.0.tgz#d23e20de595b892056f20a359fc2622908d48695"
+  integrity sha512-0et1+9uXYiIRAecx1D5Z1nk60+vimniGdIKl4XjeqkWi6acoHNlXMv1VR5jV+jF4ooeO08oWbYxeAJOcon1oMA==
+  dependencies:
+    domexception "^1.0.1"
+    webidl-conversions "^4.0.2"
+    xml-name-validator "^3.0.0"
 
 walkdir@^0.0.11:
   version "0.0.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2276,7 +2276,7 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000899:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000903.tgz#86d46227759279b3db345ddbe778335dbba9e858"
   integrity sha512-T1XVJEpGCoaq7MDw7/6hCdYUukmSaS+1l/OQJkLtw7Cr2+/+d67tNGKEbyiqf7Ck8x6EhNFUxjYFXXka0N/w5g==
 
-canvas@^2.0.0:
+canvas@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.0.1.tgz#267649ac4c9876de992fb2361252304b599b3e93"
   integrity sha512-aVESjDBMXGRL+aZqjFtxMVOg8KzHhNcKIscoeC8OROccmApKOriHsnySxq228Kc+3tzB9Qc6tzD4ukp9Zjwz1Q==


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

This version of `jsdom` adds support to `canvas` `v2.x`. One of the most
interesting things is that `canvas` downloads now automatically binaries
from `canvas-prebuilt` if they are available or fallbacks to building
and thus solving some of the issues when `canvas-prebuilt` is not
available in the user's platform.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref: #1445

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
