### PR TITLE
Fix/1405

### DIFF
--- a/packages/create-hint/src/create-hint.ts
+++ b/packages/create-hint/src/create-hint.ts
@@ -16,7 +16,6 @@ import readFile from 'hint/dist/src/lib/utils/fs/read-file';
 import toCamelCase from 'hint/dist/src/lib/utils/misc/to-camel-case';
 import toPascalCase from 'hint/dist/src/lib/utils/misc/to-pascal-case';
 import writeFileAsync from 'hint/dist/src/lib/utils/fs/write-file-async';
-import { trackEvent, trackException } from 'hint/dist/src/lib/utils/appinsights';
 
 /*
  * ------------------------------------------------------------------------------
@@ -438,15 +437,11 @@ New ${hintPackage.isMulti ? 'package' : 'hint'} ${hintPackage.name} created in $
 3. Run 'npm run hint -- https://YourUrl' to analyze you site.`);
         }
 
-        trackEvent('new-hint');
-
         return true;
     } catch (e) {
         /* istanbul ignore next */{ // eslint-disable-line no-lone-blocks
             logger.error('Error trying to create new hint');
             logger.error(e);
-
-            trackException(e);
 
             return false;
         }

--- a/packages/create-hintrc/src/create-hintrc.ts
+++ b/packages/create-hintrc/src/create-hintrc.ts
@@ -22,7 +22,7 @@ import { getInstalledResources, getCoreResources } from 'hint/dist/src/lib/utils
 import { ResourceType } from 'hint/dist/src/lib/enums/resourcetype';
 import { generateBrowserslistConfig } from './browserslist';
 import { getOfficialPackages, installPackages } from 'hint/dist/src/lib/utils/npm';
-import { trackEvent } from 'hint/dist/src/lib/utils/appinsights';
+import { sendPendingData, trackEvent } from 'hint/dist/src/lib/utils/appinsights';
 
 const debug: debug.IDebugger = d(__filename);
 const defaultFormatter = 'summary';
@@ -205,6 +205,7 @@ export default async (): Promise<boolean> => {
     }
 
     trackEvent('new-hintrc', result.config);
+    await sendPendingData();
 
     return true;
 };

--- a/packages/create-parser/src/new-parser.ts
+++ b/packages/create-parser/src/new-parser.ts
@@ -10,7 +10,7 @@ import isOfficial from 'hint/dist/src/lib/utils/packages/is-official';
 import normalize from 'hint/dist/src/lib/utils/misc/normalize-string-by-delimeter';
 import writeFileAsync from 'hint/dist/src/lib/utils/fs/write-file-async';
 import { escapeSafeString, compileTemplate } from './handlebars-utils';
-import { trackEvent } from 'hint/dist/src/lib/utils/appinsights';
+import { sendPendingData, trackEvent } from 'hint/dist/src/lib/utils/appinsights';
 
 /*
  * ------------------------------------------------------------------------------
@@ -330,6 +330,7 @@ New parser created in ${parserData.destination}
     }
 
     trackEvent('new-parser');
+    await sendPendingData();
 
     return true;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -142,291 +142,6 @@
   dependencies:
     arrify "^1.0.1"
 
-"@hint/configuration-web-recommended@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@hint/configuration-web-recommended/-/configuration-web-recommended-2.0.1.tgz#0ede8e18210ab30131115a8bed7d8056fc5fa865"
-  integrity sha512-zB/luXGBvv0uqtZVvWxB75y59q4M/qh1vT5GHzE2TUjrC2xEw5RpSZi8QxbOIB8x3/fmElFQ7s7LZvIxLZpWcA==
-  dependencies:
-    "@hint/connector-chrome" "^1.1.5"
-    "@hint/connector-jsdom" "^1.0.9"
-    "@hint/connector-local" "^1.1.3"
-    "@hint/formatter-html" "^1.1.2"
-    "@hint/formatter-stylish" "^1.0.2"
-    "@hint/formatter-summary" "^1.0.3"
-    "@hint/hint-axe" "^1.1.1"
-    "@hint/hint-content-type" "^1.0.4"
-    "@hint/hint-disown-opener" "^1.0.5"
-    "@hint/hint-highest-available-document-mode" "^1.0.5"
-    "@hint/hint-html-checker" "^1.0.3"
-    "@hint/hint-http-cache" "^1.0.4"
-    "@hint/hint-http-compression" "^2.0.1"
-    "@hint/hint-image-optimization-cloudinary" "^1.0.4"
-    "@hint/hint-meta-charset-utf-8" "^1.0.4"
-    "@hint/hint-meta-viewport" "^1.0.3"
-    "@hint/hint-no-bom" "^1.0.4"
-    "@hint/hint-no-disallowed-headers" "^1.0.4"
-    "@hint/hint-no-friendly-error-pages" "^1.0.3"
-    "@hint/hint-no-html-only-headers" "^1.0.4"
-    "@hint/hint-no-http-redirects" "^1.0.4"
-    "@hint/hint-no-protocol-relative-urls" "^1.0.4"
-    "@hint/hint-no-vulnerable-javascript-libraries" "^1.9.1"
-    "@hint/hint-sri" "^1.0.3"
-    "@hint/hint-ssllabs" "^1.0.3"
-    "@hint/hint-strict-transport-security" "^1.0.7"
-    "@hint/hint-stylesheet-limits" "^1.0.2"
-    "@hint/hint-validate-set-cookie-header" "^1.0.3"
-    "@hint/hint-x-content-type-options" "^1.0.4"
-    "@hint/parser-html" "^1.0.6"
-
-"@hint/connector-chrome@^1.0.4", "@hint/connector-chrome@^1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@hint/connector-chrome/-/connector-chrome-1.1.5.tgz#1a8276c1f18dee7c3b37a7691954713ec2933787"
-  integrity sha512-3KotCQXwcwx8F39KVyPNDXvH1fPeENt41gjFKfo7OJbLgdX+xd9jShCl4GUY0qARVZducwquZcVtckKFw81/bQ==
-  dependencies:
-    "@hint/utils-debugging-protocol-common" "^1.0.14"
-    chrome-launcher "^0.10.4"
-    is-ci "^1.2.1"
-    lockfile "^1.0.4"
-
-"@hint/connector-jsdom@^1.0.4", "@hint/connector-jsdom@^1.0.9":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@hint/connector-jsdom/-/connector-jsdom-1.1.0.tgz#7350957577439e7d67f85e8f4bf0ad850b505d3c"
-  integrity sha512-502wjKnN/eSfk7UPIZeGuvTSBVwsZplzuIc8ur0/Xa3J1VNHtrmEsGHgd5DpX/Xg0+5XobXh6xNsWEOf841K6Q==
-  dependencies:
-    "@hint/utils-connector-tools" "^1.0.8"
-    jsdom "^13.0.0"
-    mutationobserver-shim "^0.3.2"
-    node-pre-gyp "^0.11.0"
-    whatwg-fetch "^3.0.0"
-  optionalDependencies:
-    canvas "^2.0.1"
-
-"@hint/connector-local@^1.1.1", "@hint/connector-local@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@hint/connector-local/-/connector-local-1.1.3.tgz#2497374dc19d6c16d0aadf63cfe7fd5f123479d7"
-  integrity sha512-O7NWvZUctoyasx920gogGwefy5BxiXU6ReqAVtFB73UavQm9hzmJXw2LEHHdM3mpPhElCOO8RrOPqyEN7euhpQ==
-  dependencies:
-    chokidar "^2.0.4"
-    globby "^8.0.1"
-
-"@hint/formatter-html@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@hint/formatter-html/-/formatter-html-1.1.2.tgz#cffb06244342b08b2542dd6f1c9f88c5c5662742"
-  integrity sha512-Lf1kFUKUV8sBq5+wP8qjheazbSaBXiDJFv8uQyJICo9uQYRHzkeiBWzcG4CqyIohU92VBmQYkoKOYuBQZV9Cdg==
-  dependencies:
-    ejs "^2.6.1"
-    fs-extra "^7.0.0"
-    lodash "^4.17.11"
-    moment "^2.22.2"
-
-"@hint/formatter-stylish@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@hint/formatter-stylish/-/formatter-stylish-1.0.2.tgz#0f53b9387ea9db57dff26841d15a36f08588f4c4"
-  integrity sha512-HjFhfWR91pkyGt9hbpl8t9CJDJDoHT0MPB/UizRR3f9+hboJsL+H2Vqfs5Cm6fAKlypqOwtNkgHuaijaRV8RTg==
-  dependencies:
-    chalk "^2.4.1"
-    lodash "^4.17.11"
-    log-symbols "^2.2.0"
-    text-table "^0.2.0"
-
-"@hint/formatter-summary@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@hint/formatter-summary/-/formatter-summary-1.0.3.tgz#6331966546d5a9ea08f3e356ababe0d7e22e3d75"
-  integrity sha512-aVBqST6HHhBND0OCv7fa99MsW6NBytbqtIBs08+9II9jVY03JDurPGVIUL7itKlQkrRAi7CMmt2NCX9dyhcRPQ==
-  dependencies:
-    chalk "^2.4.1"
-    lodash "^4.17.11"
-    log-symbols "^2.2.0"
-    text-table "^0.2.0"
-
-"@hint/hint-axe@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@hint/hint-axe/-/hint-axe-1.1.1.tgz#317ea22349f24a05c2dc631b29afcb1cd7d282ff"
-  integrity sha512-ca3K6stn6LZa2wVkNfTuxEQzv/vdWKd4llDMpU8RPg6QVxtPhNAZs10py6TLIljZqNbuMcVMxvQhrUxrNDxFGw==
-  dependencies:
-    axe-core "^3.1.1"
-
-"@hint/hint-content-type@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@hint/hint-content-type/-/hint-content-type-1.0.4.tgz#0e439769847549f70fef58fcf7c8b15d0f9e3542"
-  integrity sha512-Slj37ra4l6Jiy7WKj6tkIcze+HvTzd+3lj+qDkkWvcpeOIHHB/4YgRifx1QyKc85WyETn/An6IQ+r+piofxVfQ==
-  dependencies:
-    content-type "^1.0.4"
-
-"@hint/hint-disown-opener@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@hint/hint-disown-opener/-/hint-disown-opener-1.0.5.tgz#8e79dc5d4ba3d52116fff12bf094da7fda6bc1a6"
-  integrity sha512-Uk3uPjdEaZD4n0oX23b6birOWVhnRhrkzn7lUqvO6HmEKQQo93N8RtC1G1+kQgpKRDIDhzpOXdi9+kbE0HaDAA==
-
-"@hint/hint-highest-available-document-mode@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@hint/hint-highest-available-document-mode/-/hint-highest-available-document-mode-1.0.5.tgz#5050d73b3950dba60239f415c442d6a5bfbdf03b"
-  integrity sha512-2lyPx9EOyuehcqFfMeMrbu7YcTGpOMixJYA1h0R9GzLG1PvA5+zKcq7+/0hn3u/lc3WL2NXcI6dbXzaDYprRYw==
-
-"@hint/hint-html-checker@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@hint/hint-html-checker/-/hint-html-checker-1.0.3.tgz#1bab2cc9617c0ee04545035ff72c2dda4994646d"
-  integrity sha512-nPwwVBogq8l0Pck57I9z/900H5nFS10rHxt2XV/3x1gzhB3XbiB4z36PfvW1JPxUErZMv3/mqaGRQrBO/FsgHQ==
-  dependencies:
-    lodash "^4.17.11"
-
-"@hint/hint-http-cache@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@hint/hint-http-cache/-/hint-http-cache-1.0.4.tgz#3352e4dedc96a9face8858e81ae9d094e477289a"
-  integrity sha512-20WIS/BSppvDJK9ZxjT+LkNitLfvnA9Xcy1Y7oExMZ0eY//L9WuwfStf7EIB0WaEuAzPyslqs6/jyJdH1Np/Uw==
-
-"@hint/hint-http-compression@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@hint/hint-http-compression/-/hint-http-compression-2.0.1.tgz#5f231a974019a8cfe4b323e9c1532166f17e176d"
-  integrity sha512-LhSKYh7oicj1FzKmo3bOOAK0jowHkuYMWFhSX8rg+R4H9Ik/6Vvm2N7EkXc2jhKq6BX7brhzo9R7eMgmAZwqsA==
-  dependencies:
-    iltorb "^2.4.0"
-
-"@hint/hint-image-optimization-cloudinary@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@hint/hint-image-optimization-cloudinary/-/hint-image-optimization-cloudinary-1.0.4.tgz#18a50832af17fd64b781637e2ecb909239c5900a"
-  integrity sha512-+mvQfMhpJ7tVV4wA5ZMRWvOEtTgKEkfJCIFZPJOcLgkuLhFy1YdM/Ueg6BWhHPsj23MUCZCNoZkxteXUHhhoBg==
-  dependencies:
-    cloudinary "^1.9.1"
-    fs-extra "^7.0.0"
-    image-size "^0.6.3"
-
-"@hint/hint-meta-charset-utf-8@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@hint/hint-meta-charset-utf-8/-/hint-meta-charset-utf-8-1.0.4.tgz#d5c42a1bc1beb9bb73773bd084f51152e0ca8c32"
-  integrity sha512-14/AzVkNHZQ+CUTBcn7hwyo0BPza9u8Sv30KH5yFDA5QkYzM1bExmJgs2tXnhqo0EfGZ0c0XGWL50se5PhwdRQ==
-  dependencies:
-    cheerio "^1.0.0-rc.2"
-
-"@hint/hint-meta-viewport@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@hint/hint-meta-viewport/-/hint-meta-viewport-1.0.3.tgz#7a3e3d72898aaecc3b8a44e0fe1a5b36d52cfe34"
-  integrity sha512-pVl/BCgjsFR+U0wVirS5SxyxxC8JyuFNIXHftmS7Yu7UpvA1H6ZpxmPlJCOKA9LHot7tHwI/KMzJ1CSL91sSpA==
-  dependencies:
-    metaviewport-parser "^0.2.0"
-
-"@hint/hint-no-bom@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@hint/hint-no-bom/-/hint-no-bom-1.0.4.tgz#959ce93f16b9ff9834692d427b68535195fd6878"
-  integrity sha512-x2kebZti++oWpDT4vzkV2OJQK6ML4Wzuk2GDZn8+GJx5wdXeOHtvU7LpzN5Z8JwpHCBpnBAttUYUdFSN1whcOg==
-
-"@hint/hint-no-disallowed-headers@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@hint/hint-no-disallowed-headers/-/hint-no-disallowed-headers-1.0.4.tgz#982757743b3445a9584f4a02695d21bb5d6af982"
-  integrity sha512-J6Kl1S4KD8vl1n4d2SXOiCNWdFhYqKq5P1Eoy7kCPVkqO6BUjyqkxYkFfSiYgkLhRj9zfmlIvLRvGFW10XQ5gw==
-
-"@hint/hint-no-friendly-error-pages@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@hint/hint-no-friendly-error-pages/-/hint-no-friendly-error-pages-1.0.3.tgz#bf72dec3875e8cef210e05349fdb0910320848a5"
-  integrity sha512-d6+VTXkBg01o8hocyuXtL65LyLpxtHJNkNbD9qDyw4zxo/IlNCSz7lgVnv0Gvxd3qIk57rnXT1ALIFVZxv6pQg==
-
-"@hint/hint-no-html-only-headers@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@hint/hint-no-html-only-headers/-/hint-no-html-only-headers-1.0.4.tgz#f880788e5d6e406dc2c1efbd3c33cdf69e40c5a8"
-  integrity sha512-FZtO1VqBmI0/Isjqa0rlHwf/yBD2u46RVi1nD2hyIMlO0AQxzEo0JC1WEXcvBbbIslbawNBicdrmCZ8ONX95GA==
-
-"@hint/hint-no-http-redirects@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@hint/hint-no-http-redirects/-/hint-no-http-redirects-1.0.4.tgz#f4ea5a9623404c7d657b2b78c43171a355531a45"
-  integrity sha512-rnG0FPut1jpsmZWhOIRv0hr53X+JNis/4v3qxTzccbR8xmCMvGoK0Gsl5v43uOpoNnVqLjzS+XrlJBWOgHNWKA==
-
-"@hint/hint-no-protocol-relative-urls@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@hint/hint-no-protocol-relative-urls/-/hint-no-protocol-relative-urls-1.0.4.tgz#814f35cb18429b905e9d0df7b873f8bc86fc7532"
-  integrity sha512-y99ZzWBDl9+cb+X9jcTSQHojJv8V6sNmnMNb6sWZHJk1fhaL4OlehXhMpCebSc8lUipN8yjk6WnqO8b1+jZVZg==
-
-"@hint/hint-no-vulnerable-javascript-libraries@^1.9.1":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@hint/hint-no-vulnerable-javascript-libraries/-/hint-no-vulnerable-javascript-libraries-1.10.0.tgz#715035ab542f489ca1276aad8e1f310af3548f96"
-  integrity sha512-wxvlD36gV+pzlMOQqObgba7bRf7DKksuAl/JJFevSUYMEMNBOuSo2EQr5xhZEV5GwwKF2g6616HKamGh6NmIyw==
-  dependencies:
-    js-library-detector "^5.1.0"
-    lodash "^4.17.11"
-    semver "^5.6.0"
-
-"@hint/hint-sri@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@hint/hint-sri/-/hint-sri-1.0.3.tgz#007da628d9562e03a2240a6cefa59a330ca49200"
-  integrity sha512-zqny7uYXuVJvL59VDRqwsdNLtql7BHnR30sLCDeIZcwNymY5YFDt6NMq79ryt0ZxrxwII4eM4ayTbWbo8nc+4Q==
-  dependencies:
-    async "^2.6.1"
-
-"@hint/hint-ssllabs@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@hint/hint-ssllabs/-/hint-ssllabs-1.0.3.tgz#3ccabfba6fd083846cce6a9cf2d9dab15cfce9e9"
-  integrity sha512-REzgyFCYtzbKumElHhGi32yLRnm1/YtXqQgHJbuByIT8s3d2b9lpJP5LUGFdXqJz7JVFP/X2r9ghf41QwYZOsg==
-  dependencies:
-    node-ssllabs "^0.5.0"
-
-"@hint/hint-strict-transport-security@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@hint/hint-strict-transport-security/-/hint-strict-transport-security-1.0.7.tgz#f91c76e28a1cc92f0254ffff8bd2167d800b3723"
-  integrity sha512-syqXde9MJGIezh/u5ky9xNuXuyWAVGZe6hzfxBN5/WWSIe7DapF+RHICQx8nhyhi8OasXzCP3zRvdCLi2BXlfw==
-
-"@hint/hint-stylesheet-limits@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@hint/hint-stylesheet-limits/-/hint-stylesheet-limits-1.0.2.tgz#c073fdd91fa3f1078433b8466c05bbeebc8e6768"
-  integrity sha512-ZrcLMPw4D17BbpjqPJzW7nlUkeJnVrmaT1cXyN/9cfNZIrNiQhglWVkkghPZkJwmDAO0cVPRIAMH2zoTDpSk7w==
-
-"@hint/hint-validate-set-cookie-header@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@hint/hint-validate-set-cookie-header/-/hint-validate-set-cookie-header-1.0.3.tgz#88e5c79d0a1c3e0e61c5f281a3eb1e2e5fbad0fc"
-  integrity sha512-0bjfr6w9JnyDXMUvNk2sZVxegboTqfMXSD7UN+fhOC+/N1XPZTgdPGyvDutKB/btB9nZdp4KNNhhKgomTD0WpQ==
-
-"@hint/hint-x-content-type-options@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@hint/hint-x-content-type-options/-/hint-x-content-type-options-1.0.4.tgz#3976fd02b5c1578a9af4a9098814447ec397afa1"
-  integrity sha512-htnMIqbDvnQR2m2fd8lL0FCCOXTGiQoIXETIFuxnOYnr6S3ZClHyefHNoVCBbT2k/UFZbBaAHixQv7W9HDSYUA==
-
-"@hint/parser-html@^1.0.6":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@hint/parser-html/-/parser-html-1.1.0.tgz#bd15c1e2d8ad9b78fd926646b9f3f5dd59ac26f2"
-  integrity sha512-1uK0MZntWK9GDjLb6XOD/hm+scJGWu0/6uW2gqJUSJsy/R6AHeL89963ZNE0blpFCneYVavLGeCg1sfvEkTxAg==
-  dependencies:
-    jsdom "^13.0.0"
-
-"@hint/utils-connector-tools@^1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@hint/utils-connector-tools/-/utils-connector-tools-1.0.8.tgz#ee4d49c0494f9e6bd818824d45b6a5a8e53f1988"
-  integrity sha512-W7xv6+g+B+YnB/DU2wPfxzFH5rHS6Qea5r/XXno7PqGSI6Ri2ms3GPBmY6oU/LJlOM6zj50Wd4XLgJybZd3wpw==
-  dependencies:
-    async "^2.6.1"
-    data-urls "^1.0.1"
-    iconv-lite "^0.4.24"
-    iltorb "^2.4.0"
-    request "^2.88.0"
-
-"@hint/utils-create-server@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@hint/utils-create-server/-/utils-create-server-1.0.3.tgz#df1ef5d798388d7c17d4840312674eb2293516ef"
-  integrity sha512-3V7OjjKyLsPM0+sk9uKW6fEckwGB8f1l9vT0qoxA5xIfWh+0vqVTegbuv7VblxM/RC7r/CKF+NPJhIeru971tQ==
-  dependencies:
-    express "^4.16.3"
-    lodash "^4.17.10"
-    on-headers "^1.0.1"
-
-"@hint/utils-debugging-protocol-common@^1.0.14":
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/@hint/utils-debugging-protocol-common/-/utils-debugging-protocol-common-1.0.14.tgz#146a92defed8f46b1e84ab5f02599e54bada6a07"
-  integrity sha512-1bEYDCsmfX/W/PHcVVlR2Sy7qOUPMN+90FLUkPqmwQidHwCnOWeIt1RIIl3AhDHxX2dH15a6xV2r526W5LKvww==
-  dependencies:
-    "@hint/utils-connector-tools" "^1.0.8"
-    abab "^2.0.0"
-    chrome-remote-interface "^0.26.1"
-    lodash "^4.17.11"
-
-"@hint/utils-tests-helpers@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@hint/utils-tests-helpers/-/utils-tests-helpers-1.0.1.tgz#0a343be26bf9c65d169464e43955bed8f6670b5f"
-  integrity sha512-tG9KoM3sH2RZC3j2imcH5Pa7fFBbtjFN9QYj4YxyZY6oS/gFhopmzR/MPMG2EfB5sqXeUtqZiYzRJjcSRX53jg==
-  dependencies:
-    "@hint/connector-chrome" "^1.0.4"
-    "@hint/connector-jsdom" "^1.0.4"
-    "@hint/connector-local" "^1.1.1"
-    "@hint/utils-create-server" "^1.0.3"
-    ava "^0.25.0"
-    hint "^3.3.2"
-
 "@ladjs/time-require@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@ladjs/time-require/-/time-require-0.1.4.tgz#5c615d75fd647ddd5de9cf6922649558856b21a1"
@@ -1310,7 +1025,7 @@ ajv@^5.2.3, ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.1.0, ajv@^6.5.3, ajv@^6.5.4, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.5.3, ajv@^6.5.5:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.5.tgz#cf97cdade71c6399a92c6d6c4177381291b781a1"
   integrity sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==
@@ -1427,7 +1142,7 @@ append-transform@^1.0.0:
   dependencies:
     default-require-extensions "^2.0.0"
 
-applicationinsights@^1.0.6, applicationinsights@^1.0.7:
+applicationinsights@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.7.tgz#f8d5758b99e5c3e5b2877cfa120c2164a5cf675b"
   integrity sha512-h2v03PzxrsFe/kiPt1FTRKUjVXBln2ZqCCGByeeBbFt8nkyWHfLV6pBgRRRJjMQ0IZCnayzH0lPm4XeOCqugoQ==
@@ -2929,7 +2644,7 @@ cloneable-readable@^1.0.0:
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
 
-cloudinary@^1.13.2, cloudinary@^1.9.1:
+cloudinary@^1.13.2:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/cloudinary/-/cloudinary-1.13.2.tgz#af3c3f5091119d743d85c27be9405cf15e9012db"
   integrity sha512-mZWxWxgln6Bkk5QA72BGb1mwRBFs+r94ZzdN37gROPL7FSOslhvFfEvF/Rz/ruPqR7mblMdzVz3wuLQi1oCalw==
@@ -3021,7 +2736,7 @@ commander@2.17.x, commander@~2.17.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@2.9.0:
+commander@2.9.0, commander@~2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
@@ -3517,6 +3232,11 @@ deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+
+deep-extend@~0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.1.tgz#b894a9dd90d3023fbf1c55a394fb858eb2066f1f"
+  integrity sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -4314,7 +4034,7 @@ expand-template@^1.0.2:
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-1.1.1.tgz#981f188c0c3a87d2e28f559bc541426ff94f21dd"
   integrity sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==
 
-express@^4.16.3, express@^4.16.4:
+express@^4.16.4:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"
   integrity sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==
@@ -4544,7 +4264,7 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-file-type@^10.2.0, file-type@^10.5.0:
+file-type@^10.5.0:
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-10.5.0.tgz#895d686cb677f73aba2ff36ea0fc8a232ae7b890"
   integrity sha512-zxVkZQY5rtw2H75SMPQUXJveD7uWGdaJJtsVBFfdW3m0W6UeBXzUwiIENFKQ2aRuPozTgBZYV6WhyeGOvs5YsA==
@@ -4861,6 +4581,11 @@ get-stdin@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
   integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
+get-stdin@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+  integrity sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -4990,7 +4715,7 @@ glob@^5.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -5302,41 +5027,6 @@ highlight.js@^9.13.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.13.1.tgz#054586d53a6863311168488a0f58d6c505ce641e"
   integrity sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==
 
-hint@^3.3.2, hint@^3.4.10:
-  version "3.4.14"
-  resolved "https://registry.yarnpkg.com/hint/-/hint-3.4.14.tgz#9c0ad3b24d7ec2b711d6a332700a780c70231d9c"
-  integrity sha512-HDl3jPUnC+h6SEoDBdY+sKag7aNOa3qviLUDUwcNyQfAFxgQdTLGgXwnYyea+X0HH33PDlzu511qYW9IGeV36Q==
-  dependencies:
-    ajv "^6.5.4"
-    applicationinsights "^1.0.6"
-    async "^2.6.1"
-    boxen "^2.0.0"
-    browserslist "^4.3.4"
-    caniuse-api "^3.0.0"
-    chalk "^2.4.1"
-    content-type "^1.0.4"
-    debug "^4.1.0"
-    eventemitter2 "^5.0.1"
-    file-type "^10.2.0"
-    file-url "^2.0.2"
-    globby "^8.0.1"
-    handlebars "^4.0.11"
-    is-ci "^1.2.1"
-    is-svg "^3.0.0"
-    jsonc-parser "^2.0.2"
-    lodash "^4.17.11"
-    mime-db "1.35.0"
-    npm-registry-fetch "^3.8.0"
-    optionator "^0.8.2"
-    ora "^3.0.0"
-    request "^2.88.0"
-    semver "^5.6.0"
-    strip-bom "^3.0.0"
-    strip-json-comments "^2.0.1"
-    update-notifier "^2.5.0"
-  optionalDependencies:
-    "@hint/configuration-web-recommended" "^2.0.0"
-
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -5542,7 +5232,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-iltorb@^2.4.0, iltorb@^2.4.1:
+iltorb@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/iltorb/-/iltorb-2.4.1.tgz#3ae14f0a76ba880503884a2fe630b1f748eb4c17"
   integrity sha512-huyAN7dSNe2b7VAl5AyvaeZ8XTcDTSF1b8JVYDggl+SBfHsORq3qMZeesZW7zoEy21s15SiERAITWT5cwxu1Uw==
@@ -6248,6 +5938,14 @@ js-yaml@^3.10.0, js-yaml@^3.12.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@~3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
+  integrity sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -6678,7 +6376,12 @@ lodash.difference@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
   integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
 
-lodash.flatten@^4.2.0:
+lodash.differencewith@~4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz#bafafbc918b55154e179176a00bb0aefaac854b7"
+  integrity sha1-uvr7yRi1UVTheRdqALsK76rIVLc=
+
+lodash.flatten@^4.2.0, lodash.flatten@~4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
@@ -6901,7 +6604,23 @@ markdown-it@8.4.2:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-markdownlint@^0.11.0:
+markdownlint-cli@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli/-/markdownlint-cli-0.13.0.tgz#af1d29e5d8b434256c451c81b87dff1c218844cb"
+  integrity sha512-DCjhAIb4EDny6xdjOcu2Rckp1sOSktQU9PjRN2pK9p0Azby7YYBqZXO8I+vhv5XKd2Pk0IbbOhyZ/+zjfH4oww==
+  dependencies:
+    commander "~2.9.0"
+    deep-extend "~0.5.1"
+    get-stdin "~5.0.1"
+    glob "~7.1.2"
+    js-yaml "~3.11.0"
+    lodash.differencewith "~4.5.0"
+    lodash.flatten "~4.4.0"
+    markdownlint "~0.11.0"
+    minimatch "~3.0.4"
+    rc "~1.2.7"
+
+markdownlint@^0.11.0, markdownlint@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.11.0.tgz#3858bbdbc1ab78abf0c098d841c72b63dd3206a0"
   integrity sha512-wE5WdKD6zW2DQaPQ5TFBTXh5j76DnWd/IFffnDQgHmi6Y61DJXBDfLftZ/suJHuv6cwPjM6gKw2GaRLJMOR+Mg==
@@ -7158,7 +6877,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -8687,7 +8406,7 @@ raw-loader@^0.5.1:
   resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
   integrity sha1-DD0L6u2KAclm2Xh793goElKpeao=
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
+rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@~1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -10327,7 +10046,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript-eslint-parser@20.1.1:
+typescript-eslint-parser@20.1.1, typescript-eslint-parser@^20.0.0:
   version "20.1.1"
   resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-20.1.1.tgz#a09f3e2f1924dd9e0369835f496ccde31eedfb8b"
   integrity sha512-IJhpqHK60Pz2J5pe8rJUQ10DcMcGwhQnvRFcPV79coEV3bpNfSiHkgpS+sf6zx2ANDWgBhmtZbK9ICOy+v3FKA==


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

Fix #1405 

AppInsights was preventing the `create` packages to finish on macOS. This flushes any pending data.
Also AppInsights was causing an `EventEmitter` warning with `create-hint` on macOS and node 10+. This PR removes AppInsights from the package.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
