### PR TITLE
Chore: Deprecate unused `Configuration` methods

### DIFF
--- a/packages/hint/src/lib/config.ts
+++ b/packages/hint/src/lib/config.ts
@@ -28,6 +28,7 @@ import loadJSONFile from './utils/fs/load-json-file';
 import { validateConfig } from './config/config-validator';
 import normalizeHints from './config/normalize-hints';
 import { validate as validateHint, getSeverity } from './config/config-hints';
+import * as logger from './utils/logging';
 import * as resourceLoader from './utils/resource-loader';
 
 const debug: debug.IDebugger = d(__filename);
@@ -213,10 +214,13 @@ export class Configuration {
     }
 
     /**
+     * @deprecated
      * Generates the list of browsers to target using the `browserslist` property
      * of the `hint` configuration or `package.json` or uses the default one
      */
     public static loadBrowsersList(config: UserConfig) {
+        logger.warn('`Configuration.loadBrowsersList` is deprecated. Use `Configuration.fromConfig` instead.');
+
         const directory: string = process.cwd();
         const files: string[] = CONFIG_FILES.reduce((total, configFile) => {
             const filename: string = path.join(directory, configFile);
@@ -428,10 +432,13 @@ export class Configuration {
     }
 
     /**
+     * @deprecated
      * Loads a configuration file regardless of the source. Inspects the file path
      * to determine the correctly way to load the config file.
      */
     public static fromFilePath(filePath: string, actions: CLIOptions): Configuration {
+        logger.warn('`Configuration.fromFilePath` is deprecated. Use `Configuration.loadConfigFile` with `Configuration.fromConfig` instead.');
+
         /**
          * 1. Load the file from the HD
          * 2. Validate it's OK

--- a/packages/hint/src/lib/utils/logging.ts
+++ b/packages/hint/src/lib/utils/logging.ts
@@ -15,3 +15,8 @@ export const error = (message: any, ...optionalParams: any[]) => {
 export const log = (message: any, ...optionalParams: any[]) => {
     console.log(message, ...optionalParams);
 };
+
+/** Cover for console.warn */
+export const warn = (message: any, ...optionalParams: any[]) => {
+    console.warn(message, ...optionalParams);
+};

--- a/packages/hint/tests/lib/utils/logging.ts
+++ b/packages/hint/tests/lib/utils/logging.ts
@@ -7,21 +7,32 @@ test.beforeEach((t) => {
     t.context.console = console;
     console.log = sinon.spy(console, 'log');
     console.error = sinon.spy(console, 'error');
+    console.warn = sinon.spy(console, 'warn');
 });
 
 test.afterEach.always((t) => {
     t.context.console.log.restore();
     t.context.console.error.restore();
+    t.context.console.warn.restore();
 });
 
 test.serial('logging calls console.log', (t) => {
     logging.log('Log');
     t.true(t.context.console.log.calledOnce);
     t.true(t.context.console.error.notCalled);
+    t.true(t.context.console.warn.notCalled);
 });
 
-test.serial('logging calls console.log', (t) => {
+test.serial('logging calls console.error', (t) => {
     logging.error('Error');
     t.true(t.context.console.log.notCalled);
     t.true(t.context.console.error.calledOnce);
+    t.true(t.context.console.warn.notCalled);
+});
+
+test.serial('logging calls console.warn', (t) => {
+    logging.warn('Warn');
+    t.true(t.context.console.log.notCalled);
+    t.true(t.context.console.error.notCalled);
+    t.true(t.context.console.warn.calledOnce);
 });


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~Added/Updated related documentation.~
- ~Added/Updated related tests.~

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Both `fromFilePath` and `loadBrowsersList` are no longer used by
the online scanner, CLI, or extensions. Deprecating prior to removal
since these APIs are public.