### PR TITLE
Fix: Avoid race condition on debugging protocol

### DIFF
--- a/packages/connector-chrome/src/chrome-launcher.ts
+++ b/packages/connector-chrome/src/chrome-launcher.ts
@@ -2,23 +2,17 @@
  * @fileoverview Launches the given browser with the right configuration to be used via the Chrome Debugging Protocol
  *
  */
-import { promisify } from 'util';
-
 import * as chromeLauncher from 'chrome-launcher';
 import * as isCI from 'is-ci';
-import * as lockfile from 'lockfile';
 
 import { Launcher } from '@hint/utils-debugging-protocol-common/dist/src/launcher';
 import { BrowserInfo, LauncherOptions } from 'hint/dist/src/lib/types';
-import * as logger from 'hint/dist/src/lib/utils/logging';
 import { debug as d } from 'hint/dist/src/lib/utils/debug';
 import delay from 'hint/dist/src/lib/utils/misc/delay';
 import readFileAsync from 'hint/dist/src/lib/utils/fs/read-file-async';
 import writeFileAsync from 'hint/dist/src/lib/utils/fs/write-file-async';
 
 const debug: debug.IDebugger = d(__filename);
-const lock = promisify(lockfile.lock) as (path: string, options: lockfile.Options) => Promise<void>;
-const unlock = promisify(lockfile.unlock);
 
 export class CDPLauncher extends Launcher {
     /** Indicates if the default profile should be used by Chrome or not */
@@ -110,30 +104,12 @@ export class CDPLauncher extends Launcher {
         await writeFileAsync(this.pidFile, JSON.stringify({ pid: browserInfo.pid, port: browserInfo.port || this.port }, null, 4));
     }
 
-    public async launch(url: string): Promise<BrowserInfo> {
-        const cdpLock = 'cdp.lock';
+    public async launch(url: string, callback: Function): Promise<BrowserInfo> {
 
-        try {
-            await lock(cdpLock, {
-                pollPeriod: 500,
-                retries: 20,
-                retryWait: 1000,
-                stale: 50000,
-                wait: 50000
-            });
-        } catch (e) {
-            /* istanbul ignore next */
-            { // eslint-disable-line
-                logger.error('Error while locking', e);
-                throw e;
-            }
-        }
         // If a browser is already launched using `launcher` then we return its PID.
         const currentInfo = await this.getBrowserInfo();
 
         if (currentInfo.pid !== -1) {
-            await unlock(cdpLock);
-
             currentInfo.isNew = false;
 
             return currentInfo;
@@ -163,16 +139,12 @@ export class CDPLauncher extends Launcher {
 
             debug('Browser launched correctly');
 
-            await unlock(cdpLock);
-
             return browserInfo;
         } catch (e) {
             /* istanbul ignore next */
             { // eslint-disable-line
                 debug('Error launching browser');
                 debug(e);
-
-                await unlock(cdpLock);
 
                 throw e;
             }

--- a/packages/utils-debugging-protocol-common/package.json
+++ b/packages/utils-debugging-protocol-common/package.json
@@ -3,6 +3,7 @@
     "@hint/utils-connector-tools": "^2.0.2",
     "abab": "^2.0.0",
     "chrome-remote-interface": "^0.27.0",
+    "is-ci": "^2.0.0",
     "lodash": "^4.17.11"
   },
   "description": "hint debugging protocol common functionality",

--- a/packages/utils-debugging-protocol-common/src/launcher.ts
+++ b/packages/utils-debugging-protocol-common/src/launcher.ts
@@ -29,5 +29,5 @@ export abstract class Launcher implements ILauncher {
     /**
      * Launches browser with the given url and ready to be used with the Chrome Debugging Protocol.
      */
-    public abstract async launch(url: string): Promise<BrowserInfo>;
+    public abstract async launch(url: string, callback?: Function): Promise<BrowserInfo>;
 }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

Same as #1758 but without the server in a separate thread. I want to see how much of an impact it has on build times. Depending on the time I might disable the threading option on CI.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
