### PR TITLE
Fix: Add types to tests

### DIFF
--- a/packages/connector-local/tests/tests.ts
+++ b/packages/connector-local/tests/tests.ts
@@ -9,8 +9,24 @@ import delay from 'hint/dist/src/lib/utils/misc/delay';
 import asPathString from 'hint/dist/src/lib/utils/network/as-path-string';
 import { getAsUri } from 'hint/dist/src/lib/utils/network/as-uri';
 
-const chokidar = { watch() { } };
-const isFile = { default() { } };
+type IsFile = {
+    default: (filePath: string) => boolean;
+};
+
+type Chokidar = {
+    watch: () => Stream;
+};
+
+const chokidar: Chokidar = {
+    watch() {
+        return new Stream();
+    }
+};
+const isFile: IsFile = {
+    default(filePath: string): boolean {
+        return false;
+    }
+};
 
 mock('hint/dist/src/lib/utils/fs/is-file', isFile);
 mock('chokidar', chokidar);
@@ -26,7 +42,6 @@ test.beforeEach((t) => {
         notify() { },
         on() { }
     };
-    t.context.isFile = isFile;
 });
 
 test.after(() => {
@@ -38,7 +53,7 @@ test.serial(`If target is a file, it should emit 'fetch::start::target' event`, 
 
     const sandbox = sinon.createSandbox();
 
-    sandbox.stub(t.context.isFile, 'default').returns(true);
+    sandbox.stub(isFile, 'default').returns(true);
     sandbox.spy(t.context.engine, 'emitAsync');
 
     const connector = new LocalConnector(t.context.engine as any, {});
@@ -60,7 +75,7 @@ test.serial(`If target is a html file, it should emit 'fetch::end::html' event i
 
     const sandbox = sinon.createSandbox();
 
-    sandbox.stub(t.context.isFile, 'default').returns(true);
+    sandbox.stub(isFile, 'default').returns(true);
     sandbox.spy(t.context.engine, 'emitAsync');
 
     const connector = new LocalConnector(t.context.engine as any, {});
@@ -82,7 +97,7 @@ test.serial(`If target is a file (text), 'content' is setted`, async (t) => {
 
     const sandbox = sinon.createSandbox();
 
-    sandbox.stub(t.context.isFile, 'default').returns(true);
+    sandbox.stub(isFile, 'default').returns(true);
     sandbox.spy(t.context.engine, 'emitAsync');
 
     const connector = new LocalConnector(t.context.engine as any, {});
@@ -106,7 +121,7 @@ test.serial(`If content is passed, it is used instead of the file`, async (t) =>
 
     const sandbox = sinon.createSandbox();
 
-    sandbox.stub(t.context.isFile, 'default').returns(true);
+    sandbox.stub(isFile, 'default').returns(true);
     sandbox.spy(t.context.engine, 'emitAsync');
 
     const connector = new LocalConnector(t.context.engine as any, {});
@@ -128,7 +143,7 @@ test.serial(`If target is a file (image), 'content' is empty`, async (t) => {
 
     const sandbox = sinon.createSandbox();
 
-    sandbox.stub(t.context.isFile, 'default').returns(true);
+    sandbox.stub(isFile, 'default').returns(true);
     sandbox.spy(t.context.engine, 'emitAsync');
 
     const connector = new LocalConnector(t.context.engine as any, {});
@@ -150,7 +165,7 @@ test.serial(`If target is an image, 'content' is empty`, async (t) => {
 
     const sandbox = sinon.createSandbox();
 
-    sandbox.stub(t.context.isFile, 'default').returns(true);
+    sandbox.stub(isFile, 'default').returns(true);
     sandbox.spy(t.context.engine, 'emitAsync');
 
     const connector = new LocalConnector(t.context.engine as any, {});
@@ -172,7 +187,7 @@ test.serial(`If target is a directory, shouldn't emit the event 'fetch::start::t
 
     const sandbox = sinon.createSandbox();
 
-    sandbox.stub(t.context.isFile, 'default').returns(false);
+    sandbox.stub(isFile, 'default').returns(false);
     sandbox.spy(t.context.engine, 'emitAsync');
 
     const connector = new LocalConnector(t.context.engine as any, {});
@@ -203,7 +218,7 @@ test.serial(`If target is a directory, passed content should be ignored`, async 
 
     const sandbox = sinon.createSandbox();
 
-    sandbox.stub(t.context.isFile, 'default').returns(false);
+    sandbox.stub(isFile, 'default').returns(false);
     sandbox.spy(t.context.engine, 'emitAsync');
 
     const connector = new LocalConnector(t.context.engine as any, {});
@@ -239,7 +254,7 @@ test.serial(`If watch is true, it should watch the right files`, async (t) => {
 
     (stream as any).close = () => { };
 
-    sandbox.stub(t.context.isFile, 'default').returns(false);
+    sandbox.stub(isFile, 'default').returns(false);
     sandbox.stub(process, 'cwd').returns(directory);
     sandbox.spy(t.context.engine, 'emitAsync');
     sandbox.stub(chokidar, 'watch').returns(stream);
@@ -288,7 +303,7 @@ test.serial(`If watch is true, it should use the .gitignore`, async (t) => {
 
     (stream as any).close = () => { };
 
-    sandbox.stub(t.context.isFile, 'default').returns(false);
+    sandbox.stub(isFile, 'default').returns(false);
     sandbox.stub(process, 'cwd').returns(directory);
     sandbox.spy(t.context.engine, 'emitAsync');
     sandbox.stub(chokidar, 'watch').returns(stream);
@@ -329,7 +344,7 @@ test.serial(`When the watcher is ready, it should emit the scan::end event`, asy
 
     (stream as any).close = () => { };
 
-    sandbox.stub(t.context.isFile, 'default').returns(false);
+    sandbox.stub(isFile, 'default').returns(false);
     sandbox.stub(process, 'cwd').returns(directory);
     sandbox.spy(t.context.engine, 'emitAsync');
     sandbox.stub(chokidar, 'watch').returns(stream);
@@ -373,7 +388,7 @@ test.serial(`When the watcher detects a new file, it should emit the fetch::end:
 
     (stream as any).close = () => { };
 
-    sandbox.stub(t.context.isFile, 'default').returns(false);
+    sandbox.stub(isFile, 'default').returns(false);
     sandbox.stub(process, 'cwd').returns(directory);
     sandbox.spy(t.context.engine, 'emitAsync');
     sandbox.stub(chokidar, 'watch').returns(stream);
@@ -420,7 +435,7 @@ test.serial(`When the watcher detects a change in a file, it should emit the fet
 
     (stream as any).close = () => { };
 
-    sandbox.stub(t.context.isFile, 'default').returns(false);
+    sandbox.stub(isFile, 'default').returns(false);
     sandbox.stub(process, 'cwd').returns(directory);
     sandbox.spy(t.context.engine, 'emitAsync');
     sandbox.stub(chokidar, 'watch').returns(stream);
@@ -467,7 +482,7 @@ test.serial(`When the watcher detects that a file was removed, it should emit th
 
     (stream as any).close = () => { };
 
-    sandbox.stub(t.context.isFile, 'default').returns(false);
+    sandbox.stub(isFile, 'default').returns(false);
     sandbox.stub(process, 'cwd').returns(directory);
     sandbox.spy(t.context.engine, 'emitAsync');
     sandbox.stub(chokidar, 'watch').returns(stream);
@@ -513,7 +528,7 @@ test.serial(`When the watcher get an error, it should throw an error`, async (t)
 
     (stream as any).close = () => { };
 
-    sandbox.stub(t.context.isFile, 'default').returns(false);
+    sandbox.stub(isFile, 'default').returns(false);
     sandbox.stub(process, 'cwd').returns(directory);
     sandbox.spy(t.context.engine, 'emitAsync');
     sandbox.stub(chokidar, 'watch').returns(stream);

--- a/packages/connector-local/tests/tests.ts
+++ b/packages/connector-local/tests/tests.ts
@@ -9,20 +9,12 @@ import delay from 'hint/dist/src/lib/utils/misc/delay';
 import asPathString from 'hint/dist/src/lib/utils/network/as-path-string';
 import { getAsUri } from 'hint/dist/src/lib/utils/network/as-uri';
 
-type IsFile = {
-    default: (filePath: string) => boolean;
-};
-
-type Chokidar = {
-    watch: () => Stream;
-};
-
-const chokidar: Chokidar = {
-    watch() {
+const chokidar = {
+    watch(): Stream {
         return new Stream();
     }
 };
-const isFile: IsFile = {
+const isFile = {
     default(filePath: string): boolean {
         return false;
     }

--- a/packages/create-hint/tests/create-hint.ts
+++ b/packages/create-hint/tests/create-hint.ts
@@ -6,11 +6,15 @@ import test from 'ava';
 
 import * as handlebarsUtils from '../src/handlebars-utils';
 
+type FsExtra = {
+    copy: (orig: string, dest: string) => void;
+};
+
 const inquirer = { prompt() { } };
 const writeFileAsyncModule = { default() { } };
 const isOfficialModule = { default() { } };
 
-const fsExtra = { copy() { } };
+const fsExtra: FsExtra = { copy(orig: string, dest: string) { } };
 const mkdirp = (dir: string, callback: Function) => {
     callback();
 };
@@ -41,7 +45,7 @@ test.serial('It creates a hint if the option multiple hints is false', async (t)
 
     const fsExtraCopyStub = sandbox.stub(fsExtra, 'copy').resolves();
     const miscWriteFileAsyncStub = sandbox.stub(writeFileAsyncModule, 'default').resolves();
-    const handlebarsCompileTemplateStub = sandbox.stub(handlebarsUtils, 'compileTemplate').returns('');
+    const handlebarsCompileTemplateStub = sandbox.stub(handlebarsUtils, 'compileTemplate').resolves('');
 
     sandbox.stub(isOfficialModule, 'default').resolves(true);
     sandbox.stub(process, 'cwd').returns(root);
@@ -86,7 +90,7 @@ test.serial('It creates a package with multiple hints', async (t) => {
 
     const fsExtraCopyStub = sandbox.stub(fsExtra, 'copy').resolves();
     const miscWriteFileAsyncStub = sandbox.stub(writeFileAsyncModule, 'default').resolves();
-    const handlebarsCompileTemplateStub = sandbox.stub(handlebarsUtils, 'compileTemplate').returns('');
+    const handlebarsCompileTemplateStub = sandbox.stub(handlebarsUtils, 'compileTemplate').resolves('');
 
     sandbox.stub(isOfficialModule, 'default').resolves(false);
     sandbox.stub(process, 'cwd').returns(root);

--- a/packages/create-hint/tests/create-hint.ts
+++ b/packages/create-hint/tests/create-hint.ts
@@ -6,15 +6,11 @@ import test from 'ava';
 
 import * as handlebarsUtils from '../src/handlebars-utils';
 
-type FsExtra = {
-    copy: (orig: string, dest: string) => void;
-};
-
 const inquirer = { prompt() { } };
 const writeFileAsyncModule = { default() { } };
 const isOfficialModule = { default() { } };
 
-const fsExtra: FsExtra = { copy(orig: string, dest: string) { } };
+const fsExtra = { copy(orig: string, dest: string) { } };
 const mkdirp = (dir: string, callback: Function) => {
     callback();
 };

--- a/packages/create-hintrc/tests/create-hintrc.ts
+++ b/packages/create-hintrc/tests/create-hintrc.ts
@@ -5,11 +5,25 @@ import test from 'ava';
 
 import { NpmPackage } from 'hint/dist/src/lib/types';
 
+type Npm = {
+    getOfficialPackages: () => NpmPackage[] | null;
+    installPackages: () => boolean;
+};
+
+type ResourceLoader = {
+    getCoreResources: () => [] | null;
+    getInstalledResources: () => string[] | null;
+};
+
 const inquirer = { prompt() { } };
 const stubBrowserslistObject = { generateBrowserslistConfig() { } };
-const resourceLoader = {
-    getCoreResources() { },
-    getInstalledResources() { }
+const resourceLoader: ResourceLoader = {
+    getCoreResources() {
+        return null;
+    },
+    getInstalledResources() {
+        return null;
+    }
 };
 const child = { spawnSync() { } };
 const fs = {
@@ -21,9 +35,13 @@ const logger = {
     log() { }
 };
 
-const npm = {
-    getOfficialPackages() { },
-    installPackages() { }
+const npm: Npm = {
+    getOfficialPackages() {
+        return null;
+    },
+    installPackages() {
+        return false;
+    }
 };
 
 const promisifyObject = { promisify() { } };

--- a/packages/create-hintrc/tests/create-hintrc.ts
+++ b/packages/create-hintrc/tests/create-hintrc.ts
@@ -5,23 +5,13 @@ import test from 'ava';
 
 import { NpmPackage } from 'hint/dist/src/lib/types';
 
-type Npm = {
-    getOfficialPackages: () => NpmPackage[] | null;
-    installPackages: () => boolean;
-};
-
-type ResourceLoader = {
-    getCoreResources: () => [] | null;
-    getInstalledResources: () => string[] | null;
-};
-
 const inquirer = { prompt() { } };
 const stubBrowserslistObject = { generateBrowserslistConfig() { } };
-const resourceLoader: ResourceLoader = {
-    getCoreResources() {
+const resourceLoader = {
+    getCoreResources(): [] | null {
         return null;
     },
-    getInstalledResources() {
+    getInstalledResources(): string[] | null {
         return null;
     }
 };
@@ -35,11 +25,11 @@ const logger = {
     log() { }
 };
 
-const npm: Npm = {
-    getOfficialPackages() {
+const npm = {
+    getOfficialPackages(): NpmPackage[] | null {
         return null;
     },
-    installPackages() {
+    installPackages(): boolean {
         return false;
     }
 };

--- a/packages/create-parser/tests/new-parser.ts
+++ b/packages/create-parser/tests/new-parser.ts
@@ -6,10 +6,18 @@ import * as InquirerTypes from 'inquirer';
 
 import * as handlebarsUtils from '../src/handlebars-utils';
 
+type NormalizeStringByDelimiter = {
+    default: () => string
+};
+
 const fsExtra = { copy() { } };
 const inquirer = { prompt() { } };
 const isOfficial = { default() { } };
-const normalizeStringByDelimiter = { default() { } };
+const normalizeStringByDelimiter: NormalizeStringByDelimiter = {
+    default() {
+        return '';
+    }
+};
 const readFileAsync = { default() { } };
 const writeFileAsync = { default() { } };
 
@@ -35,7 +43,7 @@ test.beforeEach((t) => {
     sinon.stub(writeFileAsync, 'default').resolves();
     sinon.stub(normalizeStringByDelimiter, 'default').returns('');
     sinon.stub(readFileAsync, 'default').resolves('');
-    sinon.stub(handlebarsUtils, 'compileTemplate').returns('');
+    sinon.stub(handlebarsUtils, 'compileTemplate').resolves('');
 
     t.context.fs = fsExtra;
     t.context.misc = {

--- a/packages/create-parser/tests/new-parser.ts
+++ b/packages/create-parser/tests/new-parser.ts
@@ -6,15 +6,11 @@ import * as InquirerTypes from 'inquirer';
 
 import * as handlebarsUtils from '../src/handlebars-utils';
 
-type NormalizeStringByDelimiter = {
-    default: () => string
-};
-
 const fsExtra = { copy() { } };
 const inquirer = { prompt() { } };
 const isOfficial = { default() { } };
-const normalizeStringByDelimiter: NormalizeStringByDelimiter = {
-    default() {
+const normalizeStringByDelimiter = {
+    default(): string {
         return '';
     }
 };

--- a/packages/extension-vscode/tests/fixtures/mocks.ts
+++ b/packages/extension-vscode/tests/fixtures/mocks.ts
@@ -4,6 +4,41 @@ import {
     TextDocument,
     TextDocumentChangeEvent
 } from 'vscode-languageserver';
+import { Problem } from 'hint/dist/src/lib/types';
+
+type Access = {
+    error: () => Error | null;
+}
+
+type MessageResult = {
+    title: string;
+};
+
+type MockWindow = {
+    showErrorMessage: () => MessageResult;
+    showInformationMessage: () => MessageResult;
+    showWarningMessage: () => MessageResult;
+};
+
+type Connection = {
+    listen: () => void;
+    onDidChangeWatchedFiles: (fn: typeof fileWatcher) => void;
+    onInitialize: (fn: typeof initializer) => void;
+    sendDiagnostics: () => void;
+    sendNotification: () => void;
+    window: MockWindow;
+}
+
+type Documents = {
+    all: () => TextDocument[];
+    listen: () => void;
+    onDidChangeContent: (fn: typeof contentWatcher) => void;
+}
+
+type EngineMock = {
+    clear: () => void;
+    executeOn: () => Partial<Problem>[];
+}
 
 export const child = {
     on(event: string, listener: () => void) {
@@ -13,8 +48,8 @@ export const child = {
             }, 0);
         }
     },
-    stderr: { pipe() { }},
-    stdout: { pipe() { }}
+    stderr: { pipe() { } },
+    stdout: { pipe() { } }
 };
 
 // eslint-disable-next-line
@@ -24,21 +59,21 @@ export const child_process = {
     }
 };
 
-export const access = {
+export const access: Access = {
     error() {
         return new Error('ENOENT');
     }
 };
 
 export const fs = {
-    access(path: string, callback: (err: NodeJS.ErrnoException) => void) {
+    access(path: string, callback: (err: Error | null) => void) {
         setTimeout(() => {
             callback(access.error());
         }, 0);
     }
 };
 
-export const engine = {
+export const engine: EngineMock = {
     clear() { },
     executeOn() {
         return [];
@@ -64,7 +99,7 @@ export const loadResources = () => { };
 export let fileWatcher: () => any;
 export let initializer: (params: Partial<InitializeParams>) => Promise<InitializeResult>;
 
-export const connection = {
+export const connection: Connection = {
     listen() { },
     onDidChangeWatchedFiles(fn: typeof fileWatcher) {
         fileWatcher = fn;
@@ -75,9 +110,15 @@ export const connection = {
     sendDiagnostics() { },
     sendNotification() { },
     window: {
-        showErrorMessage() { },
-        showInformationMessage() { },
-        showWarningMessage() { }
+        showErrorMessage() {
+            return { title: '' }
+        },
+        showInformationMessage() {
+            return { title: '' }
+        },
+        showWarningMessage() {
+            return { title: '' }
+        }
     }
 };
 
@@ -97,7 +138,7 @@ export const Files = {
     }
 };
 
-export const ProposedFeatures = { all: { } };
+export const ProposedFeatures = { all: {} };
 
 export const document = {
     getText() {
@@ -110,7 +151,7 @@ export const document = {
 
 export let contentWatcher: (change: Partial<TextDocumentChangeEvent>) => any;
 
-export const documents = {
+export const documents: Documents = {
     all() {
         return [];
     },

--- a/packages/extension-vscode/tests/fixtures/mocks.ts
+++ b/packages/extension-vscode/tests/fixtures/mocks.ts
@@ -6,40 +6,6 @@ import {
 } from 'vscode-languageserver';
 import { Problem } from 'hint/dist/src/lib/types';
 
-type Access = {
-    error: () => Error | null;
-}
-
-type MessageResult = {
-    title: string;
-};
-
-type MockWindow = {
-    showErrorMessage: () => MessageResult;
-    showInformationMessage: () => MessageResult;
-    showWarningMessage: () => MessageResult;
-};
-
-type Connection = {
-    listen: () => void;
-    onDidChangeWatchedFiles: (fn: typeof fileWatcher) => void;
-    onInitialize: (fn: typeof initializer) => void;
-    sendDiagnostics: () => void;
-    sendNotification: () => void;
-    window: MockWindow;
-}
-
-type Documents = {
-    all: () => TextDocument[];
-    listen: () => void;
-    onDidChangeContent: (fn: typeof contentWatcher) => void;
-}
-
-type EngineMock = {
-    clear: () => void;
-    executeOn: () => Partial<Problem>[];
-}
-
 export const child = {
     on(event: string, listener: () => void) {
         if (event === 'exit') {
@@ -59,8 +25,8 @@ export const child_process = {
     }
 };
 
-export const access: Access = {
-    error() {
+export const access = {
+    error(): Error | null {
         return new Error('ENOENT');
     }
 };
@@ -73,9 +39,9 @@ export const fs = {
     }
 };
 
-export const engine: EngineMock = {
+export const engine = {
     clear() { },
-    executeOn() {
+    executeOn(): Partial<Problem>[] {
         return [];
     }
 };
@@ -99,7 +65,7 @@ export const loadResources = () => { };
 export let fileWatcher: () => any;
 export let initializer: (params: Partial<InitializeParams>) => Promise<InitializeResult>;
 
-export const connection: Connection = {
+export const connection = {
     listen() { },
     onDidChangeWatchedFiles(fn: typeof fileWatcher) {
         fileWatcher = fn;
@@ -151,8 +117,8 @@ export const document = {
 
 export let contentWatcher: (change: Partial<TextDocumentChangeEvent>) => any;
 
-export const documents: Documents = {
-    all() {
+export const documents = {
+    all(): TextDocument[] {
         return [];
     },
     listen() { },

--- a/packages/hint-typescript-config/tests/import-helpers.ts
+++ b/packages/hint-typescript-config/tests/import-helpers.ts
@@ -7,7 +7,15 @@ import { getHintPath } from 'hint/dist/src/lib/utils/hint-helpers';
 import * as hintRunner from '@hint/utils-tests-helpers/dist/src/hint-runner';
 import { HintLocalTest } from '@hint/utils-tests-helpers/dist/src/hint-test-type';
 
-const loadPackage = require('hint/dist/src/lib/utils/packages/load-package');
+type Package = {
+    exists: boolean;
+};
+
+type LoadPackage = {
+    default: () => Package;
+};
+
+const loadPackage: LoadPackage = require('hint/dist/src/lib/utils/packages/load-package');
 
 const hintPath = getHintPath(__filename, true);
 

--- a/packages/hint/package.json
+++ b/packages/hint/package.json
@@ -55,7 +55,7 @@
     "@types/ora": "^1.3.4",
     "@types/request": "^2.48.1",
     "@types/semver": "^5.4.0",
-    "@types/sinon": "5.0.5",
+    "@types/sinon": "^5.0.7",
     "@types/strip-bom": "^3.0.0",
     "@types/strip-json-comments": "^0.0.30",
     "@types/update-notifier": "^2.5.0",

--- a/packages/hint/tests/lib/cli.ts
+++ b/packages/hint/tests/lib/cli.ts
@@ -1,49 +1,76 @@
 import chalk from 'chalk';
 import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
-import test from 'ava';
+import anyTest, { AssertContext, Context, RegisterContextual } from 'ava';
+import { NotifyOptions, UpdateInfo } from 'update-notifier';
 
-const stubbedNotifier = {
-    notify() { },
-    update: {}
+type Notifier = {
+    notify: (customMessage?: NotifyOptions) => any;
+    update: UpdateInfo | null;
 };
 
-const stubbedLogger = { error() { } };
+type Logger = {
+    error: (text: string) => any;
+};
+
+type HintPackage = {
+    version: string;
+};
+
+type LoadHintPackage = {
+    default: () => HintPackage;
+};
+
+const loadHintPackage: LoadHintPackage = {
+    default() {
+        return { version: '' };
+    }
+};
+
+const logger: Logger = { error(text: string) { } };
+
+type ConfigTestContext = {
+    notifyStub: sinon.SinonStub<[(NotifyOptions | undefined)?]>;
+    updateInfo: UpdateInfo | null;
+    errorStub: sinon.SinonSpy<[string]>;
+};
+
+type TestContext = Context<ConfigTestContext> & AssertContext;
+
+const notifier: Notifier = {
+    notify(customMessage?: NotifyOptions) { },
+    update: {} as UpdateInfo
+};
 
 const updateNotifier = () => {
-    return stubbedNotifier;
+    return notifier;
 };
-
-const loadHintPackage = { default() { } };
 
 const cliActions = [] as any;
 
+const test = anyTest as RegisterContextual<ConfigTestContext>;
+
 proxyquire('../../src/lib/cli', {
     './cli/actions': cliActions,
-    './utils/logging': stubbedLogger,
+    './utils/logging': logger,
     './utils/packages/load-hint-package': loadHintPackage,
     'update-notifier': updateNotifier
 });
 
-test.beforeEach((t) => {
-    sinon.stub(stubbedNotifier, 'notify').resolves();
-    sinon.spy(stubbedLogger, 'error');
-    t.context.notifier = stubbedNotifier;
-    t.context.loadHintPackage = loadHintPackage;
-    t.context.logger = stubbedLogger;
+test.beforeEach((t: TestContext) => {
+    const notifyStub = sinon.stub<Notifier, 'notify'>(notifier, 'notify');
+
+    notifyStub.resolves();
+    t.context.errorStub = sinon.spy<Logger, 'error'>(logger, 'error');
+    t.context.notifyStub = notifyStub;
 });
 
-test.afterEach.always((t) => {
-    t.context.notifier.notify.restore();
-
-    if (t.context.loadHintPackage.default.restore) {
-        t.context.loadHintPackage.default.restore();
-    }
-
-    t.context.logger.error.restore();
+test.afterEach.always((t: TestContext) => {
+    t.context.notifyStub.restore();
+    t.context.errorStub.restore();
 });
 
-test.serial('Users should be notified if there is a new version of hint', async (t) => {
+test.serial('Users should be notified if there is a new version of hint', async (t: TestContext) => {
     const newUpdate = {
         current: '0.2.0',
         latest: '0.3.0',
@@ -54,27 +81,29 @@ test.serial('Users should be notified if there is a new version of hint', async 
     const expectedMessage = `Update available ${chalk.red(newUpdate.current)}${chalk.reset(' → ')}${chalk.green(newUpdate.latest)}
 See ${chalk.cyan('https://webhint.io/about/changelog/')} for details`;
 
-    t.context.notifier.update = newUpdate;
-    sinon.stub(t.context.loadHintPackage, 'default').returns({ version: '0.2.0' });
+    notifier.update = newUpdate;
+    const loadHintPackageStub = sinon.stub(loadHintPackage, 'default').returns({ version: '0.2.0' });
 
     const cli = await import('../../src/lib/cli');
 
     await cli.execute('');
 
-    t.true(t.context.notifier.notify.calledOnce);
-    t.is(t.context.notifier.notify.args[0][0].message, expectedMessage);
+    t.true(t.context.notifyStub.calledOnce);
+    t.is(t.context.notifyStub.args[0][0]!.message, expectedMessage);
+
+    loadHintPackageStub.restore();
 });
 
-test.serial(`Users shouldn't be notified if the current version is up to date`, async (t) => {
-    t.context.notifier.update = null;
+test.serial(`Users shouldn't be notified if the current version is up to date`, async (t: TestContext) => {
+    notifier.update = null;
     const cli = await import('../../src/lib/cli');
 
     await cli.execute('');
 
-    t.is(t.context.notifier.notify.callCount, 0);
+    t.is(t.context.notifyStub.callCount, 0);
 });
 
-test.serial(`Users shouldn't be notified if they just updated to the latest version and the data is still cached`, async (t) => {
+test.serial(`Users shouldn't be notified if they just updated to the latest version and the data is still cached`, async (t: TestContext) => {
     const newUpdate = {
         current: '0.2.0',
         latest: '0.3.0',
@@ -82,23 +111,25 @@ test.serial(`Users shouldn't be notified if they just updated to the latest vers
         type: 'minor'
     };
 
-    t.context.notifier.update = newUpdate;
-    sinon.stub(t.context.loadHintPackage, 'default').returns({ version: '0.3.0' });
+    notifier.update = newUpdate;
+    const loadHintPackageStub = sinon.stub(loadHintPackage, 'default').returns({ version: '0.3.0' });
 
     const cli = await import('../../src/lib/cli');
 
     await cli.execute('');
 
-    t.is(t.context.notifier.notify.callCount, 0);
+    t.is(t.context.notifyStub.callCount, 0);
+
+    loadHintPackageStub.restore();
 });
 
-test.serial(`The process should exit if non-existing arguments are passed in to 'execute'`, async (t) => {
-    t.context.notifier.update = null;
+test.serial(`The process should exit if non-existing arguments are passed in to 'execute'`, async (t: TestContext) => {
+    notifier.update = null;
 
     const cli = await import('../../src/lib/cli');
 
     await t.notThrows(cli.execute(['', '', '--inti']));
 
-    t.true(t.context.logger.error.calledOnce);
-    t.is(t.context.logger.error.args[0][0], `Invalid option '--inti' - perhaps you meant '--hints'?`);
+    t.true(t.context.errorStub.calledOnce);
+    t.is(t.context.errorStub.args[0][0], `Invalid option '--inti' - perhaps you meant '--hints'?`);
 });

--- a/packages/hint/tests/lib/cli.ts
+++ b/packages/hint/tests/lib/cli.ts
@@ -4,30 +4,13 @@ import * as sinon from 'sinon';
 import anyTest, { AssertContext, Context, RegisterContextual } from 'ava';
 import { NotifyOptions, UpdateInfo } from 'update-notifier';
 
-type Notifier = {
-    notify: (customMessage?: NotifyOptions) => any;
-    update: UpdateInfo | null;
-};
-
-type Logger = {
-    error: (text: string) => any;
-};
-
-type HintPackage = {
-    version: string;
-};
-
-type LoadHintPackage = {
-    default: () => HintPackage;
-};
-
-const loadHintPackage: LoadHintPackage = {
+const loadHintPackage = {
     default() {
         return { version: '' };
     }
 };
 
-const logger: Logger = { error(text: string) { } };
+const logger = { error(text: string): any { } };
 
 type ConfigTestContext = {
     notifyStub: sinon.SinonStub<[(NotifyOptions | undefined)?]>;
@@ -37,9 +20,9 @@ type ConfigTestContext = {
 
 type TestContext = Context<ConfigTestContext> & AssertContext;
 
-const notifier: Notifier = {
+const notifier = {
     notify(customMessage?: NotifyOptions) { },
-    update: {} as UpdateInfo
+    update: {} as UpdateInfo | null
 };
 
 const updateNotifier = () => {
@@ -58,10 +41,10 @@ proxyquire('../../src/lib/cli', {
 });
 
 test.beforeEach((t: TestContext) => {
-    const notifyStub = sinon.stub<Notifier, 'notify'>(notifier, 'notify');
+    const notifyStub = sinon.stub(notifier, 'notify');
 
     notifyStub.resolves();
-    t.context.errorStub = sinon.spy<Logger, 'error'>(logger, 'error');
+    t.context.errorStub = sinon.spy(logger, 'error');
     t.context.notifyStub = notifyStub;
 });
 

--- a/packages/hint/tests/lib/cli/analyze.ts
+++ b/packages/hint/tests/lib/cli/analyze.ts
@@ -32,24 +32,6 @@ type ValidateHintsConfigResult = {
     invalid: any[];
 };
 
-type Configuration = {
-    fromConfig: (config: UserConfig | null) => {};
-    getFilenameForDirectory: () => string | null;
-    loadConfigFile: () => {};
-    validateHintsConfig: () => ValidateHintsConfigResult | null;
-};
-
-type Config = {
-    Configuration: Configuration;
-};
-
-type Spinner = {
-    fail: () => void;
-    start: () => void;
-    succeed: () => void;
-    text: string;
-};
-
 type AskQuestion = {
     default: () => any;
 };
@@ -80,24 +62,24 @@ const logger: Logger = {
     log(text: string) { }
 };
 
-const config: Config = {
+const config = {
     Configuration: {
         fromConfig(config: UserConfig | null) {
             return {};
         },
-        getFilenameForDirectory() {
+        getFilenameForDirectory(): string | null {
             return '';
         },
         loadConfigFile() {
             return {};
         },
-        validateHintsConfig() {
+        validateHintsConfig(): ValidateHintsConfigResult | null {
             return null;
         }
     }
 };
 
-const spinner: Spinner = {
+const spinner = {
     fail() { },
     start() { },
     succeed() { },

--- a/packages/hint/tests/lib/types/parser.ts
+++ b/packages/hint/tests/lib/types/parser.ts
@@ -5,13 +5,31 @@ import { EventEmitter2 } from 'eventemitter2';
 
 import { Engine } from '../../../src/lib/engine';
 
-const asPathString = { default() { } };
+const asPathString = {
+    default(): string {
+        return '';
+    }
+};
 const asUri = { getAsUri() { } };
 const path = {
-    dirname() { },
-    resolve() { }
+    dirname(): string {
+        return '';
+    },
+    resolve(): string {
+        return '';
+    }
 };
-const loadJSONFileModule = { default() { } };
+
+type FileModule = {
+    extends: string | null;
+    name: string;
+};
+
+const loadJSONFileModule = {
+    default(): FileModule | null {
+        return null;
+    }
+};
 
 proxyquire('../../../src/lib/types/parser', {
     '../utils/fs/load-json-file': loadJSONFileModule,
@@ -20,7 +38,7 @@ proxyquire('../../../src/lib/types/parser', {
     path
 });
 
-import { ExtendableConfiguration, Parser} from '../../../src/lib/types/parser';
+import { ExtendableConfiguration, Parser } from '../../../src/lib/types/parser';
 
 interface ITestConfig extends ExtendableConfiguration {
     name?: string;

--- a/packages/hint/tests/lib/utils/appinsights.ts
+++ b/packages/hint/tests/lib/utils/appinsights.ts
@@ -4,19 +4,48 @@ import test from 'ava';
 import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
 
-const misc = { getHintPackage() { } };
+const misc = {
+    getHintPackage(): string {
+        return '';
+    }
+};
 
-const applicationinsightsClient = {
+type ApplicationinsightsClient = {
+    trackEvent: () => void;
+    trackException: () => void;
+};
+
+type ApplicationInsights = {
+    defaultClient: ApplicationinsightsClient;
+};
+
+type ApplicationInsightsExtended = ApplicationInsights & {
+    setAutoCollectDependencies: () => ApplicationInsights;
+    setAutoCollectExceptions: () => ApplicationInsights;
+    setAutoCollectPerformance: () => ApplicationInsights;
+    setAutoCollectRequests: () => ApplicationInsights;
+    setAutoDependencyCorrelation: () => ApplicationInsights;
+    setInternalLogging: () => ApplicationInsights;
+    setup: () => ApplicationInsights;
+    setUseDiskRetryCaching: () => ApplicationInsights;
+    start: () => ApplicationinsightsClient;
+};
+
+const applicationinsightsClient: ApplicationinsightsClient = {
     trackEvent() { },
     trackException() { }
 };
 
 const configStore = {
-    get() { },
-    set() { }
+    get(): boolean {
+        return false;
+    },
+    set(): boolean {
+        return false;
+    }
 };
 
-const applicationinsights = {
+const applicationinsights: ApplicationInsightsExtended = {
     defaultClient: applicationinsightsClient,
     setAutoCollectDependencies() {
         return applicationinsights;
@@ -43,7 +72,7 @@ const applicationinsights = {
         return applicationinsights;
     },
     start() {
-        return applicationinsights;
+        return applicationinsightsClient;
     }
 };
 

--- a/packages/hint/tests/lib/utils/npm.ts
+++ b/packages/hint/tests/lib/utils/npm.ts
@@ -8,16 +8,32 @@ import readFile from '../../../src/lib/utils/fs/read-file';
 
 const npmRegistryFetch = { json() { } };
 
-const child = { spawn() { } };
+const child = {
+    spawn(): EventEmitter | null {
+        return null;
+    }
+};
 const logger = {
     error() { },
     log() { }
 };
 
-const findPackageRootModule = { default() { } };
-const loadJSONFileModule = { default() { } };
+const findPackageRootModule = {
+    default(): string {
+        return '';
+    }
+};
+const loadJSONFileModule = {
+    default(): string {
+        return '';
+    }
+};
 
-const fs = { existsSync() { } };
+const fs = {
+    existsSync(): boolean {
+        return true;
+    }
+};
 
 const devDependencyJson = JSON.parse(readFile(`${__dirname}/fixtures/dev-package.json`));
 const dependencyJson = JSON.parse(readFile(`${__dirname}/fixtures/dep-package.json`));

--- a/packages/parser-css/tests/basic-tests.ts
+++ b/packages/parser-css/tests/basic-tests.ts
@@ -5,8 +5,28 @@ import { Rule, Declaration } from 'postcss';
 import * as CSSParser from '../src/parser';
 import { StyleParse } from '../src/types';
 
-const postcss = { parse() { } };
-const element = { getAttribute() { }, outerHTML() { } };
+type Element = {
+    getAttribute: () => string | null;
+    outerHTML: () => Promise<string>;
+};
+
+type Postcss = {
+    parse: () => {};
+};
+
+const postcss: Postcss = {
+    parse() {
+        return {};
+    }
+};
+const element: Element = {
+    getAttribute() {
+        return null;
+    },
+    outerHTML() {
+        return Promise.resolve('');
+    }
+};
 
 test.beforeEach((t) => {
     t.context.element = element;
@@ -37,7 +57,7 @@ test.serial('We should provide a correct AST when parsing CSS.', async (t) => {
     t.is(t.context.engine.emitAsync.args[1][0], 'parse::start::css');
 
     const args = t.context.engine.emitAsync.args[2];
-    const data= args[1] as StyleParse;
+    const data = args[1] as StyleParse;
     const root = data.ast;
     const rule = root.first as Rule;
     const declaration = rule.first as Declaration;

--- a/packages/parser-css/tests/basic-tests.ts
+++ b/packages/parser-css/tests/basic-tests.ts
@@ -5,25 +5,16 @@ import { Rule, Declaration } from 'postcss';
 import * as CSSParser from '../src/parser';
 import { StyleParse } from '../src/types';
 
-type Element = {
-    getAttribute: () => string | null;
-    outerHTML: () => Promise<string>;
-};
-
-type Postcss = {
-    parse: () => {};
-};
-
-const postcss: Postcss = {
+const postcss = {
     parse() {
         return {};
     }
 };
-const element: Element = {
-    getAttribute() {
+const element = {
+    getAttribute(): string | null {
         return null;
     },
-    outerHTML() {
+    outerHTML(): Promise<string> {
         return Promise.resolve('');
     }
 };

--- a/packages/parser-css/tests/interface-tests.ts
+++ b/packages/parser-css/tests/interface-tests.ts
@@ -3,25 +3,16 @@ import * as sinon from 'sinon';
 import test from 'ava';
 import { EventEmitter2 } from 'eventemitter2';
 
-type Element = {
-    getAttribute: () => string | null;
-    outerHTML: () => Promise<string>;
-};
-
-type Postcss = {
-    parse: () => {};
-};
-
-const postcss: Postcss = {
+const postcss = {
     parse() {
         return {};
     }
 };
-const element: Element = {
-    getAttribute() {
+const element = {
+    getAttribute(): string | null {
         return null;
     },
-    outerHTML() {
+    outerHTML(): Promise<string> {
         return Promise.resolve('');
     }
 };

--- a/packages/parser-css/tests/interface-tests.ts
+++ b/packages/parser-css/tests/interface-tests.ts
@@ -3,8 +3,28 @@ import * as sinon from 'sinon';
 import test from 'ava';
 import { EventEmitter2 } from 'eventemitter2';
 
-const postcss = { parse() { } };
-const element = { getAttribute() { }, outerHTML() { } };
+type Element = {
+    getAttribute: () => string | null;
+    outerHTML: () => Promise<string>;
+};
+
+type Postcss = {
+    parse: () => {};
+};
+
+const postcss: Postcss = {
+    parse() {
+        return {};
+    }
+};
+const element: Element = {
+    getAttribute() {
+        return null;
+    },
+    outerHTML() {
+        return Promise.resolve('');
+    }
+};
 
 proxyquire('../src/parser', { postcss });
 

--- a/packages/parser-javascript/tests/tests.ts
+++ b/packages/parser-javascript/tests/tests.ts
@@ -3,34 +3,21 @@ import * as sinon from 'sinon';
 import test from 'ava';
 import { EventEmitter2 } from 'eventemitter2';
 
-type Element = {
-    getAttribute: () => string | null;
-    outerHTML: () => Promise<string>;
-};
-
-type Eslint = {
-    SourceCode: () => {};
-};
-
-type Espree = {
-    parse: () => {};
-};
-
-const eslint: Eslint = {
+const eslint = {
     SourceCode() {
         return {};
     }
 };
-const espree: Espree = {
+const espree = {
     parse() {
         return {};
     }
 };
-const element: Element = {
-    getAttribute() {
+const element = {
+    getAttribute(): string | null {
         return null;
     },
-    outerHTML() {
+    outerHTML(): Promise<string> {
         return Promise.resolve('');
     }
 };

--- a/packages/parser-javascript/tests/tests.ts
+++ b/packages/parser-javascript/tests/tests.ts
@@ -3,13 +3,41 @@ import * as sinon from 'sinon';
 import test from 'ava';
 import { EventEmitter2 } from 'eventemitter2';
 
-const eslint = { SourceCode() { } };
-const espree = { parse() { } };
-const element = { getAttribute() { }, outerHTML() { } };
+type Element = {
+    getAttribute: () => string | null;
+    outerHTML: () => Promise<string>;
+};
+
+type Eslint = {
+    SourceCode: () => {};
+};
+
+type Espree = {
+    parse: () => {};
+};
+
+const eslint: Eslint = {
+    SourceCode() {
+        return {};
+    }
+};
+const espree: Espree = {
+    parse() {
+        return {};
+    }
+};
+const element: Element = {
+    getAttribute() {
+        return null;
+    },
+    outerHTML() {
+        return Promise.resolve('');
+    }
+};
 
 proxyquire('../src/parser', {
     // eslint-disable-next-line
-    'eslint/lib/util/source-code': function(...args: any[]) {
+    'eslint/lib/util/source-code': function (...args: any[]) {
         return Reflect.construct(eslint.SourceCode, args, new.target);
     },
     espree

--- a/packages/parser-webpack-config/tests/webpack-config.ts
+++ b/packages/parser-webpack-config/tests/webpack-config.ts
@@ -4,15 +4,7 @@ import { EventEmitter2 } from 'eventemitter2';
 import * as path from 'path';
 import * as proxyquire from 'proxyquire';
 
-type Package = {
-    version: string;
-};
-
-type LoadPackage = {
-    default: () => Package;
-};
-
-const loadPackage: LoadPackage = {
+const loadPackage = {
     default() {
         return { version: '' };
     }

--- a/packages/parser-webpack-config/tests/webpack-config.ts
+++ b/packages/parser-webpack-config/tests/webpack-config.ts
@@ -4,7 +4,19 @@ import { EventEmitter2 } from 'eventemitter2';
 import * as path from 'path';
 import * as proxyquire from 'proxyquire';
 
-const loadPackage = { default() { } };
+type Package = {
+    version: string;
+};
+
+type LoadPackage = {
+    default: () => Package;
+};
+
+const loadPackage: LoadPackage = {
+    default() {
+        return { version: '' };
+    }
+};
 
 proxyquire('../src/parser', { 'hint/dist/src/lib/utils/packages/load-package': loadPackage });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -671,10 +671,10 @@
     "@types/glob" "*"
     "@types/node" "*"
 
-"@types/sinon@5.0.5":
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-5.0.5.tgz#de600fa07eb1ec9d5f55669d5bac46a75fc88115"
-  integrity sha512-Wnuv66VhvAD2LEJfZkq8jowXGxe+gjVibeLCYcVBp7QLdw0BFx2sRkKzoiiDkYEPGg5VyqO805Rcj0stVjQwCQ==
+"@types/sinon@^5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-5.0.7.tgz#0d9f89dd0c9988c4f1505a92a3a324ee7bdb18a6"
+  integrity sha512-opwMHufhUwkn/UUDk35LDbKJpA2VBsZT8WLU8NjayvRLGPxQkN+8XmfC2Xl35MAscBE8469koLLBjaI3XLEIww==
 
 "@types/strip-bom@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
Fix #1517

@antross I need your help hehehe.

As you can see, there is a lot of `as any`, e.g.:
`t.true((t.context.notifier.notify as any).calledOnce);`

In this case, I have defined `notifier.notify` as `() => any`, so calledOnce doesn't exists.
I think I have to use the type: `SinonSpy`:
```ts
interface SinonSpy<TArgs extends any[] = any[], TReturnValue = any>
        extends Pick<
                SinonSpyCallApi<TArgs, TReturnValue>,
                Exclude<keyof SinonSpyCallApi<TArgs, TReturnValue>, 'args'>
            >
```
But if I do something like:
```ts
type StubbedNotifier = {
    notify: sinon.SinonSpy<any>;
    update: {} | null;
};
```
and then I do:
```ts
const stubbedNotifier: StubbedNotifier = {
    notify() { },
    update: {}
};
```

I get the error:
`Type '() => void' is not assignable to type 'SinonSpy<any,any>'`

I think I'm missing something, but no idea what it is :s
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
