### PR TITLE
Fix: Analyze when devtools is undocked

### DIFF
--- a/packages/extension-browser/src/background-script.ts
+++ b/packages/extension-browser/src/background-script.ts
@@ -75,7 +75,7 @@ browser.runtime.onConnect.addListener((port) => {
 
 // Watch for messages from content scripts and devtools panels (listed roughly in the order they will occur).
 browser.runtime.onMessage.addListener((message: Events, sender) => {
-    const tabId = sender.tab && sender.tab.id || message.tabId;
+    const tabId = message.tabId || sender.tab && sender.tab.id;
 
     /* istanbul ignore if */
     // Aid debugging by ensuring a tabId is always found.


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~Added/Updated related documentation.~
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

When undocked `sender.tab` exists and `sender.tab.id`
is `-1`. Preferring `message.tabId` fixes the issue.

Bundle for testing:
* [extension-browser-pr-1788.zip](https://github.com/webhintio/hint/files/2805444/extension-browser-pr-1788.zip)
