### PR TITLE
Fix: Ignore status codes for dns-prefetch and preconnect links

### DIFF
--- a/packages/hint-no-broken-links/README.md
+++ b/packages/hint-no-broken-links/README.md
@@ -66,6 +66,10 @@ the URLs.
 
 URLs which return 200 OK will pass this hint.
 
+URLs requested via `<link rel="dns-prefetch">` or `<link rel="preconnect">`
+[resource hints](https://www.w3.org/TR/resource-hints/#resource-hints) will
+pass this hint if the request succeeds, regardless of status code.
+
 ## How to use this hint?
 
 To use it you will have to install it via `npm`:

--- a/packages/hint-no-broken-links/src/hint.ts
+++ b/packages/hint-no-broken-links/src/hint.ts
@@ -203,7 +203,17 @@ export default class NoBrokenLinksHint implements IHint {
                     return requester
                         .get(fullURL)
                         .then((value: NetworkData) => {
-                            return handleSuccess(value, fullURL, element);
+                            if (element.nodeName !== 'LINK') {
+                                return handleSuccess(value, fullURL, element);
+                            }
+
+                            const relAttribute = element.getAttribute('rel');
+
+                            if (relAttribute !== 'dns-prefetch' && relAttribute !== 'preconnect') {
+                                return handleSuccess(value, fullURL, element);
+                            }
+
+                            return undefined;
                         })
                         .catch((error: any) => {
                             return handleRejection(error, fullURL, element);

--- a/packages/hint-no-broken-links/src/hint.ts
+++ b/packages/hint-no-broken-links/src/hint.ts
@@ -86,6 +86,16 @@ export default class NoBrokenLinksHint implements IHint {
             return context.report(url, 'Broken link found (domain not found).', { element });
         };
 
+        const isDNSOnlyResourceHint = (element: IAsyncHTMLElement): boolean => {
+            if (element.nodeName !== 'LINK') {
+                return false;
+            }
+
+            const relAttribute = element.getAttribute('rel');
+
+            return (relAttribute === 'dns-prefetch' || relAttribute === 'preconnect');
+        };
+
         /**
          * The callback to handle success handler returned from the `head` method
          * We will check the response status againist the brokenStatusCodes list
@@ -93,6 +103,10 @@ export default class NoBrokenLinksHint implements IHint {
          * so that duplicate requests will not be made if 2 links have the same href value
          */
         const handleSuccess = (networkData: NetworkData, url: string, element: IAsyncHTMLElement) => {
+            if (isDNSOnlyResourceHint(element)) {
+                return Promise.resolve();
+            }
+
             const statusIndex = brokenStatusCodes.indexOf(
                 networkData.response.statusCode
             );
@@ -203,17 +217,7 @@ export default class NoBrokenLinksHint implements IHint {
                     return requester
                         .get(fullURL)
                         .then((value: NetworkData) => {
-                            if (element.nodeName !== 'LINK') {
-                                return handleSuccess(value, fullURL, element);
-                            }
-
-                            const relAttribute = element.getAttribute('rel');
-
-                            if (relAttribute !== 'dns-prefetch' && relAttribute !== 'preconnect') {
-                                return handleSuccess(value, fullURL, element);
-                            }
-
-                            return undefined;
+                            return handleSuccess(value, fullURL, element);
                         })
                         .catch((error: any) => {
                             return handleRejection(error, fullURL, element);

--- a/packages/hint-no-broken-links/tests/tests.ts
+++ b/packages/hint-no-broken-links/tests/tests.ts
@@ -80,6 +80,14 @@ const bodyWithBrokenPreconnectLinkTag = `<div>
 <link rel="preconnect" href="http://localhost/404">
 </div>`;
 
+const bodyWithInvalidDomainDnsPrefetchLinkTag = `<div>
+<link rel="dns-prefetch" href="https://invalid.domain/">
+</div>`;
+
+const bodyWithInvalidDomainPreconnectLinkTag = `<div>
+<link rel="preconnect" href="https://invalid.domain/">
+</div>`;
+
 const tests: HintTest[] = [
     {
         name: `This test should pass as it has links with valid href value`,
@@ -221,6 +229,16 @@ const tests: HintTest[] = [
             '/': { content: generateHTMLPage('', bodyWithBrokenPreconnectLinkTag) },
             '/404': { status: 404 }
         }
+    },
+    {
+        name: `This test should fail as the domain is not found for the dns-prefetch link tag`,
+        reports: [{ message: `Broken link found (domain not found).` }],
+        serverConfig: generateHTMLPage('', bodyWithInvalidDomainDnsPrefetchLinkTag)
+    },
+    {
+        name: `This test should fail as the domain is not found for the preconnect link tag`,
+        reports: [{ message: `Broken link found (domain not found).` }],
+        serverConfig: generateHTMLPage('', bodyWithInvalidDomainPreconnectLinkTag)
     }
 ];
 

--- a/packages/hint-no-broken-links/tests/tests.ts
+++ b/packages/hint-no-broken-links/tests/tests.ts
@@ -72,6 +72,14 @@ const bodyWithInvalidUrl = `<div>
 <a href='http://'>About</a>
 </div>`;
 
+const bodyWithBrokenDnsPrefetchLinkTag = `<div>
+<link rel="dns-prefetch" href="https://example.com/404">
+</div>`;
+
+const bodyWithBrokenPreconnectLinkTag = `<div>
+<link rel="preconnect" href="https://example.com/404">
+</div>`;
+
 const tests: HintTest[] = [
     {
         name: `This test should pass as it has links with valid href value`,
@@ -199,6 +207,14 @@ const tests: HintTest[] = [
         name: `Invalid URL triggers an error`,
         reports: [{ message: `Broken link found (invalid URL).` }],
         serverConfig: { '/': { content: generateHTMLPage('', bodyWithInvalidUrl) } }
+    },
+    {
+        name: `This test should pass as the 404 error should be ignored for dns-prefetch link tags`,
+        serverConfig: { '/': { content: generateHTMLPage('', bodyWithBrokenDnsPrefetchLinkTag) } }
+    },
+    {
+        name: `This test should pass as the 404 error should be ignored for preconnect link tags`,
+        serverConfig: { '/': { content: generateHTMLPage('', bodyWithBrokenPreconnectLinkTag) } }
     }
 ];
 

--- a/packages/hint-no-broken-links/tests/tests.ts
+++ b/packages/hint-no-broken-links/tests/tests.ts
@@ -73,11 +73,11 @@ const bodyWithInvalidUrl = `<div>
 </div>`;
 
 const bodyWithBrokenDnsPrefetchLinkTag = `<div>
-<link rel="dns-prefetch" href="https://example.com/404">
+<link rel="dns-prefetch" href="http://localhost/404">
 </div>`;
 
 const bodyWithBrokenPreconnectLinkTag = `<div>
-<link rel="preconnect" href="https://example.com/404">
+<link rel="preconnect" href="http://localhost/404">
 </div>`;
 
 const tests: HintTest[] = [
@@ -210,11 +210,17 @@ const tests: HintTest[] = [
     },
     {
         name: `This test should pass as the 404 error should be ignored for dns-prefetch link tags`,
-        serverConfig: { '/': { content: generateHTMLPage('', bodyWithBrokenDnsPrefetchLinkTag) } }
+        serverConfig: {
+            '/': { content: generateHTMLPage('', bodyWithBrokenDnsPrefetchLinkTag) },
+            '/404': { status: 404 }
+        }
     },
     {
         name: `This test should pass as the 404 error should be ignored for preconnect link tags`,
-        serverConfig: { '/': { content: generateHTMLPage('', bodyWithBrokenPreconnectLinkTag) } }
+        serverConfig: {
+            '/': { content: generateHTMLPage('', bodyWithBrokenPreconnectLinkTag) },
+            '/404': { status: 404 }
+        }
     }
 ];
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

This pull request ensures that status codes are ignored when checking an URL of a [dns-prefetch](https://www.w3.org/TR/resource-hints/#dfn-dns-prefetch) or [preconnect](https://www.w3.org/TR/resource-hints/#dfn-preconnect) link. The spec for [Resource Hints](https://www.w3.org/TR/resource-hints) says that those type of links should only be used for DNS lookups, TCP handshakes, and optional TLS negotiations. Therefore I think checking the resource but ignoring the status code it returns is a good approximation to check those links.

I used https://example.com/404 in the tests to simulate a 404 response. But dns-prefetch and preconnect links should normally be used without any path in the URL. Is there a way to mock a server which returns a 404 response when receiving a request without a path in the tests?

Please let me know if there is anything I should change.