### PR TITLE
Chore: Move `vscode` to `devDependencies`

### DIFF
--- a/packages/extension-vscode/package.json
+++ b/packages/extension-vscode/package.json
@@ -17,7 +17,6 @@
     "Linters"
   ],
   "dependencies": {
-    "vscode": "^1.1.22",
     "vscode-languageclient": "^5.1.1",
     "vscode-languageserver": "^5.0.3"
   },
@@ -37,7 +36,8 @@
     "rimraf": "^2.6.3",
     "sinon": "^7.2.2",
     "typescript": "^3.2.2",
-    "typescript-eslint-parser": "21.0.2"
+    "typescript-eslint-parser": "21.0.2",
+    "vscode": "^1.1.22"
   },
   "displayName": "webhint",
   "engines": {
@@ -76,5 +76,5 @@
     "watch:test": "ava --watch",
     "watch:ts": "npm run build:ts -- --watch"
   },
-  "version": "1.0.4"
+  "version": "1.0.5"
 }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~Added/Updated related documentation.~
- ~Added/Updated related tests.~

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Was previously incorrectly listed in `dependencies`.