### PR TITLE
Docs: Clarify browserslist configuration precedence

### DIFF
--- a/packages/hint/docs/user-guide/configuring-webhint/browser-context.md
+++ b/packages/hint/docs/user-guide/configuring-webhint/browser-context.md
@@ -1,9 +1,8 @@
 # Browser configuration
 
 `webhint` allows you to define what browsers are relevant to your
-scenario by adding the property `browserslist` to your `.hintrc`
-file, or in the `package.json` file. This property follows the same
-convention as [`browserslist`][browserslist]:
+scenario by adding the property `browserslist` to your `package.json`
+file as defined by [`browserslist`][browserslist]:
 
 ```json
 {
@@ -17,20 +16,31 @@ convention as [`browserslist`][browserslist]:
 By specifying this property, you are giving more context to the hints
 allowing them to adapt their behavior. An example of a hint taking
 advantage of this property is [`highest-available-document-mode`][doc
-modes]. This hint will advice to use `edge` mode if Internet Explorer
-8, 9, or 10 need to be supported, but tell you to remove that tag or
-header otherwise, as document modes are not needed for other browsers.
+modes]. This hint will advise you to use `edge` mode if Internet
+Explorer 8, 9, or 10 need to be supported, but tell you to remove that
+tag or header otherwise, as document modes are not needed for other
+browsers.
 
 If no value is defined, [`browserslist`’s defaults][browserslist
 defaults] will be used:
 
 ```js
 browserslist.defaults = [
-    '> 1%',
+    '> 0.5%',
     'last 2 versions',
-    'Firefox ESR'
+    'Firefox ESR',
+    'not dead'
 ];
 ```
+
+You can also configure browsers using any other
+[`browserslist` configuration option][browserslist defaults], such as
+`.browserslistrc`.
+
+If you need to configure browsers for `webhint` without affecting
+other tools, you can specify a `browserslist` property in your
+`.hintrc` file using the same format. This list will take precedence
+over any `browserslist` specified elsewhere when using `webhint`.
 
 <!-- Link labels: -->
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- ~Added/Updated related tests.~

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Also restructure documentation to emphasize using `browserslist`
in `package.json` as recommended by the `browserslist` project.

Plus fix `defaults` example to match current `browserslist` behavior.