### PR TITLE
Fix: Use enum instead of oneOf

### DIFF
--- a/packages/hint-sri/src/meta.ts
+++ b/packages/hint-sri/src/meta.ts
@@ -15,13 +15,13 @@ const meta: HintMetadata = {
         additionalProperties: false,
         properties: {
             baseline: {
-                oneOf: Object.keys(Algorithms).filter((key) => {
+                enum: Object.keys(Algorithms).filter((key) => {
                     return isNaN(parseInt(key, 10));
                 }),
                 type: 'string'
             },
             originCriteria: {
-                oneOf: Object.keys(OriginCriteria).filter((key) => {
+                enum: Object.keys(OriginCriteria).filter((key) => {
                     return isNaN(parseInt(key, 10));
                 }),
                 type: 'string'


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

I'm sorry for the confusion, but unfortunately my other pull request (#1690) did not fix the issue completely.

This pull request replaces the `oneOf` keyword with the `enum` keyword in the definition of the JSON schema. And this time I actually tested the changes by running the compiled changes with the `hint` command.

I think `oneOf` is meant for allowing different types, whereas `enum` is a special case where the type is always the same but can have different values.

https://json-schema.org/understanding-json-schema/reference/combining.html#oneof
https://json-schema.org/understanding-json-schema/reference/object.html#properties