### PR TITLE
Fix: Handle optional `node.source` from `postcss`

### DIFF
--- a/packages/hint-compat-api/src/helpers/compat-css.ts
+++ b/packages/hint-compat-api/src/helpers/compat-css.ts
@@ -31,7 +31,7 @@ export class CompatCSS extends CompatBase<StyleEvents, StyleParse> implements IC
     }
 
     private getProblemLocationFromNode(node: ChildNode): ProblemLocation | undefined {
-        const start = node.source.start;
+        const start = node.source && node.source.start;
 
         if (!start) {
             return undefined;


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~Added/Updated related documentation.~
- ~Added/Updated related tests.~

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Fix #1661

Found via a recent type definition update to `postcss`.