### PR TITLE
Build: Increase build timeout

### DIFF
--- a/azure-pipelines/all-versions.yml
+++ b/azure-pipelines/all-versions.yml
@@ -17,4 +17,5 @@ jobs:
        node_version: 11.x
   steps:
   - template: worker.yml
+  timeoutInMinutes: 90
   condition: ${{ parameters.condition }}

--- a/azure-pipelines/latest-version.yml
+++ b/azure-pipelines/latest-version.yml
@@ -13,4 +13,5 @@ jobs:
         node_version: 11.x
   steps:
   - template: worker.yml
+  timeoutInMinutes: 90
   condition: ${{ parameters.condition }}


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

Increase the timeout to stop an agent to 90 minutes from the 60 default ones. The reason is that full test times are over 60 minutes in some of the platforms.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
