### PR TITLE
Fix hint sri schema

### DIFF
--- a/packages/hint-sri/src/meta.ts
+++ b/packages/hint-sri/src/meta.ts
@@ -15,11 +15,11 @@ const meta: HintMetadata = {
         additionalProperties: false,
         properties: {
             baseline: {
-                oneOf: [Object.keys(Algorithms)],
+                oneOf: Object.keys(Algorithms),
                 type: 'string'
             },
             originCriteria: {
-                oneOf: [Object.keys(OriginCriteria)],
+                oneOf: Object.keys(OriginCriteria),
                 type: 'string'
             }
         }

--- a/packages/hint-sri/src/meta.ts
+++ b/packages/hint-sri/src/meta.ts
@@ -15,11 +15,15 @@ const meta: HintMetadata = {
         additionalProperties: false,
         properties: {
             baseline: {
-                oneOf: Object.keys(Algorithms),
+                oneOf: Object.keys(Algorithms).filter((key) => {
+                    return isNaN(parseInt(key, 10));
+                }),
                 type: 'string'
             },
             originCriteria: {
-                oneOf: Object.keys(OriginCriteria),
+                oneOf: Object.keys(OriginCriteria).filter((key) => {
+                    return isNaN(parseInt(key, 10));
+                }),
                 type: 'string'
             }
         }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

I noticed a little regression in the schema definition of hint-sri which this pull request tries to fix.

The current schema definition essentially compiles to something like this:

```json
"properties": {
    "baseline": {
        "oneOf": [ [ "1", "2", "3", "sha256", "sha384", "sha512" ] ],
        "type": "string"
    },
    "originCriteria": {
        "oneOf": [ [ "1", "2", "all", "crossOrigin" ] ],
        "type": "string"
    }
}
```

This pull request removes the extra nesting of the enums and also removes the number indexes which are added by the TypeScript compiler. Afterwards the schema should look like this:

```json
"properties": {
    "baseline": {
        "oneOf": [ "sha256", "sha384", "sha512" ],
        "type": "string"
    },
    "originCriteria": {
        "oneOf": [ "all", "crossOrigin" ],
        "type": "string"
    }
}
```

Please let me know if any of this was intentional and/or I should change something.