### PR TITLE
Build: Allow node v11 builds to fail for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,19 @@ install:
       fi
 
 jobs:
+
+  # Allow node v11 builds to fail for now as `canvas-prebuilt`
+  # will be missing.
+  #
+  # Ref: https://github.com/webhintio/hint/issues/1445
+
+  allow_failures:
+    - node_js: node
+
+  fast_finish: true
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
   include:
 
     # Stage used for checking for broken links.


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

Allow node v11 builds to fail for now as `canvas-prebuilt` will be missing.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref #1445
