### PR TITLE
Fix: Gracefully handle invalid browserslist and URL queries

### DIFF
--- a/packages/extension-browser/src/devtools/panel/panel.css
+++ b/packages/extension-browser/src/devtools/panel/panel.css
@@ -7,6 +7,7 @@ html {
     --bg-inverse-alt-color: #999;
     --border-color: #333;
     --border-alt-color: #d7d7d7;
+    --invalid-outline-color: red;
     --link-color: #4700a3;
     --shadow-color: #00000080;
     --text-color: #000;
@@ -38,8 +39,6 @@ body {
 body {
     background-color: var(--bg-color);
     color: var(--text-color);
-    display: flex;
-    flex-direction: column;
     font-family: "Segoe UI", Tahoma, sans-serif; /* Match default overrides in Chrome */
     font-size: 12px; /* Match default overrides in Chrome */
     margin: 0;

--- a/packages/extension-browser/src/devtools/panel/views/pages/analyze.ts
+++ b/packages/extension-browser/src/devtools/panel/views/pages/analyze.ts
@@ -9,10 +9,14 @@ type Props = {
     onCancelClick: Function;
 };
 
+const onSubmit = (event: Event) => {
+    event.preventDefault();
+};
+
 export default function view({ onCancelClick }: Props) {
     return html`
-        ${headerView({analyzeDisabled: true, analyzeText: 'Analyze website'})}
-        <section class="analyze page">
+        <form class="analyze page" onsubmit=${onSubmit}>
+            ${headerView({analyzeDisabled: true, analyzeText: 'Analyze website'})}
             <h1 class="page__header">
                 Analyzing...
             </h1>
@@ -21,6 +25,6 @@ export default function view({ onCancelClick }: Props) {
                     Cancel analysis
                 </button>
             </section>
-        </section>
+        </form>
     `;
 }

--- a/packages/extension-browser/src/devtools/panel/views/pages/configuration.css
+++ b/packages/extension-browser/src/devtools/panel/views/pages/configuration.css
@@ -1,8 +1,3 @@
-.configuration {
-    background-color: var(--bg-alt-color);
-    position: relative;
-}
-
 .configuration__section {
     margin: 1.5rem 2rem;
 }
@@ -25,6 +20,10 @@
     margin: 0.75rem 1.25rem;
 }
 
+.configuration__input:invalid {
+    outline: 1px solid var(--invalid-outline-color);
+}
+
 .configuration__example {
     color: var(--text-highlight-color);
     font-size: 0.85em;
@@ -32,7 +31,8 @@
 }
 
 .configuration__restore-button {
-    position: absolute;
-    right: 2rem;
-    top: 3rem;
+    float: right;
+    margin-right: 2rem;
+    margin-top: 1.5rem;
+    margin-left: -5rem;
 }

--- a/packages/extension-browser/src/devtools/panel/views/pages/configuration.html.ts
+++ b/packages/extension-browser/src/devtools/panel/views/pages/configuration.html.ts
@@ -1,5 +1,4 @@
 import html from '../../../../shared/html-literal';
-import { Config } from '../../../../shared/types';
 
 import headerView from '../partials/header';
 
@@ -8,18 +7,26 @@ import './configuration.css';
 
 type Props = {
     categories: string[];
-    onAnalyzeClick: (config: Config) => void;
+    onAnalyzeClick: () => void;
+    onBrowsersListChange: () => void;
+    onResourcesChange: () => void;
     onRestoreClick: () => void;
 };
 
 /* eslint-disable */
-export default function view({ categories, onAnalyzeClick, onRestoreClick }: Props) {
+export default function view({ categories, onAnalyzeClick, onBrowsersListChange, onResourcesChange, onRestoreClick }: Props) {
+    const onSubmit = (event: Event) => {
+        event.preventDefault();
+        onAnalyzeClick();
+    };
+
     return html`
-        ${headerView({ analyzeText: 'Analyze website', onAnalyzeClick })}
-        <section class="configuration page">
+        <form class="configuration page" onsubmit=${onSubmit}>
+            ${headerView({ analyzeText: 'Analyze website' })}
             <h1 class="page__header">
                 Configuration
             </h1>
+            <button type="button" class="page__button configuration__restore-button" onclick=${onRestoreClick}>Restore defaults</button>
             <section class="configuration__section">
                 <h1 class="configuration__header">
                     Categories:
@@ -36,13 +43,13 @@ export default function view({ categories, onAnalyzeClick, onRestoreClick }: Pro
                     Your target browsers:
                 </h1>
                 <label class="configuration__label">
-                    <input type="checkbox" name="recommended-browsers" checked />
+                    <input type="checkbox" name="recommended-browsers" checked oninput="${onBrowsersListChange}" />
                     Recommended settings
                     <div class="configuration__example">&gt; 0.5%, last 2 versions, Firefox ESR, not dead</div>
                 </label>
                 <label class="configuration__label">
-                    <input type="checkbox" name="custom-browsers" />
-                    <input type="text" name="custom-browsers-list" placeholder="&gt; 1% in US, IE 10" />
+                    <input type="checkbox" name="custom-browsers" oninput="${onBrowsersListChange}" />
+                    <input type="text" class="configuration__input" name="custom-browsers-list" placeholder="&gt; 1% in US, IE 10" oninput="${onBrowsersListChange}" />
                     <div class="configuration__example">
                         <a href="https://github.com/browserslist/browserslist#full-list" target="_blank">
                             See query instructions
@@ -55,16 +62,16 @@ export default function view({ categories, onAnalyzeClick, onRestoreClick }: Pro
                     Ignored resources:
                 </h1>
                 <label class="configuration__label">
-                    <input type="radio" name="resources" value="none" checked />
+                    <input type="radio" name="resources" value="none" checked oninput="${onResourcesChange}" />
                     None
                 </label>
                 <label class="configuration__label">
-                    <input type="radio" name="resources" value="third-party" />
+                    <input type="radio" name="resources" value="third-party" oninput="${onResourcesChange}" />
                     Different origin
                 </label>
                 <label class="configuration__label">
-                    <input type="radio" name="resources" value="custom" />
-                    <input type="text" name="custom-resources" placeholder="google-analytics\.com" />
+                    <input type="radio" name="resources" value="custom" oninput="${onResourcesChange}" />
+                    <input type="text" class="configuration__input" name="custom-resources" placeholder="google-analytics\.com" oninput="${onResourcesChange}" />
                     <div class="configuration__example">
                         <a href="https://webhint.io/docs/user-guide/configuring-webhint/ignoring-domains/" target="_blank">
                             See expression instructions
@@ -72,7 +79,6 @@ export default function view({ categories, onAnalyzeClick, onRestoreClick }: Pro
                     </div>
                 </label>
             </section>
-            <button type="button" class="page__button configuration__restore-button" onclick=${onRestoreClick}>Restore defaults</button>
-        </section>
+        </form>
     `;
 }

--- a/packages/extension-browser/src/devtools/panel/views/pages/results.ts
+++ b/packages/extension-browser/src/devtools/panel/views/pages/results.ts
@@ -13,11 +13,16 @@ type Props = {
 };
 
 export default function view({ onRestartClick, results }: Props) {
+    const onSubmit = (event: Event) => {
+        event.preventDefault();
+        onRestartClick();
+    };
+
     return html`
-        ${headerView({ analyzeText: 'Analyze again', onAnalyzeClick: onRestartClick })}
-        <section class="results page">
+        <form class="results page" onsubmit=${onSubmit}>
+            ${headerView({ analyzeText: 'Analyze again' })}
             <h1 class="page__header">Hints</h1>
             ${results.categories.map(categoryView)}
-        </section>
+        </form>
     `;
 }

--- a/packages/extension-browser/src/devtools/panel/views/partials/category.css
+++ b/packages/extension-browser/src/devtools/panel/views/partials/category.css
@@ -1,3 +1,8 @@
+.configuration {
+    background-color: var(--bg-alt-color);
+    position: relative;
+}
+
 .category__summary {
     background-color: var(--bg-alt-color);
     border: 1px solid var(--border-alt-color);

--- a/packages/extension-browser/src/devtools/panel/views/partials/header.css
+++ b/packages/extension-browser/src/devtools/panel/views/partials/header.css
@@ -1,7 +1,7 @@
 .header {
     align-items: center;
+    background-color: var(--bg-color);
     display: flex;
-    flex: none;
     padding: 1rem;
 }
 

--- a/packages/extension-browser/src/devtools/panel/views/partials/header.ts
+++ b/packages/extension-browser/src/devtools/panel/views/partials/header.ts
@@ -6,18 +6,16 @@ import './header.css';
 type Props = {
     analyzeDisabled?: boolean;
     analyzeText: string;
-    onAnalyzeClick?: Function;
 };
 
-export default function view({ analyzeDisabled, analyzeText, onAnalyzeClick }: Props) {
+export default function view({ analyzeDisabled, analyzeText }: Props) {
     return html`
         <header class="header">
             <div class="header__actions">
                 <button
-                    type="button"
+                    type="submit"
                     class="page__button page__button--primary header__analyze-button"
                     ${analyzeDisabled ? 'disabled' : ''}
-                    onclick=${onAnalyzeClick}
                 >
                     ${analyzeText}
                 </button>

--- a/packages/extension-browser/src/devtools/panel/views/partials/page.css
+++ b/packages/extension-browser/src/devtools/panel/views/partials/page.css
@@ -1,5 +1,5 @@
 .page {
-    flex: auto;
+    height: 100%;
 }
 
 .page__header {

--- a/packages/extension-browser/tests/content-script.ts
+++ b/packages/extension-browser/tests/content-script.ts
@@ -228,3 +228,37 @@ test.serial('It configures ignored urls', async (t) => {
         });
     }), 'Issues in external resource were not ignored');
 });
+
+test.serial('It handles invalid ignored urls', async (t) => {
+    const url = 'http://localhost/';
+    const html = await readFixture('missing-lang.html');
+
+    const resultsPromise = stubEvents({ ignoredUrls: '(foo' }, () => {
+        sendFetch(url, html);
+    });
+
+    stubContext(url, html);
+
+    require(paths.webhint);
+
+    const results = await resultsPromise;
+
+    t.not(results.categories.length, 0);
+});
+
+test.serial('It handles invalid browserslist queries', async (t) => {
+    const url = 'http://localhost/';
+    const html = await readFixture('missing-lang.html');
+
+    const resultsPromise = stubEvents({ browserslist: 'foo' }, () => {
+        sendFetch(url, html);
+    });
+
+    stubContext(url, html);
+
+    require(paths.webhint);
+
+    const results = await resultsPromise;
+
+    t.not(results.categories.length, 0);
+});


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~Added/Updated related documentation.~
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Fix #1666

Prevent form submission when analysis is run with an invalid
`browserslist` query. Similarly, prevent form submission
when an invalid `RegExp` is provided for ignored URLs.

Update the analysis script gracefully handle invalid should
any be successfully submitted by falling back to defaults.

Also provide feedback to the user during query construction on
whether or not the query is valid and why.