### PR TITLE
Fix: Use only enum instead of oneOf in schema

### DIFF
--- a/packages/hint-performance-budget/src/meta.ts
+++ b/packages/hint-performance-budget/src/meta.ts
@@ -15,7 +15,7 @@ const meta: HintMetadata = {
         additionalProperties: false,
         properties: {
             connectionType: {
-                oneOf: [{ enum: Connections.ids }],
+                enum: Connections.ids,
                 type: 'string'
             },
             loadTime: {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

This pull request does just simplify the JSON schema of the `performance-budget` hint as discussed here: #1695.

It should not change any functionality.