### PR TITLE
Chore: Remove obsolete failing test

### DIFF
--- a/packages/hint-compat-api/tests/css.ts
+++ b/packages/hint-compat-api/tests/css.ts
@@ -82,20 +82,6 @@ const removedInEarlierVersionsAndAddedLater: HintTest[] = [
 
 hintRunner.testHint(hintPath, removedInEarlierVersionsAndAddedLater, { browserslist: ['opera 32'], parsers: ['css']});
 
-const removedForBrowser: HintTest[] = [
-    {
-        name: 'Features that were removed in a version equal to the targeted browser should fail.',
-        reports: [
-            { message: 'keyframes is not supported by opera 15.', position: { column: 0, line: 0 }},
-            { message: 'keyframes is not supported by opera 15.', position: { column: 0, line: 6 }},
-            { message: 'keyframes is not supported by opera 15.', position: { column: 0, line: 12 }}
-        ],
-        serverConfig: generateCSSConfig('keyframes')
-    }
-];
-
-hintRunner.testHint(hintPath, removedForBrowser, { browserslist: ['opera 15'], parsers: ['css']});
-
 const removedForPrefixEqualToTargetedBrowsers: HintTest[] = [
     {
         name: 'Prefixed features that were removed in a version equal to the targeted browser should fail.',


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~Added/Updated related documentation.~
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
The `keyframes` property is supported by Opera 15, but was
previously incorrectly reported as unsupported due to a bug in
the MDN data. This bug was fixed in
https://github.com/mdn/browser-compat-data/pull/3227.

No other un-prefixed CSS feature exists which is both included
in the MDN data and has been removed by a browser so removing
this test.