### PR TITLE
Fix: Manifest parser runs twice

### DIFF
--- a/packages/parser-manifest/src/parser.ts
+++ b/packages/parser-manifest/src/parser.ts
@@ -45,6 +45,11 @@ export default class ManifestParser extends Parser<ManifestEvents> {
 
         engine.on('element::link', this.fetchManifest.bind(this));
         engine.on('fetch::end::manifest', this.validateManifest.bind(this));
+        engine.on('scan::end', this.onScanEnd.bind(this));
+    }
+
+    private onScanEnd() {
+        this.parsed = false;
     }
 
     private async fetchManifest(elementFound: ElementFound) {
@@ -110,7 +115,7 @@ export default class ManifestParser extends Parser<ManifestEvents> {
                 element,
                 error: error || new Error(`'${hrefValue}' could not be fetched (status code: ${statusCode}).`),
                 hops: (manifestNetworkData && manifestNetworkData.response.hops) || [manifestURL],
-                resource
+                resource: manifestURL
             });
 
             return;
@@ -121,7 +126,7 @@ export default class ManifestParser extends Parser<ManifestEvents> {
         await this.engine.emitAsync(this.fetchEndEventName, {
             element,
             request: manifestNetworkData.request,
-            resource,
+            resource: manifestURL,
             response: manifestNetworkData.response
         });
     }

--- a/packages/parser-manifest/src/parser.ts
+++ b/packages/parser-manifest/src/parser.ts
@@ -26,6 +26,7 @@ const schema = require('./schema.json');
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 export default class ManifestParser extends Parser<ManifestEvents> {
+    private parsed: boolean = false;
 
     // Event names.
 
@@ -46,7 +47,7 @@ export default class ManifestParser extends Parser<ManifestEvents> {
         engine.on('fetch::end::manifest', this.validateManifest.bind(this));
     }
 
-    private async fetchManifest (elementFound: ElementFound) {
+    private async fetchManifest(elementFound: ElementFound) {
         const { element, resource } = elementFound;
 
         /*
@@ -125,7 +126,16 @@ export default class ManifestParser extends Parser<ManifestEvents> {
         });
     }
 
-    private async validateManifest (fetchEnd: FetchEnd) {
+    private async validateManifest(fetchEnd: FetchEnd) {
+        /*
+         * Chrome fetch the manifest automatically so we need to
+         * ensure that the validation is done just once.
+         */
+        if (this.parsed) {
+            return;
+        }
+
+        this.parsed = true;
         const { resource, response } = fetchEnd;
 
         await this.engine.emitAsync(`parse::start::manifest`, { resource });

--- a/packages/parser-manifest/src/parser.ts
+++ b/packages/parser-manifest/src/parser.ts
@@ -26,8 +26,6 @@ const schema = require('./schema.json');
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 export default class ManifestParser extends Parser<ManifestEvents> {
-    private parsed: boolean = false;
-
     // Event names.
 
     private readonly fetchEndEventName = 'fetch::end::manifest';
@@ -45,11 +43,6 @@ export default class ManifestParser extends Parser<ManifestEvents> {
 
         engine.on('element::link', this.fetchManifest.bind(this));
         engine.on('fetch::end::manifest', this.validateManifest.bind(this));
-        engine.on('scan::end', this.onScanEnd.bind(this));
-    }
-
-    private onScanEnd() {
-        this.parsed = false;
     }
 
     private async fetchManifest(elementFound: ElementFound) {
@@ -132,15 +125,6 @@ export default class ManifestParser extends Parser<ManifestEvents> {
     }
 
     private async validateManifest(fetchEnd: FetchEnd) {
-        /*
-         * Chrome fetch the manifest automatically so we need to
-         * ensure that the validation is done just once.
-         */
-        if (this.parsed) {
-            return;
-        }
-
-        this.parsed = true;
         const { resource, response } = fetchEnd;
 
         await this.engine.emitAsync(`parse::start::manifest`, { resource });

--- a/packages/utils-debugging-protocol-common/src/debugging-protocol-connector.ts
+++ b/packages/utils-debugging-protocol-common/src/debugging-protocol-connector.ts
@@ -335,6 +335,17 @@ export class Connector implements IConnector {
 
         const eventName = `fetch::end::${suffix}` as 'fetch::end::*';
 
+        /*
+         * New versions of chrome are fetching the manifest
+         * automatically, so to prevent emit the event `fetch::end::manifest`
+         * twice, we need to ignore the event here.
+         * The manifest is already captured and processed by
+         * `parser-manifest` when the element is detected in the DOM.
+         */
+        if (suffix === 'manifest') {
+            return;
+        }
+
 
         /** Event is also emitted when status code in response is not 200. */
         await this._server.emitAsync(eventName, data);


### PR DESCRIPTION
It seems like with some chrome versions, the manifest parser runs twice, one when we are traversing the dom and the connector find the `link` element (`element::link`) and a second time when the connector loads the manifest. This second case seems to be the one that didn't happen before but now it is happening.
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
