### PR TITLE
Fix/canvas vscode

### DIFF
--- a/packages/extension-vscode/.vscode/launch.json
+++ b/packages/extension-vscode/.vscode/launch.json
@@ -23,7 +23,8 @@
                 "<node_internals>/**/*.js"
             ],
             "sourceMaps": true,
-            "outFiles": ["${workspaceRoot}/dist/**/*.js"]
+            "outFiles": ["${workspaceRoot}/dist/**/*.js"],
+            "timeout": 15000
         }
     ],
     "compounds": [

--- a/packages/extension-vscode/CONTRIBUTING.md
+++ b/packages/extension-vscode/CONTRIBUTING.md
@@ -12,6 +12,11 @@ for Visual Studio Code.
 * Select `Client + Server` from the drop down.
 * Run the launch config.
 
+**NOTE**: Make sure to open a project and a file that can be analyzed
+by `webhint` (e.g.: `.html`) in the new VS Code instance in order to
+get everything started. Otherwise you will get timeout errors when
+trying to debug.
+
 ## Running Tests
 
 * Run `yarn test` from this directory.

--- a/packages/extension-vscode/package.json
+++ b/packages/extension-vscode/package.json
@@ -76,5 +76,5 @@
     "watch:test": "ava --watch",
     "watch:ts": "npm run build:ts -- --watch"
   },
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/packages/extension-vscode/src/server.ts
+++ b/packages/extension-vscode/src/server.ts
@@ -223,6 +223,9 @@ connection.onInitialize((params) => {
 
     const jsdomPath: string = require.resolve('jsdom', { paths: [path.join(workspace, 'node_modules')] });
     const jsdomNodeModules = jsdomPath.substring(0, jsdomPath.indexOf('jsdom'));
+    const fakeCanvas = new Module('', null);
+
+    fakeCanvas.exports = function () { };
 
     ['canvas', 'canvas-prebuilt'].forEach((moduleName) => {
         try {
@@ -232,9 +235,7 @@ connection.onInitialize((params) => {
                 return;
             }
 
-            const fakeCanvas = new Module(canvasPath, null);
-
-            fakeCanvas.exports = function () { };
+            
 
             require.cache[canvasPath] = fakeCanvas;
         } catch (e) {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- ~~Added/Updated related tests.~~

## Short description of the change(s)

* Add more debugging details
* Replace `canvas` and `canvas-prebuilt` with a fake Module so `jsdom` can run if the binary is not built for the current VS Code version
* Bump version (not sure the release script takes care of this one)

I've attached the packaged extension so you can test it.

[vscode-webhint-1.0.3.vsix.zip](https://github.com/webhintio/hint/files/2555046/vscode-webhint-1.0.3.vsix.zip)

