### PR TITLE
Fix: Make `mdn-browser-compat-data` a dependency

### DIFF
--- a/packages/hint-compat-api/package.json
+++ b/packages/hint-compat-api/package.json
@@ -6,6 +6,9 @@
     ],
     "timeout": "1m"
   },
+  "dependencies": {
+    "mdn-browser-compat-data": "^0.0.63"
+  },
   "description": "hint to validate if the HTML, CSS, and JavaScript APIs of the project are deprecated or not broadly supported",
   "devDependencies": {
     "@hint/parser-css": "^2.0.3",
@@ -19,7 +22,6 @@
     "eslint-plugin-typescript": "^0.14.0",
     "hint": "^4.3.1",
     "markdownlint-cli": "^0.13.0",
-    "mdn-browser-compat-data": "0.0.61",
     "npm-link-check": "^3.0.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6257,10 +6257,10 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
-mdn-browser-compat-data@0.0.61:
-  version "0.0.61"
-  resolved "https://registry.yarnpkg.com/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.61.tgz#bfc091c9fdc441c182afe7b0f046cc1465b65c36"
-  integrity sha512-EWHhyN1KUoMCwge0S5bcmBoTj7e+yWBfUuaoVzFFG4vEUmOwwCSkbuphheD96ublo5M2XKa1g82xJhyAjARx3A==
+mdn-browser-compat-data@^0.0.63:
+  version "0.0.63"
+  resolved "https://registry.yarnpkg.com/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.63.tgz#c058390c2c920fcbe9fcf94d9d2b169dfdcd3915"
+  integrity sha512-qOuG+5Kfx9xRHJUScC++iCcUTkB4dC4EqCGz2OGpzudK2AKliwQRomGa7FNVLojsibqZbLw6RQ30SryOWiURIA==
   dependencies:
     extend "3.0.2"
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~Added/Updated related documentation.~
- ~Added/Updated related tests.~

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Move `mdn-browser-compat-data` from `"devDependencies"` to
`"dependencies"` as it is needed at runtime from the CLI.