### PR TITLE
Fix: Savename of HTMLformatter output replaces q-marks with -query-

### DIFF
--- a/.idea/typescript-compiler.xml
+++ b/.idea/typescript-compiler.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="TypeScriptCompiler">
-    <option name="isCompilerEnabled" value="true" />
-    <option name="useConfig" value="true" />
-  </component>
-</project>

--- a/.idea/typescript-compiler.xml
+++ b/.idea/typescript-compiler.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="TypeScriptCompiler">
+    <option name="isCompilerEnabled" value="true" />
+    <option name="useConfig" value="true" />
+  </component>
+</project>

--- a/packages/formatter-html/src/formatter.ts
+++ b/packages/formatter-html/src/formatter.ts
@@ -128,6 +128,7 @@ export default class HTMLFormatter implements IFormatter {
                     .replace(/:/g, '-')
                     .replace(/\./g, '-')
                     .replace(/\//g, '-')
+                    .replace(/[?=]/g, '-query-')
                     .replace(/-$/, '');
                 const destDir = path.join(process.cwd(), 'hint-report', name);
                 const currentDir = path.join(__dirname);


### PR DESCRIPTION
## Pull request checklist

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

## Short description of the change(s)

Previously the HTML Formatter package output the HTML file with the filename `<url-analyzed>`. If you have query strings in your URL this will create a filename with a `?` symbol which is incompatible with some systems.

This update changes the saved filename to replace `?` with `-query-` so the URL is still readable but can be saved as the filename is no longer malformed.
