### PR TITLE
New: Allow hint metadata to be imported separately

### DIFF
--- a/packages/hint-amp-validator/README.md
+++ b/packages/hint-amp-validator/README.md
@@ -1,4 +1,4 @@
-# AMP HTML Validator (`amp-validator`)
+# AMP HTML validator (`amp-validator`)
 
 > AMP HTML is a way to build web pages that render with reliable and
 fast performance. It is our attempt at fixing what many perceive as

--- a/packages/hint-amp-validator/src/hint.ts
+++ b/packages/hint-amp-validator/src/hint.ts
@@ -4,11 +4,11 @@
 
 import * as amphtmlValidator from 'amphtml-validator';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { IHint, HintMetadata, FetchEnd } from 'hint/dist/src/lib/types';
+import { IHint, FetchEnd } from 'hint/dist/src/lib/types';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -19,19 +19,7 @@ const debug: debug.IDebugger = d(__filename);
  */
 
 export default class AmpValidatorHint implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.performance,
-            description: `Require HTML page to be AMP valid.`
-        },
-        id: 'amp-validator',
-        schema: [{
-            additionalProperties: false,
-            properties: { 'errors-only': { type: 'boolean' } },
-            type: 'object'
-        }],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
         let validPromise: Promise<amphtmlValidator.Validator>;

--- a/packages/hint-amp-validator/src/meta.ts
+++ b/packages/hint-amp-validator/src/meta.ts
@@ -1,0 +1,20 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.performance,
+        description: `Require HTML page to be AMP valid.`,
+        name: 'AMP HTML validator'
+    },
+    id: 'amp-validator',
+    schema: [{
+        additionalProperties: false,
+        properties: { 'errors-only': { type: 'boolean' } },
+        type: 'object'
+    }],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-apple-touch-icons/README.md
+++ b/packages/hint-apple-touch-icons/README.md
@@ -1,4 +1,4 @@
-# Require an apple touch icon (`apple-touch-icons`)
+# Use Apple touch icon (`apple-touch-icons`)
 
 `apple-touch-icons` requires that a single `180×180px` PNG
 `apple-touch-icon` is used.

--- a/packages/hint-apple-touch-icons/src/hint.ts
+++ b/packages/hint-apple-touch-icons/src/hint.ts
@@ -6,13 +6,13 @@ import { URL } from 'url';
 
 import * as getImageData from 'image-size';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 import isRegularProtocol from 'hint/dist/src/lib/utils/network/is-regular-protocol';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
-import { IAsyncHTMLDocument, IAsyncHTMLElement, IHint, TraverseEnd, NetworkData, HintMetadata } from 'hint/dist/src/lib/types';
+import { IAsyncHTMLDocument, IAsyncHTMLElement, IHint, TraverseEnd, NetworkData } from 'hint/dist/src/lib/types';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -24,15 +24,7 @@ const debug: debug.IDebugger = d(__filename);
 
 export default class AppleTouchIconsHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.pwa,
-            description: `Require an 'apple-touch-icon'`
-        },
-        id: 'apple-touch-icons',
-        schema: [],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-apple-touch-icons/src/meta.ts
+++ b/packages/hint-apple-touch-icons/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.pwa,
+        description: `Require an 'apple-touch-icon'`,
+        name: 'Require an apple touch icon'
+    },
+    id: 'apple-touch-icons',
+    schema: [],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-apple-touch-icons/src/meta.ts
+++ b/packages/hint-apple-touch-icons/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.pwa,
         description: `Require an 'apple-touch-icon'`,
-        name: 'Require an apple touch icon'
+        name: 'Use Apple touch icon'
     },
     id: 'apple-touch-icons',
     schema: [],

--- a/packages/hint-axe/README.md
+++ b/packages/hint-axe/README.md
@@ -1,4 +1,4 @@
-# Accessibility assessment with aXe (`axe`)
+# aXe accessibility check (`axe`)
 
 `aXe` is the accessibility engine for automated testing of HTML-based
 user interfaces. This hint performs the default accessibility tests

--- a/packages/hint-axe/src/hint.ts
+++ b/packages/hint-axe/src/hint.ts
@@ -11,12 +11,12 @@
 
 import { AxeResults, Result as AxeResult, NodeResult as AxeNodeResult } from 'axe-core';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { IAsyncHTMLElement, IHint, Severity, CanEvaluateScript, HintMetadata } from 'hint/dist/src/lib/types';
+import { IAsyncHTMLElement, IHint, Severity, CanEvaluateScript } from 'hint/dist/src/lib/types';
 import readFileAsync from 'hint/dist/src/lib/utils/fs/read-file-async';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 const debug = d(__filename);
 
@@ -28,46 +28,7 @@ const debug = d(__filename);
 
 export default class AxeHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.accessibility,
-            description: 'Runs axe-core tests in the target'
-        },
-        id: 'axe',
-        schema: [{
-            additionalProperties: false,
-            properties: {
-                rules: {
-                    patternProperties: {
-                        '^.+$': {
-                            additionalProperties: false,
-                            properties: { enabled: { type: 'boolean' } },
-                            required: ['enabled'],
-                            type: 'object'
-                        }
-                    },
-                    type: 'object'
-                },
-                runOnly: {
-                    additionalProperties: false,
-                    properties: {
-                        type: { type: 'string' },
-                        values: {
-                            items: { type: 'string' },
-                            minItems: 1,
-                            type: 'array',
-                            uniqueItems: true
-                        }
-                    },
-                    type: 'object'
-                }
-            }
-        }],
-        /*
-         * axe can not analize a file itself, it needs a connector.
-         */
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-axe/src/meta.ts
+++ b/packages/hint-axe/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.accessibility,
         description: 'Runs axe-core tests in the target',
-        name: 'Accessibility assessment with aXe'
+        name: 'aXe accessibility check'
     },
     id: 'axe',
     schema: [{

--- a/packages/hint-axe/src/meta.ts
+++ b/packages/hint-axe/src/meta.ts
@@ -1,0 +1,47 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.accessibility,
+        description: 'Runs axe-core tests in the target',
+        name: 'Accessibility assessment with aXe'
+    },
+    id: 'axe',
+    schema: [{
+        additionalProperties: false,
+        properties: {
+            rules: {
+                patternProperties: {
+                    '^.+$': {
+                        additionalProperties: false,
+                        properties: { enabled: { type: 'boolean' } },
+                        required: ['enabled'],
+                        type: 'object'
+                    }
+                },
+                type: 'object'
+            },
+            runOnly: {
+                additionalProperties: false,
+                properties: {
+                    type: { type: 'string' },
+                    values: {
+                        items: { type: 'string' },
+                        minItems: 1,
+                        type: 'array',
+                        uniqueItems: true
+                    }
+                },
+                type: 'object'
+            }
+        }
+    }],
+    /*
+     * axe can not analize a file itself, it needs a connector.
+     */
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-babel-config/docs/is-valid.md
+++ b/packages/hint-babel-config/docs/is-valid.md
@@ -1,4 +1,4 @@
-# Babel configuration is valid (`is-valid`)
+# Valid Babel configuration (`is-valid`)
 
 ## Why is this important?
 

--- a/packages/hint-babel-config/src/is-valid.ts
+++ b/packages/hint-babel-config/src/is-valid.ts
@@ -1,13 +1,13 @@
 /**
  * @fileoverview `babel-config/is-valid` warns against providing an invalid babel configuration file.
  */
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint } from 'hint/dist/src/lib/types';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 
 import { BabelConfigEvents, BabelConfigInvalidJSON, BabelConfigInvalidSchema } from '@hint/parser-babel-config';
+
+import meta from './meta/is-valid';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -17,15 +17,7 @@ const debug: debug.IDebugger = d(__filename);
  * ------------------------------------------------------------------------------
  */
 export default class BabelConfigIsValidHint implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.development,
-            description: `'babel-config/is-valid' warns against providing an invalid babel configuration file \`.babelrc\``
-        },
-        id: 'babel-config/is-valid',
-        schema: [],
-        scope: HintScope.local
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<BabelConfigEvents>) {
         const invalidJSONFile = async (babelConfigInvalid: BabelConfigInvalidJSON, event: string) => {

--- a/packages/hint-babel-config/src/meta.ts
+++ b/packages/hint-babel-config/src/meta.ts
@@ -1,0 +1,5 @@
+/**
+ * @fileoverview Verify that the babel config is valid.
+ */
+
+module.exports = { 'is-valid': require('./meta/is-valid') };

--- a/packages/hint-babel-config/src/meta/is-valid.ts
+++ b/packages/hint-babel-config/src/meta/is-valid.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.development,
+        description: `'babel-config/is-valid' warns against providing an invalid babel configuration file \`.babelrc\``,
+        name: 'Babel configuration is valid'
+    },
+    id: 'babel-config/is-valid',
+    schema: [],
+    scope: HintScope.local
+};
+
+export default meta;

--- a/packages/hint-babel-config/src/meta/is-valid.ts
+++ b/packages/hint-babel-config/src/meta/is-valid.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.development,
         description: `'babel-config/is-valid' warns against providing an invalid babel configuration file \`.babelrc\``,
-        name: 'Babel configuration is valid'
+        name: 'Valid Babel configuration'
     },
     id: 'babel-config/is-valid',
     schema: [],

--- a/packages/hint-content-type/README.md
+++ b/packages/hint-content-type/README.md
@@ -1,4 +1,4 @@
-# Require `Content-Type` HTTP response header with appropriate value (`content-type`)
+# Correct `Content-Type` header (`content-type`)
 
 `content-type` warns against not serving resources with the
 `Content-Type` HTTP response header with a value containing

--- a/packages/hint-content-type/src/hint.ts
+++ b/packages/hint-content-type/src/hint.ts
@@ -11,15 +11,15 @@
 
 import { MediaType, parse } from 'content-type';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { IHint, FetchEnd, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint, FetchEnd } from 'hint/dist/src/lib/types';
 import getHeaderValueNormalized from 'hint/dist/src/lib/utils/network/normalized-header-value';
 import isDataURI from 'hint/dist/src/lib/utils/network/is-data-uri';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
 import { isTextMediaType } from 'hint/dist/src/lib/utils/content-type';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 const debug = d(__filename);
 
@@ -31,19 +31,7 @@ const debug = d(__filename);
 
 export default class ContentTypeHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.interoperability,
-            description: 'Require `Content-Type` header with appropriate value'
-        },
-        id: 'content-type',
-        schema: [{
-            items: { type: 'string' },
-            type: ['object', 'null'],
-            uniqueItems: true
-        }],
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-content-type/src/meta.ts
+++ b/packages/hint-content-type/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.interoperability,
         description: 'Require `Content-Type` header with appropriate value',
-        name: 'Require `Content-Type` header'
+        name: 'Correct `Content-Type` header'
     },
     id: 'content-type',
     schema: [{

--- a/packages/hint-content-type/src/meta.ts
+++ b/packages/hint-content-type/src/meta.ts
@@ -1,0 +1,20 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.interoperability,
+        description: 'Require `Content-Type` header with appropriate value',
+        name: 'Require `Content-Type` header'
+    },
+    id: 'content-type',
+    schema: [{
+        items: { type: 'string' },
+        type: ['object', 'null'],
+        uniqueItems: true
+    }],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-disown-opener/README.md
+++ b/packages/hint-disown-opener/README.md
@@ -1,4 +1,4 @@
-# Require external links to disown opener (`disown-opener`)
+# External links disown opener (`disown-opener`)
 
 `disown-opener` checks if the `rel` attribute is specified with both
 the `noopener` and `noreferrer` values (or only `noopener` if all the

--- a/packages/hint-disown-opener/src/hint.ts
+++ b/packages/hint-disown-opener/src/hint.ts
@@ -12,16 +12,16 @@
 
 import { URL } from 'url';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import cutString from 'hint/dist/src/lib/utils/misc/cut-string';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
 import isRegularProtocol from 'hint/dist/src/lib/utils/network/is-regular-protocol';
 import { isSupported } from 'hint/dist/src/lib/utils/caniuse';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { IAsyncHTMLElement, ElementFound, IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IAsyncHTMLElement, ElementFound, IHint } from 'hint/dist/src/lib/types';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import prettyPrintArray from 'hint/dist/src/lib/utils/misc/pretty-print-array';
+
+import meta from './meta';
 
 const debug = d(__filename);
 
@@ -33,19 +33,7 @@ const debug = d(__filename);
 
 export default class DisownOpenerHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.security,
-            description: 'Require `noopener` (and `noreferrer`) on `a` and `area` element with target="_blank"'
-        },
-        id: 'disown-opener',
-        schema: [{
-            additionalProperties: false,
-            properties: { includeSameOriginURLs: { type: 'boolean' } },
-            type: ['object', 'null']
-        }],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-disown-opener/src/meta.ts
+++ b/packages/hint-disown-opener/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.security,
         description: 'Require `noopener` (and `noreferrer`) on `a` and `area` element with target="_blank"',
-        name: 'Require external links to disown opener'
+        name: 'External links disown opener'
     },
     id: 'disown-opener',
     schema: [{

--- a/packages/hint-disown-opener/src/meta.ts
+++ b/packages/hint-disown-opener/src/meta.ts
@@ -1,0 +1,20 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.security,
+        description: 'Require `noopener` (and `noreferrer`) on `a` and `area` element with target="_blank"',
+        name: 'Require external links to disown opener'
+    },
+    id: 'disown-opener',
+    schema: [{
+        additionalProperties: false,
+        properties: { includeSameOriginURLs: { type: 'boolean' } },
+        type: ['object', 'null']
+    }],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-doctype/README.md
+++ b/packages/hint-doctype/README.md
@@ -1,4 +1,4 @@
-# Check if the page has the most modern document type declaration
+# Modern DOCTYPE
 
 This hint checks if the HTML is using the most modern document type
 declaration (a.k.a. `doctype`).

--- a/packages/hint-doctype/src/hint.ts
+++ b/packages/hint-doctype/src/hint.ts
@@ -3,11 +3,11 @@
  */
 
 import * as os from 'os';
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata, FetchEnd, ProblemLocation } from 'hint/dist/src/lib/types';
+import { IHint, FetchEnd, ProblemLocation } from 'hint/dist/src/lib/types';
 import { MatchInformation } from './types';
+
+import meta from './meta';
 
 /*
  * ------------------------------------------------------------------------------
@@ -17,15 +17,7 @@ import { MatchInformation } from './types';
 
 export default class implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.interoperability,
-            description: `This hint checks if the HTML is using the most modern DOCTYPE.`
-        },
-        id: 'doctype',
-        schema: [],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
         const correctLine = 0;

--- a/packages/hint-doctype/src/meta.ts
+++ b/packages/hint-doctype/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.interoperability,
         description: `This hint checks if the HTML is using the most modern DOCTYPE.`,
-        name: 'Ensure modern DOCTYPE'
+        name: 'Modern DOCTYPE'
     },
     id: 'doctype',
     schema: [],

--- a/packages/hint-doctype/src/meta.ts
+++ b/packages/hint-doctype/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.interoperability,
+        description: `This hint checks if the HTML is using the most modern DOCTYPE.`,
+        name: 'Ensure modern DOCTYPE'
+    },
+    id: 'doctype',
+    schema: [],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-highest-available-document-mode/README.md
+++ b/packages/hint-highest-available-document-mode/README.md
@@ -1,4 +1,4 @@
-# Require highest available document mode (`highest-available-document-mode`)
+# Highest document mode (`highest-available-document-mode`)
 
 `highest-available-document-mode` warns against not informing browsers
 that support document modes to use the highest one available.

--- a/packages/hint-highest-available-document-mode/src/hint.ts
+++ b/packages/hint-highest-available-document-mode/src/hint.ts
@@ -9,12 +9,12 @@
  * ------------------------------------------------------------------------------
  */
 
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { IAsyncHTMLDocument, IAsyncHTMLElement, IHint, TraverseEnd, HintMetadata, HttpHeaders } from 'hint/dist/src/lib/types';
+import { IAsyncHTMLDocument, IAsyncHTMLElement, IHint, TraverseEnd, HttpHeaders } from 'hint/dist/src/lib/types';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
 import isLocalFile from 'hint/dist/src/lib/utils/network/is-local-file';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 /*
  * ------------------------------------------------------------------------------
@@ -24,19 +24,7 @@ import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 
 export default class HighestAvailableDocumentModeHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.interoperability,
-            description: 'Require highest available document mode'
-        },
-        id: 'highest-available-document-mode',
-        schema: [{
-            additionalProperties: false,
-            properties: { requireMetaElement: { type: 'boolean' } },
-            type: ['object', 'null']
-        }],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-highest-available-document-mode/src/meta.ts
+++ b/packages/hint-highest-available-document-mode/src/meta.ts
@@ -1,0 +1,20 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.interoperability,
+        description: 'Require highest available document mode',
+        name: 'Require highest available document mode'
+    },
+    id: 'highest-available-document-mode',
+    schema: [{
+        additionalProperties: false,
+        properties: { requireMetaElement: { type: 'boolean' } },
+        type: ['object', 'null']
+    }],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-highest-available-document-mode/src/meta.ts
+++ b/packages/hint-highest-available-document-mode/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.interoperability,
         description: 'Require highest available document mode',
-        name: 'Require highest available document mode'
+        name: 'Highest document mode'
     },
     id: 'highest-available-document-mode',
     schema: [{

--- a/packages/hint-html-checker/README.md
+++ b/packages/hint-html-checker/README.md
@@ -1,4 +1,4 @@
-# Nu HTML Test (`html-checker`)
+# Nu HTML test (`html-checker`)
 
 `html-checker` validates the markup of a website against the
 [Nu HTML checker][nu html checker].

--- a/packages/hint-html-checker/src/hint.ts
+++ b/packages/hint-html-checker/src/hint.ts
@@ -12,11 +12,11 @@
 import { uniqBy } from 'lodash';
 import { OptionsWithUrl } from 'request';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, ProblemLocation, Severity, HintMetadata, TraverseStart } from 'hint/dist/src/lib/types';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { IHint, ProblemLocation, Severity, TraverseStart } from 'hint/dist/src/lib/types';
+
+import meta from './meta';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -34,31 +34,7 @@ type CheckerData = {
 
 export default class HtmlCheckerHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.interoperability,
-            description: `Validate HTML using 'the Nu HTML checker'`
-        },
-        id: 'html-checker',
-        schema: [{
-            properties: {
-                details: { type: 'boolean' },
-                ignore: {
-                    anyOf: [
-                        {
-                            items: { type: 'string' },
-                            type: 'array'
-                        }, { type: 'string' }
-                    ]
-                },
-                validator: {
-                    pattern: '^(http|https)://',
-                    type: 'string'
-                }
-            }
-        }],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-html-checker/src/meta.ts
+++ b/packages/hint-html-checker/src/meta.ts
@@ -1,0 +1,32 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.interoperability,
+        description: `Validate HTML using 'the Nu HTML checker'`,
+        name: 'Nu HTML test'
+    },
+    id: 'html-checker',
+    schema: [{
+        properties: {
+            details: { type: 'boolean' },
+            ignore: {
+                anyOf: [
+                    {
+                        items: { type: 'string' },
+                        type: 'array'
+                    }, { type: 'string' }
+                ]
+            },
+            validator: {
+                pattern: '^(http|https)://',
+                type: 'string'
+            }
+        }
+    }],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-http-cache/README.md
+++ b/packages/hint-http-cache/README.md
@@ -1,4 +1,4 @@
-# HTTP Cache (`http-cache`)
+# HTTP cache (`http-cache`)
 
 `http-cache` verifies that the page and all its resources follow a
 good, sustainable caching strategy.

--- a/packages/hint-http-cache/src/hint.ts
+++ b/packages/hint-http-cache/src/hint.ts
@@ -2,13 +2,13 @@
  * @fileoverview Checks if your cache-control header and asset strategy follows best practices
  */
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 import getHeaderValueNormalized from 'hint/dist/src/lib/utils/network/normalized-header-value';
 import isDataURI from 'hint/dist/src/lib/utils/network/is-data-uri';
-import { IHint, FetchEnd, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint, FetchEnd } from 'hint/dist/src/lib/types';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 const debug = d(__filename);
 
@@ -23,30 +23,7 @@ type ParsedDirectives = {
 
 export default class HttpCacheHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.performance,
-            description: `Checks if your cache-control header and asset strategy follows best practices`
-        },
-        id: 'http-cache',
-        schema: [{
-            additionalProperties: false,
-            definitions: {
-                'string-array': {
-                    items: { type: 'string' },
-                    minItems: 1,
-                    type: 'array',
-                    uniqueItems: true
-                }
-            },
-            properties: {
-                maxAgeResource: { type: 'number' },
-                maxAgeTarget: { type: 'number' },
-                revvingPatterns: { $ref: '#/definitions/string-array' }
-            }
-        }],
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-http-cache/src/meta.ts
+++ b/packages/hint-http-cache/src/meta.ts
@@ -1,0 +1,31 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.performance,
+        description: `Checks if your cache-control header and asset strategy follows best practices`,
+        name: 'HTTP cache'
+    },
+    id: 'http-cache',
+    schema: [{
+        additionalProperties: false,
+        definitions: {
+            'string-array': {
+                items: { type: 'string' },
+                minItems: 1,
+                type: 'array',
+                uniqueItems: true
+            }
+        },
+        properties: {
+            maxAgeResource: { type: 'number' },
+            maxAgeTarget: { type: 'number' },
+            revvingPatterns: { $ref: '#/definitions/string-array' }
+        }
+    }],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-http-compression/README.md
+++ b/packages/hint-http-compression/README.md
@@ -1,4 +1,4 @@
-# Require resources to be served compressed (`http-compression`)
+# Optimal compression (`http-compression`)
 
 `http-compression` warns against serving resources uncompressed
 or using an inappropriate encoding.

--- a/packages/hint-http-compression/src/hint.ts
+++ b/packages/hint-http-compression/src/hint.ts
@@ -21,6 +21,7 @@ import isRegularProtocol from 'hint/dist/src/lib/utils/network/is-regular-protoc
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
 
 import { CompressionCheckOptions } from './types';
+
 import meta from './meta';
 
 const decompressBrotli = promisify(brotli.decompress) as (buffer: Buffer) => Promise<Buffer>;

--- a/packages/hint-http-compression/src/hint.ts
+++ b/packages/hint-http-compression/src/hint.ts
@@ -11,18 +11,17 @@ import { promisify } from 'util';
 
 import * as brotli from 'iltorb';
 
-
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { FetchEnd, IAsyncHTMLElement, IHint, NetworkData, Response, HintMetadata, HttpHeaders } from 'hint/dist/src/lib/types';
+import { FetchEnd, IAsyncHTMLElement, IHint, NetworkData, Response, HttpHeaders } from 'hint/dist/src/lib/types';
 import { asyncTry } from 'hint/dist/src/lib/utils/async-wrapper';
 import { getFileExtension, isTextMediaType } from 'hint/dist/src/lib/utils/content-type';
 import getHeaderValueNormalized from 'hint/dist/src/lib/utils/network/normalized-header-value';
 import isHTTP from 'hint/dist/src/lib/utils/network/is-http';
 import isRegularProtocol from 'hint/dist/src/lib/utils/network/is-regular-protocol';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
+
 import { CompressionCheckOptions } from './types';
+import meta from './meta';
 
 const decompressBrotli = promisify(brotli.decompress) as (buffer: Buffer) => Promise<Buffer>;
 const uaString = 'Mozilla/5.0 Gecko';
@@ -35,33 +34,7 @@ const uaString = 'Mozilla/5.0 Gecko';
 
 export default class HttpCompressionHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.performance,
-            description: 'Require resources to be served compressed'
-        },
-        id: 'http-compression',
-        schema: [{
-            additionalProperties: false,
-            definitions: {
-                options: {
-                    additionalProperties: false,
-                    minProperties: 1,
-                    properties: {
-                        brotli: { type: 'boolean' },
-                        gzip: { type: 'boolean' },
-                        zopfli: { type: 'boolean' }
-                    }
-                }
-            },
-            properties: {
-                html: { $ref: '#/definitions/options' },
-                resource: { $ref: '#/definitions/options' }
-            },
-            type: 'object'
-        }],
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-http-compression/src/meta.ts
+++ b/packages/hint-http-compression/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.performance,
         description: 'Require resources to be served compressed',
-        name: 'Require resources to be served compressed'
+        name: 'Optimal compression'
     },
     id: 'http-compression',
     schema: [{

--- a/packages/hint-http-compression/src/meta.ts
+++ b/packages/hint-http-compression/src/meta.ts
@@ -1,0 +1,34 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.performance,
+        description: 'Require resources to be served compressed',
+        name: 'Require resources to be served compressed'
+    },
+    id: 'http-compression',
+    schema: [{
+        additionalProperties: false,
+        definitions: {
+            options: {
+                additionalProperties: false,
+                minProperties: 1,
+                properties: {
+                    brotli: { type: 'boolean' },
+                    gzip: { type: 'boolean' },
+                    zopfli: { type: 'boolean' }
+                }
+            }
+        },
+        properties: {
+            html: { $ref: '#/definitions/options' },
+            resource: { $ref: '#/definitions/options' }
+        },
+        type: 'object'
+    }],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-https-only/README.md
+++ b/packages/hint-https-only/README.md
@@ -1,4 +1,4 @@
-# Require https for you site and assets (`https-only`)
+# Use HTTPS (`https-only`)
 
 `https-only` checks if your site is using HTTPS and warns against
 having mixed content.

--- a/packages/hint-https-only/src/hint.ts
+++ b/packages/hint-https-only/src/hint.ts
@@ -4,14 +4,14 @@
 
 import * as URL from 'url';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
 
-import { IHint, HintMetadata, FetchEnd, Response, ElementFound } from 'hint/dist/src/lib/types';
+import { IHint, FetchEnd, Response, ElementFound } from 'hint/dist/src/lib/types';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import isHTTPS from 'hint/dist/src/lib/utils/network/is-https';
 import isDataURI from 'hint/dist/src/lib/utils/network/is-data-uri';
+
+import meta from './meta';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -24,15 +24,7 @@ const debug: debug.IDebugger = d(__filename);
 export default class HttpsOnlyHint implements IHint {
     private targetIsServedOverHTTPS: boolean = false;
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.security,
-            description: `Verifies if a website is using HTTPS and if it has mixed content.`
-        },
-        id: 'https-only',
-        schema: [],
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
         let target: string;

--- a/packages/hint-https-only/src/meta.ts
+++ b/packages/hint-https-only/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.security,
         description: `Verifies if a website is using HTTPS and if it has mixed content.`,
-        name: 'Require HTTPS'
+        name: 'Use HTTPS'
     },
     id: 'https-only',
     schema: [],

--- a/packages/hint-https-only/src/meta.ts
+++ b/packages/hint-https-only/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.security,
+        description: `Verifies if a website is using HTTPS and if it has mixed content.`,
+        name: 'Require HTTPS'
+    },
+    id: 'https-only',
+    schema: [],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-image-optimization-cloudinary/README.md
+++ b/packages/hint-image-optimization-cloudinary/README.md
@@ -1,4 +1,4 @@
-# Image optimization with Cloudinary (`image-optimization-cloudinary`)
+# Optimize images (`image-optimization-cloudinary`)
 
 `image-optimization-cloudinary` uses the [Cloudinary][cloudinary]
 service to analyze your images and see if there could be size savings

--- a/packages/hint-image-optimization-cloudinary/src/hint.ts
+++ b/packages/hint-image-optimization-cloudinary/src/hint.ts
@@ -9,12 +9,12 @@ import * as fs from 'fs-extra';
 import * as getImageData from 'image-size';
 
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, FetchEnd, ScanEnd, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint, FetchEnd, ScanEnd } from 'hint/dist/src/lib/types';
 import cutString from 'hint/dist/src/lib/utils/misc/cut-string';
 import * as logger from 'hint/dist/src/lib/utils/logging';
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { cloudinaryResult } from './cloudinary-types';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 /*
  * ------------------------------------------------------------------------------
@@ -24,23 +24,7 @@ import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 
 export default class ImageOptimizationCloudinaryHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.performance,
-            description: `Image optimization with cloudinary`
-        },
-        id: 'image-optimization-cloudinary',
-        schema: [{
-            additionalProperties: false,
-            properties: {
-                apiKey: { type: 'string' },
-                apiSecret: { type: 'string' },
-                cloudName: { type: 'string' },
-                threshold: { type: 'number' }
-            }
-        }],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-image-optimization-cloudinary/src/meta.ts
+++ b/packages/hint-image-optimization-cloudinary/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.performance,
         description: `Image optimization with cloudinary`,
-        name: 'Image optimization with Cloudinary'
+        name: 'Optimize images'
     },
     id: 'image-optimization-cloudinary',
     schema: [{

--- a/packages/hint-image-optimization-cloudinary/src/meta.ts
+++ b/packages/hint-image-optimization-cloudinary/src/meta.ts
@@ -1,0 +1,24 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.performance,
+        description: `Image optimization with cloudinary`,
+        name: 'Image optimization with Cloudinary'
+    },
+    id: 'image-optimization-cloudinary',
+    schema: [{
+        additionalProperties: false,
+        properties: {
+            apiKey: { type: 'string' },
+            apiSecret: { type: 'string' },
+            cloudName: { type: 'string' },
+            threshold: { type: 'number' }
+        }
+    }],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-manifest-app-name/README.md
+++ b/packages/hint-manifest-app-name/README.md
@@ -1,4 +1,4 @@
-# Require manifest to specify the web site/app name (`manifest-app-name`)
+# Manifest has name (`manifest-app-name`)
 
 `manifest-app-name` checks if the name of the web application is
 specified within the manifest file.

--- a/packages/hint-manifest-app-name/src/hint.ts
+++ b/packages/hint-manifest-app-name/src/hint.ts
@@ -11,11 +11,11 @@
 
 import { ucs2 } from 'punycode';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { IHint, HintMetadata, IJSONLocationFunction } from 'hint/dist/src/lib/types';
+import { IHint, IJSONLocationFunction } from 'hint/dist/src/lib/types';
 import { ManifestEvents, ManifestParsed } from '@hint/parser-manifest';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 /*
  * ------------------------------------------------------------------------------
@@ -25,15 +25,7 @@ import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 
 export default class ManifestAppNameHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.pwa,
-            description: 'Require web application name to be specified in the web app manifest file'
-        },
-        id: 'manifest-app-name',
-        schema: [],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<ManifestEvents>) {
 

--- a/packages/hint-manifest-app-name/src/meta.ts
+++ b/packages/hint-manifest-app-name/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.pwa,
         description: 'Require web application name to be specified in the web app manifest file',
-        name: 'Require manifest to specify name'
+        name: 'Manifest has name'
     },
     id: 'manifest-app-name',
     schema: [],

--- a/packages/hint-manifest-app-name/src/meta.ts
+++ b/packages/hint-manifest-app-name/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.pwa,
+        description: 'Require web application name to be specified in the web app manifest file',
+        name: 'Require manifest to specify name'
+    },
+    id: 'manifest-app-name',
+    schema: [],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-manifest-exists/README.md
+++ b/packages/hint-manifest-exists/README.md
@@ -1,4 +1,4 @@
-# Require a web app manifest file (`manifest-exists`)
+# Has web app manifest (`manifest-exists`)
 
 `manifest-exists` warns when a [web app manifest][spec]
 file is not provided.

--- a/packages/hint-manifest-exists/src/hint.ts
+++ b/packages/hint-manifest-exists/src/hint.ts
@@ -9,18 +9,17 @@
  * ------------------------------------------------------------------------------
  */
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import {
     ElementFound,
     FetchError,
     IHint,
-    HintMetadata,
     ScanEnd
 } from 'hint/dist/src/lib/types';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { ManifestEvents } from '@hint/parser-manifest';
+
+import meta from './meta';
 
 /*
  * ------------------------------------------------------------------------------
@@ -30,15 +29,7 @@ import { ManifestEvents } from '@hint/parser-manifest';
 
 export default class ManifestExistsHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.pwa,
-            description: 'Require a web app manifest'
-        },
-        id: 'manifest-exists',
-        schema: [],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<ManifestEvents>) {
 

--- a/packages/hint-manifest-exists/src/meta.ts
+++ b/packages/hint-manifest-exists/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.pwa,
         description: 'Require a web app manifest',
-        name: 'Require a web app manifest'
+        name: 'Has web app manifest'
     },
     id: 'manifest-exists',
     schema: [],

--- a/packages/hint-manifest-exists/src/meta.ts
+++ b/packages/hint-manifest-exists/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.pwa,
+        description: 'Require a web app manifest',
+        name: 'Require a web app manifest'
+    },
+    id: 'manifest-exists',
+    schema: [],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-manifest-file-extension/README.md
+++ b/packages/hint-manifest-file-extension/README.md
@@ -1,4 +1,4 @@
-# Disallow non-standard file extension for the web app manifest file (`manifest-file-extension`)
+# Correct manifest extension (`manifest-file-extension`)
 
 `manifest-file-extension` warns against using non-standard file
 extensions for the [web app manifest][spec] file.

--- a/packages/hint-manifest-file-extension/src/hint.ts
+++ b/packages/hint-manifest-file-extension/src/hint.ts
@@ -9,12 +9,12 @@
  * ------------------------------------------------------------------------------
  */
 
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { ElementFound, IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { ElementFound, IHint } from 'hint/dist/src/lib/types';
 import getFileExtension from 'hint/dist/src/lib/utils/fs/file-extension';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 /*
  * ------------------------------------------------------------------------------
@@ -24,15 +24,7 @@ import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 
 export default class ManifestFileExtensionHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.pwa,
-            description: 'Require `.webmanifest` as the file extension for the web app manifest file'
-        },
-        id: 'manifest-file-extension',
-        schema: [],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-manifest-file-extension/src/meta.ts
+++ b/packages/hint-manifest-file-extension/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.pwa,
+        description: 'Require `.webmanifest` as the file extension for the web app manifest file',
+        name: 'Correct web app manifest file extension'
+    },
+    id: 'manifest-file-extension',
+    schema: [],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-manifest-file-extension/src/meta.ts
+++ b/packages/hint-manifest-file-extension/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.pwa,
         description: 'Require `.webmanifest` as the file extension for the web app manifest file',
-        name: 'Correct web app manifest file extension'
+        name: 'Correct manifest extension'
     },
     id: 'manifest-file-extension',
     schema: [],

--- a/packages/hint-manifest-is-valid/README.md
+++ b/packages/hint-manifest-is-valid/README.md
@@ -1,4 +1,4 @@
-# Require valid manifest (`manifest-is-valid`)
+# Valid manifest (`manifest-is-valid`)
 
 `manifest-is-valid` checks if the content of the web app manifest
 file is valid JSON, valid according to the specification, and the

--- a/packages/hint-manifest-is-valid/src/hint.ts
+++ b/packages/hint-manifest-is-valid/src/hint.ts
@@ -11,11 +11,9 @@
 import { parse as bcp47 } from 'bcp47';
 import { get as parseColor, ColorDescriptor } from 'color-string';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import {
     IHint,
-    IJSONLocationFunction,
-    HintMetadata
+    IJSONLocationFunction
 } from 'hint/dist/src/lib/types';
 import { isSupported } from 'hint/dist/src/lib/utils/caniuse';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
@@ -27,7 +25,8 @@ import {
     ManifestParsed
 } from '@hint/parser-manifest';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 /*
  * ---------------------------------------------------------------------
@@ -37,15 +36,7 @@ import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 
 export default class ManifestIsValidHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.pwa,
-            description: 'Require valid web app manifest'
-        },
-        id: 'manifest-is-valid',
-        schema: [],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<ManifestEvents>) {
 

--- a/packages/hint-manifest-is-valid/src/meta.ts
+++ b/packages/hint-manifest-is-valid/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.pwa,
+        description: 'Require valid web app manifest',
+        name: 'Require valid manifest'
+    },
+    id: 'manifest-is-valid',
+    schema: [],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-manifest-is-valid/src/meta.ts
+++ b/packages/hint-manifest-is-valid/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.pwa,
         description: 'Require valid web app manifest',
-        name: 'Require valid manifest'
+        name: 'Valid manifest'
     },
     id: 'manifest-is-valid',
     schema: [],

--- a/packages/hint-meta-charset-utf-8/README.md
+++ b/packages/hint-meta-charset-utf-8/README.md
@@ -1,4 +1,4 @@
-# Require charset meta tag with the value of `utf-8` (`meta-charset-utf-8`)
+# Use charset `utf-8` (`meta-charset-utf-8`)
 
 `meta-charset-utf-8` checks if the page explicitly declares the
 character encoding as `utf-8` using a meta tag early in the document.

--- a/packages/hint-meta-charset-utf-8/src/hint.ts
+++ b/packages/hint-meta-charset-utf-8/src/hint.ts
@@ -11,11 +11,11 @@
 
 import * as cheerio from 'cheerio';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { IAsyncHTMLDocument, IAsyncHTMLElement, IHint, FetchEnd, HintMetadata, TraverseEnd } from 'hint/dist/src/lib/types';
+import { IAsyncHTMLDocument, IAsyncHTMLElement, IHint, FetchEnd, TraverseEnd } from 'hint/dist/src/lib/types';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 /*
  * ------------------------------------------------------------------------------
@@ -25,15 +25,7 @@ import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 
 export default class MetaCharsetUTF8Hint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.interoperability,
-            description: 'Require `<meta charset="utf-8">`'
-        },
-        id: 'meta-charset-utf-8',
-        schema: [],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
         let receivedDOM: CheerioStatic | undefined;

--- a/packages/hint-meta-charset-utf-8/src/meta.ts
+++ b/packages/hint-meta-charset-utf-8/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.interoperability,
         description: 'Require `<meta charset="utf-8">`',
-        name: 'Require charset meta tag'
+        name: 'Use charset `utf-8`'
     },
     id: 'meta-charset-utf-8',
     schema: [],

--- a/packages/hint-meta-charset-utf-8/src/meta.ts
+++ b/packages/hint-meta-charset-utf-8/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.interoperability,
+        description: 'Require `<meta charset="utf-8">`',
+        name: 'Require charset meta tag'
+    },
+    id: 'meta-charset-utf-8',
+    schema: [],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-meta-theme-color/README.md
+++ b/packages/hint-meta-theme-color/README.md
@@ -1,4 +1,4 @@
-# Require a 'theme-color' meta tag with a valid value (`meta-theme-color`)
+# Valid `theme-color` (`meta-theme-color`)
 
 `meta-theme-color` hint checks if a single `theme-color` meta tag
 is specified in the `<head>` with a valid value supported by all user

--- a/packages/hint-meta-theme-color/src/hint.ts
+++ b/packages/hint-meta-theme-color/src/hint.ts
@@ -11,18 +11,17 @@
 
 import { get as parseColor, ColorDescriptor } from 'color-string';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import {
     ElementFound,
     IAsyncHTMLElement,
     IHint,
-    HintMetadata,
     TraverseEnd
 } from 'hint/dist/src/lib/types';
 import { isSupported } from 'hint/dist/src/lib/utils/caniuse';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 /*
  * ------------------------------------------------------------------------------
@@ -32,15 +31,7 @@ import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 
 export default class MetaThemeColorHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.pwa,
-            description: `Require a 'theme-color' meta element`
-        },
-        id: 'meta-theme-color',
-        schema: [],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-meta-theme-color/src/meta.ts
+++ b/packages/hint-meta-theme-color/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.pwa,
         description: `Require a 'theme-color' meta element`,
-        name: 'Require `theme-color` meta tag'
+        name: 'Valid `theme-color`'
     },
     id: 'meta-theme-color',
     schema: [],

--- a/packages/hint-meta-theme-color/src/meta.ts
+++ b/packages/hint-meta-theme-color/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.pwa,
+        description: `Require a 'theme-color' meta element`,
+        name: 'Require `theme-color` meta tag'
+    },
+    id: 'meta-theme-color',
+    schema: [],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-meta-viewport/README.md
+++ b/packages/hint-meta-viewport/README.md
@@ -1,4 +1,4 @@
-# Require viewport meta tag with proper value (`meta-viewport`)
+# Correct viewport (`meta-viewport`)
 
 `meta-viewport` warns against not having a single `viewport` meta
 tag in the `<head>` with the proper value.

--- a/packages/hint-meta-viewport/src/hint.ts
+++ b/packages/hint-meta-viewport/src/hint.ts
@@ -5,12 +5,12 @@
 
 import { parseMetaViewPortContent } from 'metaviewport-parser';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
-import { IAsyncHTMLDocument, IAsyncHTMLElement, TraverseEnd, HintMetadata } from 'hint/dist/src/lib/types';
+import { IAsyncHTMLDocument, IAsyncHTMLElement, TraverseEnd } from 'hint/dist/src/lib/types';
 import { IHint } from 'hint/dist/src/lib/types';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 /*
  * ------------------------------------------------------------------------------
@@ -20,15 +20,7 @@ import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 
 export default class MetaViewportHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.interoperability,
-            description: 'Require viewport meta element'
-        },
-        id: 'meta-viewport',
-        schema: [],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-meta-viewport/src/meta.ts
+++ b/packages/hint-meta-viewport/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.interoperability,
+        description: 'Require viewport meta element',
+        name: 'Require viewport meta tag'
+    },
+    id: 'meta-viewport',
+    schema: [],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-meta-viewport/src/meta.ts
+++ b/packages/hint-meta-viewport/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.interoperability,
         description: 'Require viewport meta element',
-        name: 'Require viewport meta tag'
+        name: 'Correct viewport'
     },
     id: 'meta-viewport',
     schema: [],

--- a/packages/hint-minified-js/README.md
+++ b/packages/hint-minified-js/README.md
@@ -1,4 +1,4 @@
-# JavaScript should be minified (`minified-js`)
+# Minify JavaScript (`minified-js`)
 
 This hint checks whether JavaScript used by your web page is minified
 or not.

--- a/packages/hint-minified-js/src/hint.ts
+++ b/packages/hint-minified-js/src/hint.ts
@@ -5,12 +5,12 @@
  * a reasonable threshold to determine whether a script is minified or not
  */
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint } from 'hint/dist/src/lib/types';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { ScriptEvents, ScriptParse } from '@hint/parser-javascript';
+
+import meta from './meta';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -21,18 +21,7 @@ const debug: debug.IDebugger = d(__filename);
  */
 export default class MinifiedJsHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.performance,
-            description: `Hint to check script is minified or not`
-        },
-        id: 'minified-js',
-        schema: [{
-            additionalProperties: false,
-            properties: { threshold: { type: 'number' } }
-        }],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<ScriptEvents>) {
         /*

--- a/packages/hint-minified-js/src/meta.ts
+++ b/packages/hint-minified-js/src/meta.ts
@@ -1,0 +1,19 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.performance,
+        description: `Hint to check script is minified or not`,
+        name: 'JavaScript should be minified'
+    },
+    id: 'minified-js',
+    schema: [{
+        additionalProperties: false,
+        properties: { threshold: { type: 'number' } }
+    }],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-minified-js/src/meta.ts
+++ b/packages/hint-minified-js/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.performance,
         description: `Hint to check script is minified or not`,
-        name: 'JavaScript should be minified'
+        name: 'Minify JavaScript'
     },
     id: 'minified-js',
     schema: [{

--- a/packages/hint-no-bom/README.md
+++ b/packages/hint-no-bom/README.md
@@ -1,4 +1,4 @@
-# Warn if the byte-order mark (BOM) character is at beginning of a text file (`no-bom`)
+# No byte-order mark (`no-bom`)
 
 `no-bom` warns against having the byte-order mark (BOM) character
 at the beginning of a text file.

--- a/packages/hint-no-bom/src/hint.ts
+++ b/packages/hint-no-bom/src/hint.ts
@@ -1,14 +1,14 @@
 /**
  * @fileoverview Warns against having the BOM character at the beginning of a text file
  */
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { FetchEnd, IHint, NetworkData, HintMetadata } from 'hint/dist/src/lib/types';
+import { FetchEnd, IHint, NetworkData } from 'hint/dist/src/lib/types';
 import { asyncTry } from 'hint/dist/src/lib/utils/async-wrapper';
 import { isTextMediaType } from 'hint/dist/src/lib/utils/content-type';
 import isRegularProtocol from 'hint/dist/src/lib/utils/network/is-regular-protocol';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
+
+import meta from './meta';
 
 
 const debug: debug.IDebugger = d(__filename);
@@ -21,15 +21,7 @@ const debug: debug.IDebugger = d(__filename);
 
 export default class implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.interoperability,
-            description: `Warns against using the BOM (byte-order marker) character at the beginning of a text based file`
-        },
-        id: 'no-bom',
-        schema: [],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-no-bom/src/meta.ts
+++ b/packages/hint-no-bom/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.interoperability,
+        description: `Warns against using the BOM (byte-order marker) character at the beginning of a text based file`,
+        name: 'No byte-order mark (BOM)'
+    },
+    id: 'no-bom',
+    schema: [],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-no-bom/src/meta.ts
+++ b/packages/hint-no-bom/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.interoperability,
         description: `Warns against using the BOM (byte-order marker) character at the beginning of a text based file`,
-        name: 'No byte-order mark (BOM)'
+        name: 'No byte-order mark'
     },
     id: 'no-bom',
     schema: [],

--- a/packages/hint-no-broken-links/README.md
+++ b/packages/hint-no-broken-links/README.md
@@ -1,4 +1,4 @@
-# Check for broken links (`broken-links`)
+# No broken links (`broken-links`)
 
 This hint checks and reports if any links in your page are broken.
 This includes anchor tag `href` value, image `src` value,

--- a/packages/hint-no-broken-links/src/hint.ts
+++ b/packages/hint-no-broken-links/src/hint.ts
@@ -4,20 +4,20 @@
  */
 
 import { URL } from 'url';
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
 import {
     IHint,
     ElementFound,
-    HintMetadata,
     IAsyncHTMLElement
 } from 'hint/dist/src/lib/types';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 import isRegularProtocol from 'hint/dist/src/lib/utils/network/is-regular-protocol';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { Requester } from '@hint/utils-connector-tools/dist/src/requester';
 import { IAsyncHTMLDocument, NetworkData, TraverseEnd } from 'hint/dist/src/lib/types';
 import { CoreOptions } from 'request';
+
+import meta from './meta';
+
 const debug: debug.IDebugger = d(__filename);
 
 /*
@@ -27,23 +27,7 @@ const debug: debug.IDebugger = d(__filename);
  */
 
 export default class NoBrokenLinksHint implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.performance,
-            description: `Hint to flag broken links in the page`
-        },
-        id: 'no-broken-links',
-        schema: [{
-            properties: {
-                method: {
-                    pattern: '^([hH][eE][aA][dD])|([gG][eE][tT])$',
-                    type: 'string'
-                }
-            },
-            type: 'object'
-        }],
-        scope: HintScope.site
-    };
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-no-broken-links/src/meta.ts
+++ b/packages/hint-no-broken-links/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.performance,
         description: `Hint to flag broken links in the page`,
-        name: 'Check for broken links'
+        name: 'No broken links'
     },
     id: 'no-broken-links',
     schema: [{

--- a/packages/hint-no-broken-links/src/meta.ts
+++ b/packages/hint-no-broken-links/src/meta.ts
@@ -1,0 +1,24 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.performance,
+        description: `Hint to flag broken links in the page`,
+        name: 'Check for broken links'
+    },
+    id: 'no-broken-links',
+    schema: [{
+        properties: {
+            method: {
+                pattern: '^([hH][eE][aA][dD])|([gG][eE][tT])$',
+                type: 'string'
+            }
+        },
+        type: 'object'
+    }],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-no-disallowed-headers/README.md
+++ b/packages/hint-no-disallowed-headers/README.md
@@ -1,4 +1,4 @@
-# Disallow certain HTTP headers (`no-disallowed-headers`)
+# Disallowed HTTP headers (`no-disallowed-headers`)
 
 `no-disallowed-headers` warns against responding with certain HTTP
 headers.

--- a/packages/hint-no-disallowed-headers/src/hint.ts
+++ b/packages/hint-no-disallowed-headers/src/hint.ts
@@ -9,14 +9,14 @@
  */
 
 import getHeaderValueNormalized from 'hint/dist/src/lib/utils/network/normalized-header-value';
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 import { getIncludedHeaders, mergeIgnoreIncludeArrays, toLowerCase } from 'hint/dist/src/lib/utils/hint-helpers';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
-import { FetchEnd, IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { FetchEnd, IHint } from 'hint/dist/src/lib/types';
 import isDataURI from 'hint/dist/src/lib/utils/network/is-data-uri';
 import prettyPrintArray from 'hint/dist/src/lib/utils/misc/pretty-print-array';
+
+import meta from './meta';
 
 const debug = d(__filename);
 
@@ -28,30 +28,7 @@ const debug = d(__filename);
 
 export default class NoDisallowedHeadersHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.security,
-            description: 'Disallow certain HTTP response headers'
-        },
-        id: 'no-disallowed-headers',
-        schema: [{
-            additionalProperties: false,
-            definitions: {
-                'string-array': {
-                    items: { type: 'string' },
-                    minItems: 1,
-                    type: 'array',
-                    uniqueItems: true
-                }
-            },
-            properties: {
-                ignore: { $ref: '#/definitions/string-array' },
-                include: { $ref: '#/definitions/string-array' }
-            },
-            type: ['object', 'null']
-        }],
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-no-disallowed-headers/src/meta.ts
+++ b/packages/hint-no-disallowed-headers/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.security,
         description: 'Disallow certain HTTP response headers',
-        name: 'Disallow certain HTTP headers'
+        name: 'Disallowed HTTP headers'
     },
     id: 'no-disallowed-headers',
     schema: [{

--- a/packages/hint-no-disallowed-headers/src/meta.ts
+++ b/packages/hint-no-disallowed-headers/src/meta.ts
@@ -1,0 +1,31 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.security,
+        description: 'Disallow certain HTTP response headers',
+        name: 'Disallow certain HTTP headers'
+    },
+    id: 'no-disallowed-headers',
+    schema: [{
+        additionalProperties: false,
+        definitions: {
+            'string-array': {
+                items: { type: 'string' },
+                minItems: 1,
+                type: 'array',
+                uniqueItems: true
+            }
+        },
+        properties: {
+            ignore: { $ref: '#/definitions/string-array' },
+            include: { $ref: '#/definitions/string-array' }
+        },
+        type: ['object', 'null']
+    }],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-no-friendly-error-pages/README.md
+++ b/packages/hint-no-friendly-error-pages/README.md
@@ -1,4 +1,4 @@
-# Disallow small error pages (`no-friendly-error-pages`)
+# No small error pages (`no-friendly-error-pages`)
 
 `no-friendly-error-pages` warns against using custom error pages with
 byte size under a certain threshold.

--- a/packages/hint-no-friendly-error-pages/src/hint.ts
+++ b/packages/hint-no-friendly-error-pages/src/hint.ts
@@ -12,12 +12,12 @@
 import * as url from 'url';
 import { URL } from 'url'; // this is necessary to avoid TypeScript mixes types.
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { FetchEnd, NetworkData, TraverseEnd, IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { FetchEnd, NetworkData, TraverseEnd, IHint } from 'hint/dist/src/lib/types';
 import isDataURI from 'hint/dist/src/lib/utils/network/is-data-uri';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 const debug = d(__filename);
 
@@ -29,15 +29,7 @@ const debug = d(__filename);
 
 export default class NoFriendlyErrorPagesHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.interoperability,
-            description: 'Disallow small error pages'
-        },
-        id: 'no-friendly-error-pages',
-        schema: [],
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-no-friendly-error-pages/src/meta.ts
+++ b/packages/hint-no-friendly-error-pages/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.interoperability,
+        description: 'Disallow small error pages',
+        name: 'Disallow small error pages'
+    },
+    id: 'no-friendly-error-pages',
+    schema: [],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-no-friendly-error-pages/src/meta.ts
+++ b/packages/hint-no-friendly-error-pages/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.interoperability,
         description: 'Disallow small error pages',
-        name: 'Disallow small error pages'
+        name: 'No small error pages'
     },
     id: 'no-friendly-error-pages',
     schema: [],

--- a/packages/hint-no-html-only-headers/README.md
+++ b/packages/hint-no-html-only-headers/README.md
@@ -1,4 +1,4 @@
-# Disallow unneeded HTTP headers for non-HTML resources (`no-html-only-headers`)
+# Unneeded HTTP headers (`no-html-only-headers`)
 
 `no-html-only-headers` warns against responding with HTTP headers that
 are not needed for non-HTML resources.

--- a/packages/hint-no-html-only-headers/src/hint.ts
+++ b/packages/hint-no-html-only-headers/src/hint.ts
@@ -9,14 +9,14 @@
  * ------------------------------------------------------------------------------
  */
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 import { getIncludedHeaders, mergeIgnoreIncludeArrays } from 'hint/dist/src/lib/utils/hint-helpers';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
-import { FetchEnd, Response, IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { FetchEnd, Response, IHint } from 'hint/dist/src/lib/types';
 import isDataURI from 'hint/dist/src/lib/utils/network/is-data-uri';
 import prettyPrintArray from 'hint/dist/src/lib/utils/misc/pretty-print-array';
+
+import meta from './meta';
 
 const debug = d(__filename);
 
@@ -28,30 +28,7 @@ const debug = d(__filename);
 
 export default class NoHtmlOnlyHeadersHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.performance,
-            description: 'Disallow unneeded HTTP headers for non-HTML resources'
-        },
-        id: 'no-html-only-headers',
-        schema: [{
-            additionalProperties: false,
-            definitions: {
-                'string-array': {
-                    items: { type: 'string' },
-                    minItems: 1,
-                    type: 'array',
-                    uniqueItems: true
-                }
-            },
-            properties: {
-                ignore: { $ref: '#/definitions/string-array' },
-                include: { $ref: '#/definitions/string-array' }
-            },
-            type: ['object', 'null']
-        }],
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-no-html-only-headers/src/meta.ts
+++ b/packages/hint-no-html-only-headers/src/meta.ts
@@ -1,0 +1,31 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.performance,
+        description: 'Disallow unneeded HTTP headers for non-HTML resources',
+        name: 'Unneeded HTTP headers'
+    },
+    id: 'no-html-only-headers',
+    schema: [{
+        additionalProperties: false,
+        definitions: {
+            'string-array': {
+                items: { type: 'string' },
+                minItems: 1,
+                type: 'array',
+                uniqueItems: true
+            }
+        },
+        properties: {
+            ignore: { $ref: '#/definitions/string-array' },
+            include: { $ref: '#/definitions/string-array' }
+        },
+        type: ['object', 'null']
+    }],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-no-http-redirects/README.md
+++ b/packages/hint-no-http-redirects/README.md
@@ -1,4 +1,4 @@
-# Avoid HTTP redirects in requests (`no-http-redirects`)
+# Avoid HTTP redirects (`no-http-redirects`)
 
 `no-http-redirects` checks if there are any HTTP redirects in the page
 `webhint` is analyzing.

--- a/packages/hint-no-http-redirects/src/hint.ts
+++ b/packages/hint-no-http-redirects/src/hint.ts
@@ -2,12 +2,12 @@
  * @fileoverview Checks if there are unnecesary redirects when accessign resources
  */
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
 // The list of types depends on the events you want to capture.
-import { IHint, FetchEnd, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint, FetchEnd } from 'hint/dist/src/lib/types';
 import cutString from 'hint/dist/src/lib/utils/misc/cut-string';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 /*
  * ------------------------------------------------------------------------------
@@ -17,28 +17,7 @@ import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 
 export default class NoHttpRedirectHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.performance,
-            description: `Checks if there are unnecesary redirects when accessign resources`
-        },
-        id: 'no-http-redirects',
-        schema: [{
-            additionalProperties: false,
-            properties: {
-                'max-html-redirects': {
-                    minimum: 0,
-                    type: 'integer'
-                },
-                'max-resource-redirects': {
-                    minimum: 0,
-                    type: 'integer'
-                }
-            },
-            type: 'object'
-        }],
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-no-http-redirects/src/meta.ts
+++ b/packages/hint-no-http-redirects/src/meta.ts
@@ -1,0 +1,29 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.performance,
+        description: `Checks if there are unnecesary redirects when accessign resources`,
+        name: 'Avoid HTTP redirects'
+    },
+    id: 'no-http-redirects',
+    schema: [{
+        additionalProperties: false,
+        properties: {
+            'max-html-redirects': {
+                minimum: 0,
+                type: 'integer'
+            },
+            'max-resource-redirects': {
+                minimum: 0,
+                type: 'integer'
+            }
+        },
+        type: 'object'
+    }],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-no-p3p/README.md
+++ b/packages/hint-no-p3p/README.md
@@ -1,4 +1,4 @@
-# Disallow `P3P` headers (`no-p3p`)
+# No `P3P` headers (`no-p3p`)
 
 `no-p3p` disallows the use of `P3P` in any form (headers, `rel`
 attribute, and `well-known` location).

--- a/packages/hint-no-p3p/src/hint.ts
+++ b/packages/hint-no-p3p/src/hint.ts
@@ -4,13 +4,13 @@
 
 import { URL } from 'url';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { ElementFound, FetchEnd, IHint, HintMetadata, ScanStart } from 'hint/dist/src/lib/types';
+import { ElementFound, FetchEnd, IHint, ScanStart } from 'hint/dist/src/lib/types';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { getIncludedHeaders } from 'hint/dist/src/lib/utils/hint-helpers';
+
+import meta from './meta';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -22,15 +22,7 @@ const debug: debug.IDebugger = d(__filename);
 
 export default class NoP3pHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.interoperability,
-            description: `Don't use P3P related headers or meta tags`
-        },
-        id: 'no-p3p',
-        schema: [],
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-no-p3p/src/meta.ts
+++ b/packages/hint-no-p3p/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.interoperability,
         description: `Don't use P3P related headers or meta tags`,
-        name: 'Disallow `P3P` headers'
+        name: 'No `P3P` headers'
     },
     id: 'no-p3p',
     schema: [],

--- a/packages/hint-no-p3p/src/meta.ts
+++ b/packages/hint-no-p3p/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.interoperability,
+        description: `Don't use P3P related headers or meta tags`,
+        name: 'Disallow `P3P` headers'
+    },
+    id: 'no-p3p',
+    schema: [],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-no-protocol-relative-urls/README.md
+++ b/packages/hint-no-protocol-relative-urls/README.md
@@ -1,4 +1,4 @@
-# Disallow protocol-relative URLs (`no-protocol-relative-urls`)
+# No protocol-relative URLs (`no-protocol-relative-urls`)
 
 `no-protocol-relative-urls` warns against using scheme-relative URLs
 (commonly known as protocol-relative URLs).

--- a/packages/hint-no-protocol-relative-urls/src/hint.ts
+++ b/packages/hint-no-protocol-relative-urls/src/hint.ts
@@ -8,12 +8,12 @@
  * ------------------------------------------------------------------------------
  */
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { ElementFound, IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { ElementFound, IHint } from 'hint/dist/src/lib/types';
 import cutString from 'hint/dist/src/lib/utils/misc/cut-string';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 const debug = d(__filename);
 
@@ -25,15 +25,7 @@ const debug = d(__filename);
 
 export default class NoProtocolRelativeUrlsHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.security,
-            description: 'Disallow protocol relative URLs'
-        },
-        id: 'no-protocol-relative-urls',
-        schema: [],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-no-protocol-relative-urls/src/meta.ts
+++ b/packages/hint-no-protocol-relative-urls/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.security,
+        description: 'Disallow protocol relative URLs',
+        name: 'Disallow protocol-relative URLs'
+    },
+    id: 'no-protocol-relative-urls',
+    schema: [],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-no-protocol-relative-urls/src/meta.ts
+++ b/packages/hint-no-protocol-relative-urls/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.security,
         description: 'Disallow protocol relative URLs',
-        name: 'Disallow protocol-relative URLs'
+        name: 'No protocol-relative URLs'
     },
     id: 'no-protocol-relative-urls',
     schema: [],

--- a/packages/hint-no-vulnerable-javascript-libraries/src/hint.ts
+++ b/packages/hint-no-vulnerable-javascript-libraries/src/hint.ts
@@ -8,10 +8,9 @@ import { promisify } from 'util';
 import { groupBy } from 'lodash';
 import * as semver from 'semver';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import * as logger from 'hint/dist/src/lib/utils/logging';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { IHint, CanEvaluateScript, Severity, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint, CanEvaluateScript, Severity } from 'hint/dist/src/lib/types';
 import { Library, Vulnerability } from './types';
 
 import loadJSONFile from 'hint/dist/src/lib/utils/fs/load-json-file';
@@ -20,7 +19,8 @@ import writeFileAsync from 'hint/dist/src/lib/utils/fs/write-file-async';
 import requestAsync from 'hint/dist/src/lib/utils/network/request-async';
 
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 const debug = d(__filename);
 
@@ -32,28 +32,7 @@ const debug = d(__filename);
 
 export default class NoVulnerableJavascriptLibrariesHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.security,
-            description: `This hint checks if the site is running any vulnerable library using https://snyk.io database`
-        },
-        id: 'no-vulnerable-javascript-libraries',
-        schema: [{
-            additionalProperties: false,
-            properties: {
-                severity: {
-                    pattern: '^(low|medium|high)$',
-                    type: 'string'
-                }
-            },
-            type: 'object'
-        }],
-        /*
-         * Snyk can not analize a file itself, it needs a connector.
-         * TODO: Change to any once the local connector has jsdom.
-         */
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-no-vulnerable-javascript-libraries/src/meta.ts
+++ b/packages/hint-no-vulnerable-javascript-libraries/src/meta.ts
@@ -1,0 +1,29 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.security,
+        description: `This hint checks if the site is running any vulnerable library using https://snyk.io database`,
+        name: 'No vulnerable libraries'
+    },
+    id: 'no-vulnerable-javascript-libraries',
+    schema: [{
+        additionalProperties: false,
+        properties: {
+            severity: {
+                pattern: '^(low|medium|high)$',
+                type: 'string'
+            }
+        },
+        type: 'object'
+    }],
+    /*
+     * Snyk can not analize a file itself, it needs a connector.
+     * TODO: Change to any once the local connector has jsdom.
+     */
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-performance-budget/src/hint.ts
+++ b/packages/hint-performance-budget/src/hint.ts
@@ -4,16 +4,16 @@
 
 import { URL } from 'url';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { IHint, FetchEnd, ScanEnd, Response, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint, FetchEnd, ScanEnd, Response } from 'hint/dist/src/lib/types';
 import isHTTPS from 'hint/dist/src/lib/utils/network/is-https';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
 import getHeaderValueNormalized from 'hint/dist/src/lib/utils/network/normalized-header-value';
 
 import { NetworkConfig, ResourceResponse, PerfBudgetConfig } from './types';
 import * as Connections from './connections';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -37,28 +37,7 @@ const defaultConfig: PerfBudgetConfig = {
 
 export default class PerformanceBudgetHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.performance,
-            description: `Performance budget checks if your site will load fast enough based on the size of your resources and a given connection speed`
-        },
-        id: 'performance-budget',
-        schema: [{
-            additionalProperties: false,
-            properties: {
-                connectionType: {
-                    oneOf: [{ enum: Connections.ids }],
-                    type: 'string'
-                },
-                loadTime: {
-                    minimum: 1,
-                    type: 'number'
-                }
-            },
-            type: 'object'
-        }],
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-performance-budget/src/meta.ts
+++ b/packages/hint-performance-budget/src/meta.ts
@@ -1,0 +1,31 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+import * as Connections from './connections';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.performance,
+        description: `Performance budget checks if your site will load fast enough based on the size of your resources and a given connection speed`,
+        name: 'Performance budget'
+    },
+    id: 'performance-budget',
+    schema: [{
+        additionalProperties: false,
+        properties: {
+            connectionType: {
+                oneOf: [{ enum: Connections.ids }],
+                type: 'string'
+            },
+            loadTime: {
+                minimum: 1,
+                type: 'number'
+            }
+        },
+        type: 'object'
+    }],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-sri/README.md
+++ b/packages/hint-sri/README.md
@@ -1,4 +1,4 @@
-# Require scripts and styles to use subresource integrity (`sri`)
+# Use subresource integrity (`sri`)
 
 `sri` warns about requesting scripts or stylesheets without using
 subresource integrity.

--- a/packages/hint-sri/src/hint.ts
+++ b/packages/hint-sri/src/hint.ts
@@ -8,12 +8,13 @@ import { promisify } from 'util';
 
 import * as async from 'async';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata, FetchEnd } from 'hint/dist/src/lib/types';
+import { IHint, FetchEnd } from 'hint/dist/src/lib/types';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import { algorithms } from './types';
+import meta from './meta';
 
 const debug: debug.IDebugger = d(__filename);
 const everySeries = promisify(async.everySeries) as (arr: any, iterator: any) => Promise<any>;
@@ -24,32 +25,9 @@ const everySeries = promisify(async.everySeries) as (arr: any, iterator: any) =>
  * ------------------------------------------------------------------------------
  */
 
-// We don't do a `const enum` because of this: https://stackoverflow.com/questions/18111657/how-does-one-get-the-names-of-typescript-enum-entries#comment52596297_18112157
-enum algorithms {
-    sha256 = 1,
-    sha384 = 2,
-    sha512 = 3
-}
-
 export default class SRIHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.security,
-            description: `Require scripts and link elements to use Subresource Integrity`
-        },
-        id: 'sri',
-        schema: [{
-            additionalProperties: false,
-            properties: {
-                baseline: {
-                    oneOf: [Object.keys(algorithms)],
-                    type: 'string'
-                }
-            }
-        }],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     private context: HintContext;
     private origin: string = '';

--- a/packages/hint-sri/src/meta.ts
+++ b/packages/hint-sri/src/meta.ts
@@ -8,7 +8,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.security,
         description: `Require scripts and link elements to use Subresource Integrity`,
-        name: ''
+        name: 'Use subresource integrity'
     },
     id: 'sri',
     schema: [{

--- a/packages/hint-sri/src/meta.ts
+++ b/packages/hint-sri/src/meta.ts
@@ -1,0 +1,26 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+import { algorithms } from './types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.security,
+        description: `Require scripts and link elements to use Subresource Integrity`,
+        name: ''
+    },
+    id: 'sri',
+    schema: [{
+        additionalProperties: false,
+        properties: {
+            baseline: {
+                oneOf: [Object.keys(algorithms)],
+                type: 'string'
+            }
+        }
+    }],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-sri/src/types.ts
+++ b/packages/hint-sri/src/types.ts
@@ -1,0 +1,6 @@
+// We don't do a `const enum` because of this: https://stackoverflow.com/questions/18111657/how-does-one-get-the-names-of-typescript-enum-entries#comment52596297_18112157
+export enum algorithms {
+    sha256 = 1,
+    sha384 = 2,
+    sha512 = 3
+}

--- a/packages/hint-ssllabs/README.md
+++ b/packages/hint-ssllabs/README.md
@@ -1,4 +1,4 @@
-# SSL Server Test (`ssllabs`)
+# SSL server test (`ssllabs`)
 
 `ssllabs` does a deep analysis of the site's SSL configuration using
 [SSL Labs’ SSL Server Test][ssllabs].

--- a/packages/hint-ssllabs/src/hint.ts
+++ b/packages/hint-ssllabs/src/hint.ts
@@ -13,12 +13,12 @@
 
 import { promisify } from 'util';
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { FetchEnd, ScanEnd, IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { FetchEnd, ScanEnd, IHint } from 'hint/dist/src/lib/types';
 import { Grades, SSLLabsEndpoint, SSLLabsOptions, SSLLabsResult } from './types';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 const debug = d(__filename);
 
@@ -30,41 +30,7 @@ const debug = d(__filename);
 
 export default class SSLLabsHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.security,
-            description: 'Strength of your SSL configuration'
-        },
-        id: 'ssllabs',
-        schema: [{
-            additionalProperties: false,
-            properties: {
-                grade: {
-                    pattern: '^(A\\+|A\\-|[A-F]|T|M)$',
-                    type: 'string'
-                },
-                ssllabs: {
-                    properties: {
-                        all: {
-                            pattern: '^(on|done)$',
-                            type: 'string'
-                        },
-                        fromCache: { type: 'boolean' },
-                        ignoreMismatch: { type: 'boolean' },
-                        maxAge: {
-                            minimum: 0,
-                            type: 'integer'
-                        },
-                        publish: { type: 'boolean' },
-                        startNew: { type: 'boolean' }
-                    },
-                    type: 'object'
-                }
-            },
-            type: 'object'
-        }],
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-ssllabs/src/meta.ts
+++ b/packages/hint-ssllabs/src/meta.ts
@@ -1,0 +1,42 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.security,
+        description: 'Strength of your SSL configuration',
+        name: 'SSL server test'
+    },
+    id: 'ssllabs',
+    schema: [{
+        additionalProperties: false,
+        properties: {
+            grade: {
+                pattern: '^(A\\+|A\\-|[A-F]|T|M)$',
+                type: 'string'
+            },
+            ssllabs: {
+                properties: {
+                    all: {
+                        pattern: '^(on|done)$',
+                        type: 'string'
+                    },
+                    fromCache: { type: 'boolean' },
+                    ignoreMismatch: { type: 'boolean' },
+                    maxAge: {
+                        minimum: 0,
+                        type: 'integer'
+                    },
+                    publish: { type: 'boolean' },
+                    startNew: { type: 'boolean' }
+                },
+                type: 'object'
+            }
+        },
+        type: 'object'
+    }],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-strict-transport-security/README.md
+++ b/packages/hint-strict-transport-security/README.md
@@ -1,4 +1,4 @@
-# Require `Strict-Transport-Security` response header (`strict-transport-security`)
+# Use `Strict-Transport-Security` header (`strict-transport-security`)
 
 `strict-transport-security` warns against serving resources over
 HTTPS without `strict-transport-security` header and validates the

--- a/packages/hint-strict-transport-security/src/hint.ts
+++ b/packages/hint-strict-transport-security/src/hint.ts
@@ -4,12 +4,12 @@
 import * as url from 'url';
 import { URL } from 'url'; // this is necessary to avoid TypeScript mixes types.
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { FetchEnd, IHint, NetworkData, HintMetadata } from 'hint/dist/src/lib/types';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { FetchEnd, IHint, NetworkData } from 'hint/dist/src/lib/types';
 import isRegularProtocol from 'hint/dist/src/lib/utils/network/is-regular-protocol';
+
+import meta from './meta';
 
 const debug = d(__filename);
 
@@ -21,20 +21,7 @@ const debug = d(__filename);
 
 export default class StrictTransportSecurityHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.security,
-            description: `Require 'Strict-Transport-Security' header`
-        },
-        id: 'strict-transport-security',
-        schema: [{
-            properties: {
-                checkPreload: { type: 'boolean' },
-                minMaxAgeValue: { type: 'number' }
-            }
-        }],
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-strict-transport-security/src/meta.ts
+++ b/packages/hint-strict-transport-security/src/meta.ts
@@ -1,0 +1,21 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.security,
+        description: `Require 'Strict-Transport-Security' header`,
+        name: 'Require `Strict-Transport-Security` header'
+    },
+    id: 'strict-transport-security',
+    schema: [{
+        properties: {
+            checkPreload: { type: 'boolean' },
+            minMaxAgeValue: { type: 'number' }
+        }
+    }],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-strict-transport-security/src/meta.ts
+++ b/packages/hint-strict-transport-security/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.security,
         description: `Require 'Strict-Transport-Security' header`,
-        name: 'Require `Strict-Transport-Security` header'
+        name: 'Use `Strict-Transport-Security` header'
     },
     id: 'strict-transport-security',
     schema: [{

--- a/packages/hint-stylesheet-limits/README.md
+++ b/packages/hint-stylesheet-limits/README.md
@@ -1,4 +1,4 @@
-# Avoid exceeding CSS stylesheet limits (`stylesheet-limits`)
+# Avoid CSS limits (`stylesheet-limits`)
 
 `stylesheet-limits` checks if CSS exceeds known stylesheet limits.
 

--- a/packages/hint-stylesheet-limits/src/hint.ts
+++ b/packages/hint-stylesheet-limits/src/hint.ts
@@ -2,10 +2,10 @@
  * @fileoverview Checks if CSS exceeds known stylesheet limits.
  */
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata, CanEvaluateScript } from 'hint/dist/src/lib/types';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { IHint, CanEvaluateScript } from 'hint/dist/src/lib/types';
+
+import meta from './meta';
 
 /*
  * ------------------------------------------------------------------------------
@@ -15,29 +15,7 @@ import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 
 export default class StylesheetLimitsHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.interoperability,
-            description: `Checks if CSS exceeds known stylesheet limits.`
-        },
-        id: 'stylesheet-limits',
-        schema: [{
-            additionalProperties: false,
-            definitions: {
-                number: {
-                    minimum: 0,
-                    type: 'integer'
-                }
-            },
-            properties: {
-                maxImports: { $ref: '#/definitions/number' },
-                maxRules: { $ref: '#/definitions/number' },
-                maxSheets: { $ref: '#/definitions/number' }
-            },
-            type: ['object', 'null']
-        }],
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-stylesheet-limits/src/meta.ts
+++ b/packages/hint-stylesheet-limits/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.interoperability,
         description: `Checks if CSS exceeds known stylesheet limits.`,
-        name: 'Avoid exceeding CSS stylesheet limits'
+        name: 'Avoid CSS limits'
     },
     id: 'stylesheet-limits',
     schema: [{

--- a/packages/hint-stylesheet-limits/src/meta.ts
+++ b/packages/hint-stylesheet-limits/src/meta.ts
@@ -1,0 +1,30 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.interoperability,
+        description: `Checks if CSS exceeds known stylesheet limits.`,
+        name: 'Avoid exceeding CSS stylesheet limits'
+    },
+    id: 'stylesheet-limits',
+    schema: [{
+        additionalProperties: false,
+        definitions: {
+            number: {
+                minimum: 0,
+                type: 'integer'
+            }
+        },
+        properties: {
+            maxImports: { $ref: '#/definitions/number' },
+            maxRules: { $ref: '#/definitions/number' },
+            maxSheets: { $ref: '#/definitions/number' }
+        },
+        type: ['object', 'null']
+    }],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-typescript-config/docs/consistent-casing.md
+++ b/packages/hint-typescript-config/docs/consistent-casing.md
@@ -1,4 +1,4 @@
-# Enable consistent casing in TypeScript configuration (`consistent-casing`)
+# TypeScript consistent casing (`consistent-casing`)
 
 `typescript-config/consistent-casing` checks if the property `forceConsistentCasingInFileNames`
 is enabled in your TypeScript configuration file (i.e. `tsconfig.json`).

--- a/packages/hint-typescript-config/docs/import-helpers.md
+++ b/packages/hint-typescript-config/docs/import-helpers.md
@@ -1,4 +1,4 @@
-# Enable import helpers in TypeScript configuration(`import-helpers`)
+# TypeScript import helpers (`import-helpers`)
 
 `typescript-config/import-helpers` checks if the property `importHelpers`
 is enabled in your TypeScript configuration file (i.e. `tsconfig.json`) and

--- a/packages/hint-typescript-config/docs/is-valid.md
+++ b/packages/hint-typescript-config/docs/is-valid.md
@@ -1,4 +1,4 @@
-# TypeScript configuration is valid (`is-valid`)
+# Valid TypeScript configuration (`is-valid`)
 
 ## Why is this important?
 

--- a/packages/hint-typescript-config/docs/no-comments.md
+++ b/packages/hint-typescript-config/docs/no-comments.md
@@ -1,4 +1,4 @@
-# Enable remove comments in TypeScript configuration (`no-comments`)
+# TypeScript remove comments (`no-comments`)
 
 `typescript-config/no-comments` checks that the property `removeComments`
 is enabled in your TypeScript configuration file (i.e. `tsconfig.json`).

--- a/packages/hint-typescript-config/docs/strict.md
+++ b/packages/hint-typescript-config/docs/strict.md
@@ -1,4 +1,4 @@
-# Enable strict option in TypeScript configuration (`strict`)
+# TypeScript strict (`strict`)
 
 `typescript-config/strict` checks if the property `strict`
 is enabled in your TypeScript configuration file (i.e. `tsconfig.json`).

--- a/packages/hint-typescript-config/docs/target.md
+++ b/packages/hint-typescript-config/docs/target.md
@@ -1,4 +1,4 @@
-# Check if the TypeScript target is appropriate (`target`)
+# TypeScript target (`target`)
 
 `typescript-config/target` takes into account your `webhint`'s
 `browserslist` configuration and warns you if your `target`

--- a/packages/hint-typescript-config/src/consistent-casing.ts
+++ b/packages/hint-typescript-config/src/consistent-casing.ts
@@ -3,11 +3,11 @@
  * is enabled in the TypeScript configuration file (i.e `tsconfig.json`).
  */
 import { TypeScriptConfigEvents } from '@hint/parser-typescript-config';
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint } from 'hint/dist/src/lib/types';
 import { configChecker } from './helpers/config-checker';
+
+import meta from './meta/consistent-casing';
 
 /*
  * ------------------------------------------------------------------------------
@@ -16,15 +16,7 @@ import { configChecker } from './helpers/config-checker';
  */
 
 export default class TypeScriptConfigConsistentCasing implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.development,
-            description: '`typescript-config/consistent-casing` checks if the property `forceConsistentCasingInFileNames` is enabled in the TypeScript configuration file (i.e `tsconfig.json`)'
-        },
-        id: 'typescript-config/consistent-casing',
-        schema: [],
-        scope: HintScope.local
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<TypeScriptConfigEvents>) {
         const validate = configChecker('compilerOptions.forceConsistentCasingInFileNames', true, 'The compiler option "forceConsistentCasingInFileNames" should be enabled to reduce issues when working with different OSes.', context);

--- a/packages/hint-typescript-config/src/import-helpers.ts
+++ b/packages/hint-typescript-config/src/import-helpers.ts
@@ -6,14 +6,14 @@
 import * as path from 'path';
 
 import { TypeScriptConfigEvents } from '@hint/parser-typescript-config';
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata, ScanEnd } from 'hint/dist/src/lib/types';
+import { IHint, ScanEnd } from 'hint/dist/src/lib/types';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 import loadPackage from 'hint/dist/src/lib/utils/packages/load-package';
 
 import { configChecker } from './helpers/config-checker';
+
+import meta from './meta/import-helpers';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -24,15 +24,7 @@ const debug: debug.IDebugger = d(__filename);
  */
 
 export default class TypeScriptConfigImportHelpers implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.development,
-            description: '`typescript-config/import-helpers` checks if the property `importHelpers` is enabled in the TypeScript configuration file (i.e `tsconfig.json`) to reduce the output size.'
-        },
-        id: 'typescript-config/import-helpers',
-        schema: [],
-        scope: HintScope.local
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<TypeScriptConfigEvents>) {
         const validate = configChecker('compilerOptions.importHelpers', true, 'The compiler option "importHelpers" should be enabled to reduce the output size.', context);

--- a/packages/hint-typescript-config/src/is-valid.ts
+++ b/packages/hint-typescript-config/src/is-valid.ts
@@ -1,10 +1,8 @@
 /**
  * @fileoverview `typescript-config/is-valid` warns against providing an invalid TypeScript configuration file `tsconfig.json`.
  */
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint } from 'hint/dist/src/lib/types';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 
 import {
@@ -12,6 +10,8 @@ import {
     TypeScriptConfigInvalidJSON,
     TypeScriptConfigInvalidSchema
 } from '@hint/parser-typescript-config';
+
+import meta from './meta/is-valid';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -22,15 +22,7 @@ const debug: debug.IDebugger = d(__filename);
  */
 
 export default class TypeScriptConfigIsValid implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.development,
-            description: '`typescript-config/is-valid` warns against providing an invalid TypeScript configuration file `tsconfig.json`'
-        },
-        id: 'typescript-config/is-valid',
-        schema: [],
-        scope: HintScope.local
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<TypeScriptConfigEvents>) {
 

--- a/packages/hint-typescript-config/src/meta.ts
+++ b/packages/hint-typescript-config/src/meta.ts
@@ -1,0 +1,8 @@
+module.exports = {
+    'consistent-casing': require('./meta/consistent-casing'),
+    'import-helpers': require('./meta/import-helpers'),
+    'is-valid': require('./meta/is-valid'),
+    'no-comments': require('./meta/no-comments'),
+    strict: require('./meta/strict'),
+    target: require('./meta/target')
+};

--- a/packages/hint-typescript-config/src/meta/consistent-casing.ts
+++ b/packages/hint-typescript-config/src/meta/consistent-casing.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.development,
         description: '`typescript-config/consistent-casing` checks if the property `forceConsistentCasingInFileNames` is enabled in the TypeScript configuration file (i.e `tsconfig.json`)',
-        name: 'Enable consistent casing in TypeScript configuration'
+        name: 'TypeScript consistent casing'
     },
     id: 'typescript-config/consistent-casing',
     schema: [],

--- a/packages/hint-typescript-config/src/meta/consistent-casing.ts
+++ b/packages/hint-typescript-config/src/meta/consistent-casing.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.development,
+        description: '`typescript-config/consistent-casing` checks if the property `forceConsistentCasingInFileNames` is enabled in the TypeScript configuration file (i.e `tsconfig.json`)',
+        name: 'Enable consistent casing in TypeScript configuration'
+    },
+    id: 'typescript-config/consistent-casing',
+    schema: [],
+    scope: HintScope.local
+};
+
+export default meta;

--- a/packages/hint-typescript-config/src/meta/import-helpers.ts
+++ b/packages/hint-typescript-config/src/meta/import-helpers.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.development,
+        description: '`typescript-config/import-helpers` checks if the property `importHelpers` is enabled in the TypeScript configuration file (i.e `tsconfig.json`) to reduce the output size.',
+        name: 'Enable import helpers in TypeScript configuration'
+    },
+    id: 'typescript-config/import-helpers',
+    schema: [],
+    scope: HintScope.local
+};
+
+export default meta;

--- a/packages/hint-typescript-config/src/meta/import-helpers.ts
+++ b/packages/hint-typescript-config/src/meta/import-helpers.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.development,
         description: '`typescript-config/import-helpers` checks if the property `importHelpers` is enabled in the TypeScript configuration file (i.e `tsconfig.json`) to reduce the output size.',
-        name: 'Enable import helpers in TypeScript configuration'
+        name: 'TypeScript import helpers'
     },
     id: 'typescript-config/import-helpers',
     schema: [],

--- a/packages/hint-typescript-config/src/meta/is-valid.ts
+++ b/packages/hint-typescript-config/src/meta/is-valid.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.development,
+        description: '`typescript-config/is-valid` warns against providing an invalid TypeScript configuration file `tsconfig.json`',
+        name: 'TypeScript configuration is valid'
+    },
+    id: 'typescript-config/is-valid',
+    schema: [],
+    scope: HintScope.local
+};
+
+export default meta;

--- a/packages/hint-typescript-config/src/meta/is-valid.ts
+++ b/packages/hint-typescript-config/src/meta/is-valid.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.development,
         description: '`typescript-config/is-valid` warns against providing an invalid TypeScript configuration file `tsconfig.json`',
-        name: 'TypeScript configuration is valid'
+        name: 'Valid TypeScript configuration'
     },
     id: 'typescript-config/is-valid',
     schema: [],

--- a/packages/hint-typescript-config/src/meta/no-comments.ts
+++ b/packages/hint-typescript-config/src/meta/no-comments.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.development,
+        description: '`typescript-config/no-comments` checks if the property `removeComments` is enabled in the TypeScript configuration file (i.e `tsconfig.json`)',
+        name: 'Enable remove comments in TypeScript configuration'
+    },
+    id: 'typescript-config/no-comments',
+    schema: [],
+    scope: HintScope.local
+};
+
+export default meta;

--- a/packages/hint-typescript-config/src/meta/no-comments.ts
+++ b/packages/hint-typescript-config/src/meta/no-comments.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.development,
         description: '`typescript-config/no-comments` checks if the property `removeComments` is enabled in the TypeScript configuration file (i.e `tsconfig.json`)',
-        name: 'Enable remove comments in TypeScript configuration'
+        name: 'TypeScript remove comments'
     },
     id: 'typescript-config/no-comments',
     schema: [],

--- a/packages/hint-typescript-config/src/meta/strict.ts
+++ b/packages/hint-typescript-config/src/meta/strict.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.development,
         description: '`typescript-config/strict` checks if the property `strict` is enabled in the TypeScript configuration file (i.e `tsconfig.json`).',
-        name: 'Enable strict option in TypeScript configuration'
+        name: 'TypeScript strict'
     },
     id: 'typescript-config/strict',
     schema: [],

--- a/packages/hint-typescript-config/src/meta/strict.ts
+++ b/packages/hint-typescript-config/src/meta/strict.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.development,
+        description: '`typescript-config/strict` checks if the property `strict` is enabled in the TypeScript configuration file (i.e `tsconfig.json`).',
+        name: 'Enable strict option in TypeScript configuration'
+    },
+    id: 'typescript-config/strict',
+    schema: [],
+    scope: HintScope.local
+};
+
+export default meta;

--- a/packages/hint-typescript-config/src/meta/target.ts
+++ b/packages/hint-typescript-config/src/meta/target.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.development,
+        description: '`typescript-config/target` warns against providing a `compilerOptions.target` in the TypeScript configuration file (i.e `tsconfig.json`) not optimized for the defined `browserslist` values.',
+        name: 'Check if the TypeScript target is appropriate'
+    },
+    id: 'typescript-config/target',
+    schema: [],
+    scope: HintScope.local
+};
+
+export default meta;

--- a/packages/hint-typescript-config/src/meta/target.ts
+++ b/packages/hint-typescript-config/src/meta/target.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.development,
         description: '`typescript-config/target` warns against providing a `compilerOptions.target` in the TypeScript configuration file (i.e `tsconfig.json`) not optimized for the defined `browserslist` values.',
-        name: 'Check if the TypeScript target is appropriate'
+        name: 'TypeScript target'
     },
     id: 'typescript-config/target',
     schema: [],

--- a/packages/hint-typescript-config/src/no-comments.ts
+++ b/packages/hint-typescript-config/src/no-comments.ts
@@ -3,13 +3,13 @@
  * property `removeComments` is enabled in your TypeScript configuration
  * file (i.e `tsconfig.json`).
  */
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint } from 'hint/dist/src/lib/types';
 import { configChecker } from './helpers/config-checker';
 
 import { TypeScriptConfigEvents } from '@hint/parser-typescript-config';
+
+import meta from './meta/no-comments';
 
 /*
  * ------------------------------------------------------------------------------
@@ -18,15 +18,7 @@ import { TypeScriptConfigEvents } from '@hint/parser-typescript-config';
  */
 
 export default class TypeScriptConfigNoComments implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.development,
-            description: '`typescript-config/no-comments` checks if the property `removeComments` is enabled in the TypeScript configuration file (i.e `tsconfig.json`)'
-        },
-        id: 'typescript-config/no-comments',
-        schema: [],
-        scope: HintScope.local
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<TypeScriptConfigEvents>) {
         const validate = configChecker('compilerOptions.removeComments', true, 'The compiler option "removeComments" should be enabled to reduce the output size.', context);

--- a/packages/hint-typescript-config/src/strict.ts
+++ b/packages/hint-typescript-config/src/strict.ts
@@ -2,13 +2,13 @@
  * @fileoverview `typescript-config/strict` checks if the property `strict`
  * is enabled in the TypeScript configuration file (i.e `tsconfig.json`).
  */
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint } from 'hint/dist/src/lib/types';
 import { configChecker } from './helpers/config-checker';
 
 import { TypeScriptConfigEvents } from '@hint/parser-typescript-config';
+
+import meta from './meta/strict';
 
 /*
  * ------------------------------------------------------------------------------
@@ -17,15 +17,7 @@ import { TypeScriptConfigEvents } from '@hint/parser-typescript-config';
  */
 
 export default class TypeScriptConfigStrict implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.development,
-            description: '`typescript-config/strict` checks if the property `strict` is enabled in the TypeScript configuration file (i.e `tsconfig.json`).'
-        },
-        id: 'typescript-config/strict',
-        schema: [],
-        scope: HintScope.local
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<TypeScriptConfigEvents>) {
         const validate = configChecker('compilerOptions.strict', true, 'The compiler option "strict" should be enabled to reduce type errors.', context);

--- a/packages/hint-typescript-config/src/target.ts
+++ b/packages/hint-typescript-config/src/target.ts
@@ -3,12 +3,12 @@
  * in the TypeScript configuration file (i.e `tsconfig.json`) not optimized for the defined
  * `browserslist` values.
  */
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint } from 'hint/dist/src/lib/types';
 
 import { TypeScriptConfigEvents, TypeScriptConfigParse, TypeScriptConfig } from '@hint/parser-typescript-config';
+
+import meta from './meta/target';
 
 /*
  * ------------------------------------------------------------------------------
@@ -30,15 +30,7 @@ type Browsers = {
 };
 
 export default class TypeScriptConfigTarget implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.development,
-            description: '`typescript-config/target` warns against providing a `compilerOptions.target` in the TypeScript configuration file (i.e `tsconfig.json`) not optimized for the defined `browserslist` values.'
-        },
-        id: 'typescript-config/target',
-        schema: [],
-        scope: HintScope.local
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<TypeScriptConfigEvents>) {
         const Targets: Map<string, string> = new Map([

--- a/packages/hint-validate-set-cookie-header/README.md
+++ b/packages/hint-validate-set-cookie-header/README.md
@@ -1,4 +1,4 @@
-# Validate `Set-Cookie` Header (`validate-set-cookie-header`)
+# Valid `Set-Cookie` header (`validate-set-cookie-header`)
 
 This hint validates the `set-cookie` header and confirms that
 the `Secure` and `HttpOnly` directives are defined when sent from

--- a/packages/hint-validate-set-cookie-header/src/hint.ts
+++ b/packages/hint-validate-set-cookie-header/src/hint.ts
@@ -2,15 +2,15 @@
  * @fileoverview This hint validates the `set-cookie` header and confirms that it is sent with `Secure` and `HttpOnly` directive over HTTPS.
  */
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { FetchEnd, IHint, Severity, HintMetadata } from 'hint/dist/src/lib/types';
+import { FetchEnd, IHint, Severity } from 'hint/dist/src/lib/types';
 import isHTTPS from 'hint/dist/src/lib/utils/network/is-https';
 import isRegularProtocol from 'hint/dist/src/lib/utils/network/is-regular-protocol';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
 import { ParsedSetCookieHeader } from './types';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+
+import meta from './meta';
 
 const debug = d(__filename);
 
@@ -22,16 +22,7 @@ const debug = d(__filename);
 
 export default class ValidateSetCookieHeaderHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.security,
-            description: 'This hint validates the `set-cookie` header and confirms that it is sent with `Secure` and `HttpOnly` directive over HTTPS.'
-        },
-        id: 'validate-set-cookie-header',
-        ignoredConnectors: [],
-        schema: [],
-        scope: HintScope.site
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 

--- a/packages/hint-validate-set-cookie-header/src/meta.ts
+++ b/packages/hint-validate-set-cookie-header/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.security,
         description: 'This hint validates the `set-cookie` header and confirms that it is sent with `Secure` and `HttpOnly` directive over HTTPS.',
-        name: 'Validate `Set-Cookie` header'
+        name: 'Valid `Set-Cookie` header'
     },
     id: 'validate-set-cookie-header',
     ignoredConnectors: [],

--- a/packages/hint-validate-set-cookie-header/src/meta.ts
+++ b/packages/hint-validate-set-cookie-header/src/meta.ts
@@ -1,0 +1,17 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.security,
+        description: 'This hint validates the `set-cookie` header and confirms that it is sent with `Secure` and `HttpOnly` directive over HTTPS.',
+        name: 'Validate `Set-Cookie` header'
+    },
+    id: 'validate-set-cookie-header',
+    ignoredConnectors: [],
+    schema: [],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint-webpack-config/docs/config-exists.md
+++ b/packages/hint-webpack-config/docs/config-exists.md
@@ -1,4 +1,4 @@
-# Check if webpack configuration file exists (`config-exists`)
+# Has webpack configuration (`config-exists`)
 
 ## Why is this important?
 

--- a/packages/hint-webpack-config/docs/is-installed.md
+++ b/packages/hint-webpack-config/docs/is-installed.md
@@ -1,4 +1,4 @@
-# Check if webpack is installed (`is-installed`)
+# Has webpack (`is-installed`)
 
 ## Why is this important?
 

--- a/packages/hint-webpack-config/docs/is-valid.md
+++ b/packages/hint-webpack-config/docs/is-valid.md
@@ -1,4 +1,4 @@
-# webpack configuration is valid (`is-valid`)
+# Valid webpack configuration (`is-valid`)
 
 ## Why is this important?
 

--- a/packages/hint-webpack-config/docs/module-esnext-typescript.md
+++ b/packages/hint-webpack-config/docs/module-esnext-typescript.md
@@ -1,4 +1,4 @@
-# Validate `module` property in TypeScript has the appropriate value for webpack (`module-esnext-typescript`)
+# webpack compatible TypeScript `module` (`module-esnext-typescript`)
 
 ## Why is this important?
 

--- a/packages/hint-webpack-config/docs/modules-false-babel.md
+++ b/packages/hint-webpack-config/docs/modules-false-babel.md
@@ -1,4 +1,4 @@
-# Validate `modules` property in Babel has the appropriate value for webpack (`modules-false-babel`)
+# No Babel `modules` with webpack (`modules-false-babel`)
 
 ## Why is this important?
 

--- a/packages/hint-webpack-config/docs/no-devtool-in-prod.md
+++ b/packages/hint-webpack-config/docs/no-devtool-in-prod.md
@@ -1,4 +1,4 @@
-# Check `devtool` property in webpack configuration (`no-devtool-in-prod`)
+# No production `devtool` in webpack (`no-devtool-in-prod`)
 
 ## Why is this important?
 

--- a/packages/hint-webpack-config/src/config-exists.ts
+++ b/packages/hint-webpack-config/src/config-exists.ts
@@ -1,13 +1,13 @@
 /**
  * @fileoverview `webpack-config/config-exists` warns against not having a webpack configuration file.
  */
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint } from 'hint/dist/src/lib/types';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 
 import { WebpackConfigEvents } from '@hint/parser-webpack-config';
+
+import meta from './meta/config-exists';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -18,15 +18,7 @@ const debug: debug.IDebugger = d(__filename);
  */
 
 export default class WebpackConfigConfigExists implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.development,
-            description: '`webpack-config/config-exists` warns against not having a webpack configuration file'
-        },
-        id: 'webpack-config/config-exists',
-        schema: [],
-        scope: HintScope.local
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<WebpackConfigEvents>) {
 

--- a/packages/hint-webpack-config/src/is-installed.ts
+++ b/packages/hint-webpack-config/src/is-installed.ts
@@ -1,13 +1,13 @@
 /**
  * @fileoverview `webpack-config/is-installed` warns against not having webpack installed.
  */
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint } from 'hint/dist/src/lib/types';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 
 import { WebpackConfigEvents } from '@hint/parser-webpack-config';
+
+import meta from './meta/is-installed';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -18,15 +18,7 @@ const debug: debug.IDebugger = d(__filename);
  */
 
 export default class WebpackConfigIsInstalled implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.development,
-            description: '`webpack-config/is-installed` warns against not having webpack installed'
-        },
-        id: 'webpack-config/is-installed',
-        schema: [],
-        scope: HintScope.local
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<WebpackConfigEvents>) {
 

--- a/packages/hint-webpack-config/src/is-valid.ts
+++ b/packages/hint-webpack-config/src/is-valid.ts
@@ -1,13 +1,13 @@
 /**
  * @fileoverview `webpack-config/is-valid` warns against providing an invalid webpack configuration file `webpack.config.js`.
  */
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint } from 'hint/dist/src/lib/types';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 
 import { WebpackConfigEvents, WebpackConfigInvalidConfiguration } from '@hint/parser-webpack-config';
+
+import meta from './meta/is-valid';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -18,15 +18,7 @@ const debug: debug.IDebugger = d(__filename);
  */
 
 export default class WebpackConfigIsValid implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.development,
-            description: '`webpack-config/is-valid` warns against providing an invalid webpack configuration file `webpack.config.js`'
-        },
-        id: 'webpack-config/is-valid',
-        schema: [],
-        scope: HintScope.local
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<WebpackConfigEvents>) {
 

--- a/packages/hint-webpack-config/src/meta.ts
+++ b/packages/hint-webpack-config/src/meta.ts
@@ -1,0 +1,8 @@
+module.exports = {
+    'config-exists': require('./meta/config-exists'),
+    'is-installed': require('./meta/is-installed'),
+    'is-valid': require('./meta/is-valid'),
+    'module-esnext-typescript': require('./meta/module-esnext-typescript'),
+    'modules-false-babel': require('./meta/modules-false-babel'),
+    'no-devtool-in-prod': require('./meta/no-devtool-in-prod')
+};

--- a/packages/hint-webpack-config/src/meta/config-exists.ts
+++ b/packages/hint-webpack-config/src/meta/config-exists.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.development,
+        description: '`webpack-config/config-exists` warns against not having a webpack configuration file',
+        name: 'webpack configuration exists'
+    },
+    id: 'webpack-config/config-exists',
+    schema: [],
+    scope: HintScope.local
+};
+
+export default meta;

--- a/packages/hint-webpack-config/src/meta/config-exists.ts
+++ b/packages/hint-webpack-config/src/meta/config-exists.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.development,
         description: '`webpack-config/config-exists` warns against not having a webpack configuration file',
-        name: 'webpack configuration exists'
+        name: 'Has webpack configuration'
     },
     id: 'webpack-config/config-exists',
     schema: [],

--- a/packages/hint-webpack-config/src/meta/is-installed.ts
+++ b/packages/hint-webpack-config/src/meta/is-installed.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.development,
+        description: '`webpack-config/is-installed` warns against not having webpack installed',
+        name: 'webpack is installed'
+    },
+    id: 'webpack-config/is-installed',
+    schema: [],
+    scope: HintScope.local
+};
+
+export default meta;

--- a/packages/hint-webpack-config/src/meta/is-installed.ts
+++ b/packages/hint-webpack-config/src/meta/is-installed.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.development,
         description: '`webpack-config/is-installed` warns against not having webpack installed',
-        name: 'webpack is installed'
+        name: 'Has webpack'
     },
     id: 'webpack-config/is-installed',
     schema: [],

--- a/packages/hint-webpack-config/src/meta/is-valid.ts
+++ b/packages/hint-webpack-config/src/meta/is-valid.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.development,
+        description: '`webpack-config/is-valid` warns against providing an invalid webpack configuration file `webpack.config.js`',
+        name: 'webpack configuration is valid'
+    },
+    id: 'webpack-config/is-valid',
+    schema: [],
+    scope: HintScope.local
+};
+
+export default meta;

--- a/packages/hint-webpack-config/src/meta/is-valid.ts
+++ b/packages/hint-webpack-config/src/meta/is-valid.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.development,
         description: '`webpack-config/is-valid` warns against providing an invalid webpack configuration file `webpack.config.js`',
-        name: 'webpack configuration is valid'
+        name: 'Valid webpack configuration'
     },
     id: 'webpack-config/is-valid',
     schema: [],

--- a/packages/hint-webpack-config/src/meta/module-esnext-typescript.ts
+++ b/packages/hint-webpack-config/src/meta/module-esnext-typescript.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.development,
         description: '`webpack-config/module-esnext-typescript` warns against not having set the propety `compilerOptions.module` to `esnext` in typescript configuration file',
-        name: 'TypeScript `module` is `esnext` with webpack'
+        name: 'webpack compatible TypeScript `module`'
     },
     id: 'webpack-config/module-esnext-typescript',
     schema: [],

--- a/packages/hint-webpack-config/src/meta/module-esnext-typescript.ts
+++ b/packages/hint-webpack-config/src/meta/module-esnext-typescript.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.development,
+        description: '`webpack-config/module-esnext-typescript` warns against not having set the propety `compilerOptions.module` to `esnext` in typescript configuration file',
+        name: 'TypeScript `module` is `esnext` with webpack'
+    },
+    id: 'webpack-config/module-esnext-typescript',
+    schema: [],
+    scope: HintScope.local
+};
+
+export default meta;

--- a/packages/hint-webpack-config/src/meta/modules-false-babel.ts
+++ b/packages/hint-webpack-config/src/meta/modules-false-babel.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.development,
         description: '`webpack-config/modules-false-babel` warns against not having set the propety `modules` to `false` in presets in babel configuration file',
-        name: 'Babel `modules` is `false` with webpack'
+        name: 'No Babel `modules` with webpack'
     },
     id: 'webpack-config/modules-false-babel',
     schema: [],

--- a/packages/hint-webpack-config/src/meta/modules-false-babel.ts
+++ b/packages/hint-webpack-config/src/meta/modules-false-babel.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.development,
+        description: '`webpack-config/modules-false-babel` warns against not having set the propety `modules` to `false` in presets in babel configuration file',
+        name: 'Babel `modules` is `false` with webpack'
+    },
+    id: 'webpack-config/modules-false-babel',
+    schema: [],
+    scope: HintScope.local
+};
+
+export default meta;

--- a/packages/hint-webpack-config/src/meta/no-devtool-in-prod.ts
+++ b/packages/hint-webpack-config/src/meta/no-devtool-in-prod.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.development,
+        description: '`webpack-config/no-devtool-in-prod` warns against having set the propety `devtool` to `eval`',
+        name: 'No `devtool` in webpack configuration'
+    },
+    id: 'webpack-config/no-devtool-in-prod',
+    schema: [],
+    scope: HintScope.local
+};
+
+export default meta;

--- a/packages/hint-webpack-config/src/meta/no-devtool-in-prod.ts
+++ b/packages/hint-webpack-config/src/meta/no-devtool-in-prod.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.development,
         description: '`webpack-config/no-devtool-in-prod` warns against having set the propety `devtool` to `eval`',
-        name: 'No `devtool` in webpack configuration'
+        name: 'No production `devtool` in webpack'
     },
     id: 'webpack-config/no-devtool-in-prod',
     schema: [],

--- a/packages/hint-webpack-config/src/module-esnext-typescript.ts
+++ b/packages/hint-webpack-config/src/module-esnext-typescript.ts
@@ -1,16 +1,16 @@
 /**
  * @fileoverview `webpack-config/module-esnext-typescript` warns against not having set the propety `compilerOptions.module` to `esnext` in typescript configuration file.
  */
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint } from 'hint/dist/src/lib/types';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 
 import { WebpackConfigEvents, WebpackConfigParse } from '@hint/parser-webpack-config';
 import { TypeScriptConfigEvents, TypeScriptConfigParse } from '@hint/parser-typescript-config';
 
 const debug: debug.IDebugger = d(__filename);
+
+import meta from './meta/module-esnext-typescript';
 
 /*
  * ------------------------------------------------------------------------------
@@ -19,15 +19,7 @@ const debug: debug.IDebugger = d(__filename);
  */
 
 export default class WebpackConfigModuleESNextTypescript implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.development,
-            description: '`webpack-config/module-esnext-typescript` warns against not having set the propety `compilerOptions.module` to `esnext` in typescript configuration file'
-        },
-        id: 'webpack-config/module-esnext-typescript',
-        schema: [],
-        scope: HintScope.local
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<WebpackConfigEvents & TypeScriptConfigEvents>) {
 

--- a/packages/hint-webpack-config/src/modules-false-babel.ts
+++ b/packages/hint-webpack-config/src/modules-false-babel.ts
@@ -1,14 +1,14 @@
 /**
  * @fileoverview `webpack-config/modules-false-babel` warns against not having set the propety `modules` to `false` in presets in babel configuration file.
  */
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint } from 'hint/dist/src/lib/types';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 
 import { WebpackConfigEvents, WebpackConfigParse } from '@hint/parser-webpack-config';
 import { BabelConfigEvents, BabelConfigParsed } from '@hint/parser-babel-config';
+
+import meta from './meta/modules-false-babel';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -19,15 +19,7 @@ const debug: debug.IDebugger = d(__filename);
  */
 
 export default class WebpackConfigModulesFalseBabel implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.development,
-            description: '`webpack-config/modules-false-babel` warns against not having set the propety `modules` to `false` in presets in babel configuration file'
-        },
-        id: 'webpack-config/modules-false-babel',
-        schema: [],
-        scope: HintScope.local
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<WebpackConfigEvents & BabelConfigEvents>) {
 

--- a/packages/hint-webpack-config/src/no-devtool-in-prod.ts
+++ b/packages/hint-webpack-config/src/no-devtool-in-prod.ts
@@ -1,13 +1,13 @@
 /**
  * @fileoverview `webpack-config/no-devtool-in-prod` warns against having set the propety `devtool` to `eval`.
  */
-import { Category } from 'hint/dist/src/lib/enums/category';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint } from 'hint/dist/src/lib/types';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 
 import { WebpackConfigEvents, WebpackConfigParse } from '@hint/parser-webpack-config';
+
+import meta from './meta/no-devtool-in-prod';
 
 const debug: debug.IDebugger = d(__filename);
 
@@ -18,15 +18,7 @@ const debug: debug.IDebugger = d(__filename);
  */
 
 export default class WebpackConfigNoDevtoolInProd implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.development,
-            description: '`webpack-config/no-devtool-in-prod` warns against having set the propety `devtool` to `eval`'
-        },
-        id: 'webpack-config/no-devtool-in-prod',
-        schema: [],
-        scope: HintScope.local
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<WebpackConfigEvents>) {
 

--- a/packages/hint-x-content-type-options/README.md
+++ b/packages/hint-x-content-type-options/README.md
@@ -1,4 +1,4 @@
-# Require `X-Content-Type-Options` HTTP response header (`x-content-type-options`)
+# Use `X-Content-Type-Options` header (`x-content-type-options`)
 
 `x-content-type-options` requires that all scripts and
 stylesheets are served with the `X-Content-Type-Options: nosniff`

--- a/packages/hint-x-content-type-options/src/hint.ts
+++ b/packages/hint-x-content-type-options/src/hint.ts
@@ -9,13 +9,12 @@
  * ------------------------------------------------------------------------------
  */
 
-import { Category } from 'hint/dist/src/lib/enums/category';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
-import { IAsyncHTMLElement, FetchEnd, IHint, HintMetadata } from 'hint/dist/src/lib/types';
+import { IAsyncHTMLElement, FetchEnd, IHint } from 'hint/dist/src/lib/types';
 import normalizeString from 'hint/dist/src/lib/utils/misc/normalize-string';
 import isDataURI from 'hint/dist/src/lib/utils/network/is-data-uri';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import meta from './meta';
 
 const debug = d(__filename);
 
@@ -27,16 +26,7 @@ const debug = d(__filename);
 
 export default class XContentTypeOptionsHint implements IHint {
 
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.security,
-            description: `Require 'X-Content-Type-Options' header`
-        },
-        id: 'x-content-type-options',
-        schema: [],
-        scope: HintScope.site
-    }
-
+    public static readonly meta = meta;
     public constructor(context: HintContext) {
 
         const isHeaderRequired = (element: IAsyncHTMLElement | null): boolean => {

--- a/packages/hint-x-content-type-options/src/meta.ts
+++ b/packages/hint-x-content-type-options/src/meta.ts
@@ -6,7 +6,7 @@ const meta: HintMetadata = {
     docs: {
         category: Category.security,
         description: `Require 'X-Content-Type-Options' header`,
-        name: 'Require `X-Content-Type-Options` header'
+        name: 'Use `X-Content-Type-Options` header'
     },
     id: 'x-content-type-options',
     schema: [],

--- a/packages/hint-x-content-type-options/src/meta.ts
+++ b/packages/hint-x-content-type-options/src/meta.ts
@@ -1,0 +1,16 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.security,
+        description: `Require 'X-Content-Type-Options' header`,
+        name: 'Require `X-Content-Type-Options` header'
+    },
+    id: 'x-content-type-options',
+    schema: [],
+    scope: HintScope.site
+};
+
+export default meta;

--- a/packages/hint/src/lib/types/hint-meta.ts
+++ b/packages/hint/src/lib/types/hint-meta.ts
@@ -1,0 +1,21 @@
+import { Category } from '../enums/category';
+import { HintScope } from '../enums/hintscope';
+
+export type MetadataDocs = {
+    category?: Category;
+    description: string;
+    name?: string;
+};
+
+export type HintMetadata = {
+    /** Documentation related to the hint */
+    docs?: MetadataDocs;
+    /** The id of the hint */
+    id: string;
+    /** List of connectors that should not run the hint */
+    ignoredConnectors?: string[];
+    /** The schema the hint configuration must follow in order to be valid */
+    schema: any[]; // TODO: this shouldn't be an Array of any
+    /** The scope of the hints (local, site, any) */
+    scope: HintScope;
+};

--- a/packages/hint/src/lib/types/hints.ts
+++ b/packages/hint/src/lib/types/hints.ts
@@ -1,24 +1,7 @@
-import { Category } from '../enums/category';
-import { HintScope } from '../enums/hintscope';
 import { HintContext } from '../hint-context';
+import { HintMetadata } from './hint-meta';
 
-export type MetadataDocs = {
-    category?: Category;
-    description: string;
-};
-
-export type HintMetadata = {
-    /** Documentation related to the hint */
-    docs?: MetadataDocs;
-    /** The id of the hint */
-    id: string;
-    /** List of connectors that should not run the hint */
-    ignoredConnectors?: string[];
-    /** The schema the hint configuration must follow in order to be valid */
-    schema: any[]; // TODO: this shouldn't be an Array of any
-    /** The scope of the hints (local, site, any) */
-    scope: HintScope;
-};
+export * from './hint-meta';
 
 export interface IHintConstructor {
     new(context: HintContext): IHint;


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- ~Added/Updated related tests.~

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Extracts existing `HintMetadata` objects into dedicated files and
adds a new `name` field to the `docs` property.

Allows hint metadata to be imported and bundled separately
from the implementation of a hint, reducing bundle size for
documentation scenarios.

Also updates all hint names for consistency both in the new
metadata and in the title of each associated `README`.