### PR TITLE
Ignore vendor prefixes reports when a property is not supported

### DIFF
--- a/packages/hint-compat-api/src/core/api-hint.ts
+++ b/packages/hint-compat-api/src/core/api-hint.ts
@@ -30,7 +30,7 @@ export abstract class APIHint<T extends Events, K extends Event> implements IHin
         this.compatApi = new CompatAPI(namespaceName, mdnBrowsersCollection, isCheckingNotBroadlySupported);
         this.compatLibrary = new classesMapping[namespaceName](context, this.compatApi.compatDataApi, this.testFeature.bind(this));
 
-        (context as HintContext<Events>).on('traverse::end', this.consumeReports.bind(this));
+        (context as HintContext<Events>).on('scan::end', this.consumeReports.bind(this));
     }
 
     private testFeature(feature: FeatureInfo, collection: CompatStatement): boolean {

--- a/packages/hint-compat-api/src/core/api-hint.ts
+++ b/packages/hint-compat-api/src/core/api-hint.ts
@@ -12,6 +12,8 @@ const classesMapping: {[key: string]: any} = {
     html: CompatHTML
 };
 
+const NOT_FOUND_INDEX = -1;
+
 export abstract class APIHint<T extends Events, K extends Event> implements IHint {
     private compatApi: CompatAPI;
     private compatLibrary: ICompatLibrary<K>;
@@ -155,15 +157,15 @@ export abstract class APIHint<T extends Events, K extends Event> implements IHin
     }
 
     private async consumeReports(): Promise<void> {
-        const len = this.pendingReports.length;
-        let fallbackIndex = len;
+        const pendingReportsLength = this.pendingReports.length;
+        let fallbackIndex = pendingReportsLength;
 
-        for (let i = 0; i < len; i = fallbackIndex) {
+        for (let i = 0; i < pendingReportsLength; i = fallbackIndex) {
             const [feature, supportStatementResult] = this.pendingReports[i];
 
             fallbackIndex = this.getFallbackIndex(feature, i);
 
-            if (fallbackIndex !== -1) {
+            if (fallbackIndex !== NOT_FOUND_INDEX) {
                 continue;
             }
 
@@ -175,15 +177,13 @@ export abstract class APIHint<T extends Events, K extends Event> implements IHin
     }
 
     private getFallbackIndex(feature: FeatureInfo, index: number): number {
-        const NOT_FOUND_INDEX = -1;
-
         if (!feature.prefix) {
             return NOT_FOUND_INDEX;
         }
 
-        const len = this.pendingReports.length;
+        const pendingReportsLength = this.pendingReports.length;
 
-        for (let i = index + 1; i < len; i++) {
+        for (let i = index + 1; i < pendingReportsLength; i++) {
             const [nextFeature] = this.pendingReports[i];
 
             if (feature.name !== nextFeature.name) {

--- a/packages/hint-compat-api/src/core/api-hint.ts
+++ b/packages/hint-compat-api/src/core/api-hint.ts
@@ -37,10 +37,9 @@ export abstract class APIHint<T extends Events, K extends Event> implements IHin
         });
 
         const groupedSupportByBrowser: { [key: string]: string[] } = browsersToSupport
-            .reduce((group, browserSupportStatement) => {
-                const [name, supportStatement] = browserSupportStatement;
+            .reduce((group, [name, supportStatement]) => {
                 const browserInfo: BrowsersInfo = { name, supportStatement };
-                const browserSupport = this.getSupportStatementByBrowser(feature, status, browserInfo);
+                const browserSupport = this.getSupportStatementByBrowser(browserInfo, feature, status);
 
                 if (!browserSupport) {
                     return group;
@@ -66,11 +65,15 @@ export abstract class APIHint<T extends Events, K extends Event> implements IHin
         await this.compatLibrary.reportError(feature, message);
     }
 
-    private getSupportStatementByBrowser(feature: FeatureInfo, status: StatusBlock, browserInfo: BrowsersInfo): string[] | null {
+    private getSupportStatementByBrowser(browser: BrowsersInfo, feature: FeatureInfo, status: StatusBlock): string[] | null {
         const prefix = feature.subFeature ? feature.subFeature.prefix : feature.prefix;
-        const browserFeature = this.compatApi.getSupportStatementFromInfo(browserInfo.supportStatement, prefix);
+        const browserFeature = this.compatApi.getSupportStatementFromInfo(browser.supportStatement, prefix);
 
-        return browserFeature && this.getBrowserSupport(browserInfo, feature, browserFeature, status);
+        if (!browserFeature) {
+            return null;
+        }
+
+        return this.getBrowserSupport(browser, feature, browserFeature, status);
     }
 
     /**

--- a/packages/hint-compat-api/src/core/api-hint.ts
+++ b/packages/hint-compat-api/src/core/api-hint.ts
@@ -174,6 +174,9 @@ export abstract class APIHint<T extends Events, K extends Event> implements IHin
             await this.compatLibrary.reportError(feature, message);
             fallbackIndex = i + 1;
         }
+
+        // NOTE: Clean pending reports after being consumed
+        this.pendingReports = [];
     }
 
     private getFallbackIndex(feature: FeatureInfo, index: number): number {

--- a/packages/hint-compat-api/src/helpers/compat-css.ts
+++ b/packages/hint-compat-api/src/helpers/compat-css.ts
@@ -59,11 +59,7 @@ export class CompatCSS extends CompatBase<StyleEvents, StyleParse> implements IC
             feature.displayableName = name;
         }
 
-        if (this.isFeatureAlreadyReported(feature)) {
-            return;
-        }
-
-        await this.testFunction(feature, collection);
+        await this.checkFeatureCompatibility(feature, collection);
     }
 
     private getProblemLocationFromNode(node: ChildNode): ProblemLocation | undefined {

--- a/packages/hint-compat-api/src/helpers/compat-css.ts
+++ b/packages/hint-compat-api/src/helpers/compat-css.ts
@@ -39,7 +39,7 @@ export class CompatCSS extends CompatBase<StyleEvents, StyleParse> implements IC
         await this.searchFeatures(parse);
     }
 
-    private async testFeature(strategyName: string, featureNameWithPrefix: string, location?: ProblemLocation, subfeatureNameWithPrefix?: string): Promise<void> {
+    private testFeature(strategyName: string, featureNameWithPrefix: string, location?: ProblemLocation, subfeatureNameWithPrefix?: string): void {
         const collection: CompatStatement | undefined = this.MDNData[strategyName];
 
         if (!collection) {
@@ -59,7 +59,7 @@ export class CompatCSS extends CompatBase<StyleEvents, StyleParse> implements IC
             feature.displayableName = name;
         }
 
-        await this.checkFeatureCompatibility(feature, collection);
+        this.checkFeatureCompatibility(feature, collection);
     }
 
     private getProblemLocationFromNode(node: ChildNode): ProblemLocation | undefined {

--- a/packages/hint-compat-api/src/helpers/compat-html.ts
+++ b/packages/hint-compat-api/src/helpers/compat-html.ts
@@ -87,11 +87,7 @@ export class CompatHTML extends CompatBase<Events, Event> {
     }
 
     private async testFeature(collection: CompatStatement | undefined, feature: FeatureInfo) {
-        if (this.isFeatureAlreadyReported(feature)) {
-            return;
-        }
-
-        await this.testFunction(feature, collection);
+        await this.checkFeatureCompatibility(feature, collection);
     }
 
     private async walk(callback: (element: ElementFound) => any): Promise<void> {

--- a/packages/hint-compat-api/src/helpers/compat-html.ts
+++ b/packages/hint-compat-api/src/helpers/compat-html.ts
@@ -45,22 +45,9 @@ export class CompatHTML extends CompatBase<Events, Event> {
         for (let index = 0; index < namedNodeMap.length; index++) {
             const attribute: AsyncHTMLAttribute = namedNodeMap[index];
 
-            await this.testGlobalAttributes(element, attribute, location);
+            await this.testGlobalAttributes(attribute, location);
             await this.testElementAttributes(element, attribute, location);
         }
-    }
-
-    private async testGlobalAttributes(element: IAsyncHTMLElement, attribute: AsyncHTMLAttribute, location: ProblemLocation): Promise<void> {
-        const globalAttributes = this.MDNData.global_attributes;
-        const attributeName = attribute.name;
-
-        const feature: FeatureInfo = {
-            displayableName: `global attribute ${attributeName}`,
-            location,
-            name: attributeName
-        };
-
-        await this.testFeature(globalAttributes, feature);
     }
 
     private async testElementAttributes(element: IAsyncHTMLElement, attribute: AsyncHTMLAttribute, location: ProblemLocation): Promise<void> {
@@ -84,6 +71,19 @@ export class CompatHTML extends CompatBase<Events, Event> {
         };
 
         await this.testFeature(elements, feature);
+    }
+
+    private async testGlobalAttributes(attribute: AsyncHTMLAttribute, location: ProblemLocation): Promise<void> {
+        const globalAttributes = this.MDNData.global_attributes;
+        const attributeName = attribute.name;
+
+        const feature: FeatureInfo = {
+            displayableName: `global attribute ${attributeName}`,
+            location,
+            name: attributeName
+        };
+
+        await this.testFeature(globalAttributes, feature);
     }
 
     private async testFeature(collection: CompatStatement | undefined, feature: FeatureInfo) {

--- a/packages/hint-compat-api/src/helpers/compat-html.ts
+++ b/packages/hint-compat-api/src/helpers/compat-html.ts
@@ -86,8 +86,8 @@ export class CompatHTML extends CompatBase<Events, Event> {
         await this.testFeature(globalAttributes, feature);
     }
 
-    private async testFeature(collection: CompatStatement | undefined, feature: FeatureInfo) {
-        await this.checkFeatureCompatibility(feature, collection);
+    private testFeature(collection: CompatStatement | undefined, feature: FeatureInfo): void {
+        this.checkFeatureCompatibility(feature, collection);
     }
 
     private async walk(callback: (element: ElementFound) => any): Promise<void> {

--- a/packages/hint-compat-api/src/types.ts
+++ b/packages/hint-compat-api/src/types.ts
@@ -14,7 +14,7 @@ export type FeatureStrategy<T extends ChildNode> = {
     testFeature: (node: T, location?: ProblemLocation) => void;
 };
 
-export type TestFeatureFunction = (feature: FeatureInfo, collection: CompatStatement | undefined) => void;
+export type TestFeatureFunction = (feature: FeatureInfo, collection: CompatStatement | undefined) => boolean;
 
 export type BrowserVersions = {
     [key: string]: string[];

--- a/packages/hint-compat-api/tests/css-next.ts
+++ b/packages/hint-compat-api/tests/css-next.ts
@@ -242,6 +242,19 @@ const notSupportedPropertiesAndValuesShouldNotSeparatelyLog: HintTest[] = [
 
 hintRunner.testHint(hintPath, notSupportedPropertiesAndValuesShouldNotSeparatelyLog, { browserslist: ['firefox 60', 'ie 10'], parsers: ['css']});
 
+const notSupportedFeaturesWithoutFallbackShouldSeparatelyLog: HintTest[] = [
+    {
+        name: 'Features not supported and not deprecated should separately log vendor prefixes if fallback is not defined.',
+        reports: [
+            { message: 'appearance prefixed with -webkit- is not supported by ie.', position: { column: 4, line: 1 }},
+            { message: 'appearance prefixed with -moz- is not supported by ie.', position: { column: 4, line: 2 }}
+        ],
+        serverConfig: generateCSSConfig('appearance-only-prefixes')
+    }
+];
+
+hintRunner.testHint(hintPath, notSupportedFeaturesWithoutFallbackShouldSeparatelyLog, { browserslist: ['firefox 60', 'ie 10'], parsers: ['css']});
+
 const notSupportedAndNotDeprecatedFeature: HintTest[] = [
     {
         name: 'Features not supported and not deprecated should fail.',

--- a/packages/hint-compat-api/tests/css-next.ts
+++ b/packages/hint-compat-api/tests/css-next.ts
@@ -264,3 +264,27 @@ const notSupportedAndNotDeprecatedFeature: HintTest[] = [
 ];
 
 hintRunner.testHint(hintPath, notSupportedAndNotDeprecatedFeature, { browserslist: ['android 4.4.3-4.4.4', 'edge 17', 'firefox 60', 'ie 11', 'opera 56'], parsers: ['css']});
+
+const notSupportedFeaturesSplittedByCSSRuleBlock: HintTest[] = [
+    {
+        name: 'Should handle reports separately by CSS blocks.',
+        reports: [
+            { message: 'appearance prefixed with -webkit- is not supported by ie.', position: { column: 4, line: 1 }},
+            { message: 'appearance prefixed with -moz- is not supported by ie.', position: { column: 4, line: 2 }},
+            { message: 'appearance is not supported by ie.', position: { column: 4, line: 6 }}
+        ],
+        serverConfig: generateCSSConfig('appearance-splitted')
+    }
+];
+
+hintRunner.testHint(hintPath, notSupportedFeaturesSplittedByCSSRuleBlock, { browserslist: ['firefox 60', 'ie 10'], parsers: ['css']});
+
+const disorderedNotSupportedFeatures: HintTest[] = [
+    {
+        name: 'Should handle disordered vendor prefixes',
+        reports: [{ message: 'appearance is not supported by ie.', position: { column: 4, line: 1 }}],
+        serverConfig: generateCSSConfig('appearance-disordered-prefixes')
+    }
+];
+
+hintRunner.testHint(hintPath, disorderedNotSupportedFeatures, { browserslist: ['firefox 60', 'ie 10'], parsers: ['css']});

--- a/packages/hint-compat-api/tests/css-next.ts
+++ b/packages/hint-compat-api/tests/css-next.ts
@@ -232,19 +232,15 @@ hintRunner.testHint(hintPath, prefixedFeaturesThatBecameStandardAndMarkedAsDepre
  * hintRunner.testHint(hintPath, childPrefixedFeatureAddedLaterThanTargetedBrowsers, { browserslist: ['chrome 17 - 19'], parsers: ['css']});
  */
 
-const notSupportedFeaturesShouldNotSeparatelyLog: HintTest[] = [
+const notSupportedPropertiesAndValuesShouldNotSeparatelyLog: HintTest[] = [
     {
         name: 'Features not supported and not deprecated should not separately log the feature and value.',
-        reports: [
-            { message: 'appearance prefixed with -webkit- is not supported by ie.', position: { column: 4, line: 1 }},
-            { message: 'appearance prefixed with -moz- is not supported by ie.', position: { column: 4, line: 2 }},
-            { message: 'appearance is not supported by ie.', position: { column: 4, line: 3 }}
-        ],
+        reports: [{ message: 'appearance is not supported by ie.', position: { column: 4, line: 3 }}],
         serverConfig: generateCSSConfig('appearance')
     }
 ];
 
-hintRunner.testHint(hintPath, notSupportedFeaturesShouldNotSeparatelyLog, { browserslist: ['firefox 60', 'ie 10'], parsers: ['css']});
+hintRunner.testHint(hintPath, notSupportedPropertiesAndValuesShouldNotSeparatelyLog, { browserslist: ['firefox 60', 'ie 10'], parsers: ['css']});
 
 const notSupportedAndNotDeprecatedFeature: HintTest[] = [
     {

--- a/packages/hint-compat-api/tests/css.ts
+++ b/packages/hint-compat-api/tests/css.ts
@@ -223,3 +223,13 @@ const notSupportedAndNotDeprecatedFeature: HintTest[] = [
 ];
 
 hintRunner.testHint(hintPath, notSupportedAndNotDeprecatedFeature, { browserslist: ['android 4.4.3-4.4.4', 'edge 17', 'firefox 60', 'ie 11', 'opera 56'], parsers: ['css']});
+
+const notSupportedFeaturesShouldNotSeparatelyLog: HintTest[] = [
+    {
+        name: 'Features not supported and not deprecated should not separately log the feature and value.',
+        reports: [{ message: 'box-flex is not supported by ie.', position: { column: 4, line: 3 }}],
+        serverConfig: generateCSSConfig('box-flex-prefixes')
+    }
+];
+
+hintRunner.testHint(hintPath, notSupportedFeaturesShouldNotSeparatelyLog, { browserslist: ['ie 10'], parsers: ['css']});

--- a/packages/hint-compat-api/tests/fixtures/css/appearance-disordered-prefixes.css
+++ b/packages/hint-compat-api/tests/fixtures/css/appearance-disordered-prefixes.css
@@ -1,0 +1,6 @@
+.example {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+}
+

--- a/packages/hint-compat-api/tests/fixtures/css/appearance-only-prefixes.css
+++ b/packages/hint-compat-api/tests/fixtures/css/appearance-only-prefixes.css
@@ -1,0 +1,4 @@
+.example {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+}

--- a/packages/hint-compat-api/tests/fixtures/css/appearance-splitted.css
+++ b/packages/hint-compat-api/tests/fixtures/css/appearance-splitted.css
@@ -1,0 +1,8 @@
+.example1 {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+}
+
+.example2 {
+    appearance: none;
+}

--- a/packages/hint-compat-api/tests/fixtures/css/box-flex-prefixes.css
+++ b/packages/hint-compat-api/tests/fixtures/css/box-flex-prefixes.css
@@ -1,0 +1,5 @@
+.example {
+    -webkit-box-flex: 1;
+    -moz-box-flex: 1;
+    box-flex: 1;
+}


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

- [x] #1598
- [x] #1676 
