### PR TITLE
Breaking: Validate only cross-origin resources

### DIFF
--- a/packages/hint-sri/README.md
+++ b/packages/hint-sri/README.md
@@ -48,19 +48,6 @@ This hint checks that a website correctly uses SRI, more specifically:
 
 ### Examples that **trigger** the hint
 
-Same-origin resource with no `integrity`:
-
-```html
-<link rel="stylesheet" href="/style.css">
-```
-
-Same-origin resource with hash function less secure than `sha384`:
-
-```html
-<script src="/script.js" integrity="sha256-validHashHere">
-</script>
-```
-
 Cross-origin resource with no `crossorigin` attribute:
 
 ```html
@@ -87,19 +74,18 @@ Cross-origin resource loaded over `HTTP`:
 </script>
 ```
 
-### Examples that **pass** the hint
-
-Same-origin resource with `sha384` or better:
+Same-origin resource with no `integrity` and `originCriteria` set to `all`:
 
 ```html
-<script src="/script.js" integrity="sha384-validHashHere">
-</script>
+<link rel="stylesheet" href="/style.css">
 ```
 
-Same-origin resource with multiple hashes and `sha384` is one of them:
+### Examples that **pass** the hint
+
+Cross-origin resource with multiple hashes and `sha384` is one of them:
 
 ```html
-<script src="/script.js"
+<script src="https://example.com/script.js"
   integrity="sha256-validHashHere
              sha384-validHashHere">
 </script>
@@ -116,7 +102,12 @@ Cross-origin resource with valid `crossorigin` attribute:
 
 ## Can the hint be configured?
 
-Yes, by default the baseline algorithm is `sha384` but you can
+Yes, you can define the baseline algorithm and the origin of the resources
+to analyze.
+
+### Baseline algorithm
+
+By default the baseline algorithm is `sha384` but you can
 change it to `sha256`, or `sha512` by specifying that in the
 [`.hintrc`][hintrc] file:
 
@@ -136,6 +127,31 @@ change it to `sha256`, or `sha512` by specifying that in the
 
 The above will validate that the `integrity` of all scripts and
 styles use `sha512`.
+
+### Origin criteria
+
+By default, this hint will analyze only resources with a different origin.
+To change this behavior you will have to set the `originCriteria` property
+to one of the following:
+
+* `all`: All resources will be analyzed
+* `crossOrigin`: Only cross-origin resources will be analyzed
+
+The following will analyze all the resources:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "hints": {
+        "sri": ["warning", {
+            "originCriteria": "all"
+        }],
+        ...
+    },
+    ...
+}
+```
 
 ## How to use this hint?
 

--- a/packages/hint-sri/src/meta.ts
+++ b/packages/hint-sri/src/meta.ts
@@ -2,7 +2,7 @@ import { Category } from 'hint/dist/src/lib/enums/category';
 import { HintScope } from 'hint/dist/src/lib/enums/hintscope';
 import { HintMetadata } from 'hint/dist/src/lib/types';
 
-import { algorithms } from './types';
+import { Algorithms, OriginCriteria } from './types';
 
 const meta: HintMetadata = {
     docs: {
@@ -15,7 +15,11 @@ const meta: HintMetadata = {
         additionalProperties: false,
         properties: {
             baseline: {
-                oneOf: [Object.keys(algorithms)],
+                oneOf: [Object.keys(Algorithms)],
+                type: 'string'
+            },
+            originCriteria: {
+                oneOf: [Object.keys(OriginCriteria)],
                 type: 'string'
             }
         }

--- a/packages/hint-sri/src/types.ts
+++ b/packages/hint-sri/src/types.ts
@@ -1,6 +1,11 @@
 // We don't do a `const enum` because of this: https://stackoverflow.com/questions/18111657/how-does-one-get-the-names-of-typescript-enum-entries#comment52596297_18112157
-export enum algorithms {
+export enum Algorithms {
     sha256 = 1,
     sha384 = 2,
     sha512 = 3
+}
+
+export enum OriginCriteria {
+    all = 1,
+    crossOrigin = 2
 }

--- a/packages/hint-sri/tests/tests-https.ts
+++ b/packages/hint-sri/tests/tests-https.ts
@@ -9,7 +9,21 @@ const hintPath = getHintPath(__filename);
 const styles = readFile(`${__dirname}/fixtures/styles.css`);
 const scripts = readFile(`${__dirname}/fixtures/scripts.js`);
 
-const defaultTestsHttps: HintTest[] = [
+const defaults: HintTest[] = [
+    {
+        name: 'Page with no resources passes',
+        serverConfig: generateHTMLPage()
+    },
+    {
+        name: `Page with a same-origin resource and no SRI passes`,
+        serverConfig: {
+            '/': generateHTMLPage('<link rel="stylesheet" href="/styles.css">'),
+            '/styles.css': styles
+        }
+    }
+];
+
+const configOriginAllTestsHttps: HintTest[] = [
     {
         name: 'Page with no resources passes',
         serverConfig: generateHTMLPage()
@@ -252,12 +266,23 @@ const configTestsLow: HintTest[] = [
     }
 ];
 
-hintRunner.testHint(hintPath, defaultTestsHttps, { https: true });
+
+hintRunner.testHint(hintPath, defaults, { https: true });
+hintRunner.testHint(hintPath, configOriginAllTestsHttps, {
+    hintOptions: { originCriteria: 'all' },
+    https: true
+});
 hintRunner.testHint(hintPath, configTestsHigh, {
-    hintOptions: { baseline: 'sha512' },
+    hintOptions: {
+        baseline: 'sha512',
+        originCriteria: 'all'
+    },
     https: true
 });
 hintRunner.testHint(hintPath, configTestsLow, {
-    hintOptions: { baseline: 'sha256' },
+    hintOptions: {
+        baseline: 'sha256',
+        originCriteria: 'all'
+    },
     https: true
 });


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

Add configuration option `originCriteria` that defaults to
`crossOrigin` to indicate the origin to validate ('all' or
'crossOrigin').

 - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix: #1622


<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
