### PR TITLE
Build: Use ' instead of ` in commit messages`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "greenkeeper": {
     "commitMessages": {
-      "dependencyUpdate": "Chore: Update `${dependency}` to `v${version}`",
-      "devDependencyUpdate": "Chore: Update `${dependency}` to `v${version}`",
-      "lockfileUpdate": "Chore: Update lockfile ${lockfilePath}"
+      "dependencyUpdate": "Chore: Update '${dependency}' to 'v${version}`'",
+      "devDependencyUpdate": "Chore: Update '${dependency}' to 'v${version}'",
+      "lockfileUpdate": "Chore: Update lockfile '${lockfilePath}'"
     },
     "ignore": [
       "@types/node"

--- a/scripts/check-commit-message.js
+++ b/scripts/check-commit-message.js
@@ -175,7 +175,7 @@ const isExcludedCommit = (commit) => {
      */
 
     if ((/^🚀 (hint|(configuration|connector|create|formatter|hint|parser|utils)(-[0-9a-z]+)+) - v\d+\.\d+\.\d+/i).test(commit.message) ||
-        (/^(Chore|Breaking): Update `(hint|(configuration|connector|create|formatter|hint|parser|utils)(-[0-9a-z]+)+)` to `v\d+\.\d+\.\d+`/i).test(commit.message)) {
+        (/^(Chore|Breaking): Update '(hint|(configuration|connector|create|formatter|hint|parser|utils)(-[0-9a-z]+)+)' to 'v\d+\.\d+\.\d+'/i).test(commit.message)) {
         return true;
     }
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -801,7 +801,7 @@ const commitUpdatedPackageVersionNumberInOtherPackages = async (ctx: TaskContext
         commitPrefix = 'Breaking:';
     }
 
-    await gitCommitChanges(`${commitPrefix} Update \\\`${ctx.packageName}\\\` to \\\`v${ctx.newPackageVersion}\\\``, true);
+    await gitCommitChanges(`${commitPrefix} Update '${ctx.packageName}' to 'v${ctx.newPackageVersion}'`, true);
 };
 
 const updatePackageVersionNumberInOtherPackages = (ctx: TaskContext) => {
@@ -848,7 +848,7 @@ const updatePackageVersionNumberInOtherPackages = (ctx: TaskContext) => {
 
 const updateYarnLockFile = async () => {
     await exec('yarn');
-    await gitCommitChanges(`Chore: Update \\\`yarn.lock\\\` file`);
+    await gitCommitChanges(`Chore: Update 'yarn.lock' file`);
 };
 
 const waitForUser = async () => {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Fix #1585
