### PR TITLE
Chore: Panel injects content-script

### DIFF
--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -62,8 +62,7 @@
     "typescript-eslint-parser": "^22.0.0",
     "util.promisify": "^1.0.0",
     "webpack": "^4.29.0",
-    "webpack-cli": "^3.2.1",
-    "webpack-merge": "^4.2.1"
+    "webpack-cli": "^3.2.1"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -62,7 +62,8 @@
     "typescript-eslint-parser": "^22.0.0",
     "util.promisify": "^1.0.0",
     "webpack": "^4.29.0",
-    "webpack-cli": "^3.2.1"
+    "webpack-cli": "^3.2.1",
+    "webpack-merge": "^4.2.1"
   },
   "engines": {
     "node": ">=8.0.0"
@@ -93,7 +94,7 @@
     "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
     "build:assets": "npm run build-css && npm run build-hints && cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
-    "build:webpack": "webpack && cpx \"./src/**/*.{html,json,png,svg}\" dist/bundle",
+    "build:webpack": "webpack --env.content-script && webpack && cpx \"./src/**/*.{html,json,png,svg}\" dist/bundle",
     "clean": "rimraf dist",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint . --cache --ext js --ext md --ext ts --ignore-path ../../.eslintignore --report-unused-disable-directives",

--- a/packages/extension-browser/src/@types/raw-loader.d.ts
+++ b/packages/extension-browser/src/@types/raw-loader.d.ts
@@ -1,0 +1,5 @@
+// Note: raw-loader only works correctly with the bang! syntax
+declare module 'raw-loader!*' {
+    const content: string;
+    export = content;
+}

--- a/packages/extension-browser/src/background-script.ts
+++ b/packages/extension-browser/src/background-script.ts
@@ -1,8 +1,6 @@
 import { browser } from './shared/globals';
 import { Config, Events } from './shared/types';
 
-import * as contentScriptCode from 'raw-loader!./../bundle/content-script/webhint.js';
-
 const configs = new Map<number, Config>();
 const readyTabs = new Set<number>();
 const queuedEvents = new Map<number, Events[]>();
@@ -27,8 +25,8 @@ const sendEvent = (tabId: number, event: Events) => {
 };
 
 /** Add the script to run webhint to the page. */
-const injectContentScript = (tabId: number, retries = 0) => {
-    browser.tabs.executeScript(tabId, { code: contentScriptCode, runAt: 'document_start' }, (result) => {
+const injectContentScript = (tabId: number, code: string, retries = 0) => {
+    browser.tabs.executeScript(tabId, { code, runAt: 'document_start' }, (result) => {
         // We get an empty object `{}` back on success, or `undefined` if the script failed to execute.
         if (!result) {
             if (retries <= 2) {
@@ -37,7 +35,7 @@ const injectContentScript = (tabId: number, retries = 0) => {
                  * Variation of https://bugzilla.mozilla.org/show_bug.cgi?id=1397667
                  */
                 console.warn('Failed to inject content script. Retrying...');
-                injectContentScript(tabId, retries + 1);
+                injectContentScript(tabId, code, retries + 1);
             } else {
                 // Give up if retrying still doesn't inject the content script.
                 console.error('Failed to inject content script after retrying.');
@@ -47,7 +45,7 @@ const injectContentScript = (tabId: number, retries = 0) => {
 };
 
 /** Turn on request tracking for the specified tab. */
-const enable = (tabId: number) => {
+const enable = (tabId: number, code: string) => {
     readyTabs.delete(tabId);
     let timeout = 0;
 
@@ -56,7 +54,7 @@ const enable = (tabId: number) => {
         if (details.tabId === tabId && details.frameId === 0) {
             browser.webNavigation.onCommitted.removeListener(onCommitted);
             clearTimeout(timeout);
-            injectContentScript(tabId);
+            injectContentScript(tabId, code);
         }
     };
 
@@ -87,13 +85,13 @@ browser.runtime.onMessage.addListener((message: Events, sender) => {
 
     // Activate content-script when requested by devtools page (saving configuration for when content-script is ready).
     if (message.enable) {
-        configs.set(tabId, message.enable);
-        enable(tabId);
+        configs.set(tabId, message.enable.config);
+        enable(tabId, message.enable.code);
     }
 
     // Forward configuration to content-script when asked (happens before `message.ready`).
     if (message.requestConfig) {
-        const configMessage: Events = { enable: configs.get(tabId) || {} };
+        const configMessage: Events = { config: configs.get(tabId) || {} };
 
         browser.tabs.sendMessage(tabId, configMessage);
     }

--- a/packages/extension-browser/src/background-script.ts
+++ b/packages/extension-browser/src/background-script.ts
@@ -1,6 +1,8 @@
 import { browser } from './shared/globals';
 import { Config, Events } from './shared/types';
 
+import * as contentScriptCode from 'raw-loader!./../bundle/content-script/webhint.js';
+
 const configs = new Map<number, Config>();
 const readyTabs = new Set<number>();
 const queuedEvents = new Map<number, Events[]>();
@@ -26,7 +28,7 @@ const sendEvent = (tabId: number, event: Events) => {
 
 /** Add the script to run webhint to the page. */
 const injectContentScript = (tabId: number, retries = 0) => {
-    browser.tabs.executeScript(tabId, { file: 'content-script/webhint.js', runAt: 'document_start' }, (result) => {
+    browser.tabs.executeScript(tabId, { code: contentScriptCode, runAt: 'document_start' }, (result) => {
         // We get an empty object `{}` back on success, or `undefined` if the script failed to execute.
         if (!result) {
             if (retries <= 2) {

--- a/packages/extension-browser/src/content-script/webhint.ts
+++ b/packages/extension-browser/src/content-script/webhint.ts
@@ -94,8 +94,8 @@ const main = async (userConfig: Config) => {
 };
 
 const onMessage = (events: Events) => {
-    if (events.enable) {
-        main(events.enable);
+    if (events.config) {
+        main(events.config);
         browser.runtime.onMessage.removeListener(onMessage);
     }
 };

--- a/packages/extension-browser/src/devtools/panel/panel.ts
+++ b/packages/extension-browser/src/devtools/panel/panel.ts
@@ -11,6 +11,8 @@ import { syncTheme } from './utils/themes';
 
 import * as styles from './panel.css';
 
+import * as contentScript from 'raw-loader!../../../webhint.js';
+
 document.body.classList.add(styles.root);
 
 /** Display the provided view in the panel. */
@@ -81,7 +83,7 @@ const onCancel = () => {
 /** Handle the user request to start a scan. */
 const onStart = (config: Config) => {
     // Notify the background script to begin scanning with the chosen configuration.
-    sendMessage({ enable: config });
+    sendMessage({ enable: { code: contentScript, config } });
 
     // Listen for scan results and network requests (to create `fetch::end::*` events).
     addMessageListener(onMessage);

--- a/packages/extension-browser/src/shared/types.ts
+++ b/packages/extension-browser/src/shared/types.ts
@@ -6,6 +6,11 @@ export type Config = {
     ignoredUrls?: string;
 };
 
+export type InjectDetails = {
+    code: string;
+    config: Config;
+}
+
 export type HintResults = {
     helpURL: string;
     id: string;
@@ -24,7 +29,8 @@ export type Results = {
 };
 
 export type Events = {
-    enable?: Config;
+    config?: Config;
+    enable?: InjectDetails;
     fetchEnd?: FetchEnd;
     fetchStart?: FetchStart;
     done?: boolean;

--- a/packages/extension-browser/tests/content-script.ts
+++ b/packages/extension-browser/tests/content-script.ts
@@ -81,7 +81,7 @@ const mockContext = () => {
             browser.runtime.sendMessage = (event: Events) => {
                 if (event.requestConfig) {
                     setTimeout(() => {
-                        sendMessage({ enable: config });
+                        sendMessage({ config });
                     }, 0);
                 }
                 if (event.ready) {

--- a/packages/extension-browser/tests/end-to-end.ts
+++ b/packages/extension-browser/tests/end-to-end.ts
@@ -77,7 +77,7 @@ test('It runs end-to-end in a page', async (t) => {
         });
     });
 
-    await page.addScriptTag({ path: `${__dirname}/../bundle/content-script/webhint.js` });
+    await page.addScriptTag({ path: `${__dirname}/../webhint.js` });
 
     const results = await resultsPromise;
 

--- a/packages/extension-browser/tests/end-to-end.ts
+++ b/packages/extension-browser/tests/end-to-end.ts
@@ -66,7 +66,7 @@ test('It runs end-to-end in a page', async (t) => {
                     },
                     sendMessage: (event: Events) => {
                         if (event.requestConfig) {
-                            onMessage({ enable: {} });
+                            onMessage({ config: {} });
                         }
                         if (event.results) {
                             resolve(event.results);

--- a/packages/extension-browser/webpack.config.js
+++ b/packages/extension-browser/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const merge = require('webpack-merge');
 
 const baseConfig = {
     mode: 'none',
@@ -54,17 +53,24 @@ const baseConfig = {
     resolve: { alias: { url$: path.resolve(__dirname, 'dist/src/shims/url.js') } }
 };
 
-const contentScriptConfig = merge.smart(baseConfig, {
-    entry: { webhint: './dist/src/content-script/webhint.js' },
-    output: { path: path.resolve(__dirname, 'dist') }
-});
-const extensionConfig = merge.smart(baseConfig, {
-    entry: {
-        'background-script': './dist/src/background-script.js',
-        'devtools/devtools': './dist/src/devtools/devtools.js',
-        'devtools/panel/panel': './dist/src/devtools/panel/panel.js'
+const contentScriptConfig = {
+    ...baseConfig,
+    ...{
+        entry: { webhint: './dist/src/content-script/webhint.js' },
+        output: { ...baseConfig.output, path: path.resolve(__dirname, 'dist') }
     }
-});
+};
+
+const extensionConfig = {
+    ...baseConfig,
+    ...{
+        entry: {
+            'background-script': './dist/src/background-script.js',
+            'devtools/devtools': './dist/src/devtools/devtools.js',
+            'devtools/panel/panel': './dist/src/devtools/panel/panel.js'
+        }
+    }
+};
 
 module.exports = (env) => {
     if (env && env['content-script']) {

--- a/packages/extension-browser/webpack.config.js
+++ b/packages/extension-browser/webpack.config.js
@@ -37,7 +37,6 @@ const baseConfig = {
                     'css-loader'
                 ]
             },
-            // Inline svgs as urls, see https://github.com/bhovhannes/svg-url-loader
             {
                 test: /\.svg$/,
                 use: {
@@ -55,7 +54,10 @@ const baseConfig = {
     resolve: { alias: { url$: path.resolve(__dirname, 'dist/src/shims/url.js') } }
 };
 
-const contentScriptConfig = merge.smart(baseConfig, { entry: { 'content-script/webhint': './dist/src/content-script/webhint.js' } });
+const contentScriptConfig = merge.smart(baseConfig, {
+    entry: { webhint: './dist/src/content-script/webhint.js' },
+    output: { path: path.resolve(__dirname, 'dist') }
+});
 const extensionConfig = merge.smart(baseConfig, {
     entry: {
         'background-script': './dist/src/background-script.js',

--- a/packages/extension-browser/webpack.config.js
+++ b/packages/extension-browser/webpack.config.js
@@ -42,6 +42,7 @@ module.exports = {
                     'css-loader'
                 ]
             },
+            // Inline svgs as urls, see https://github.com/bhovhannes/svg-url-loader
             {
                 test: /\.svg$/,
                 use: {

--- a/packages/extension-browser/webpack.config.js
+++ b/packages/extension-browser/webpack.config.js
@@ -1,12 +1,7 @@
 const path = require('path');
+const merge = require('webpack-merge');
 
-module.exports = {
-    entry: {
-        'background-script': './dist/src/background-script.js',
-        'content-script/webhint': './dist/src/content-script/webhint.js',
-        'devtools/devtools': './dist/src/devtools/devtools.js',
-        'devtools/panel/panel': './dist/src/devtools/panel/panel.js'
-    },
+const baseConfig = {
     mode: 'none',
     module: {
         rules: [
@@ -58,4 +53,21 @@ module.exports = {
         path: path.resolve(__dirname, 'dist/bundle')
     },
     resolve: { alias: { url$: path.resolve(__dirname, 'dist/src/shims/url.js') } }
+};
+
+const contentScriptConfig = merge.smart(baseConfig, { entry: { 'content-script/webhint': './dist/src/content-script/webhint.js' } });
+const extensionConfig = merge.smart(baseConfig, {
+    entry: {
+        'background-script': './dist/src/background-script.js',
+        'devtools/devtools': './dist/src/devtools/devtools.js',
+        'devtools/panel/panel': './dist/src/devtools/panel/panel.js'
+    }
+});
+
+module.exports = (env) => {
+    if (env && env['content-script']) {
+        return contentScriptConfig;
+    }
+
+    return extensionConfig;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10226,12 +10226,6 @@ webpack-cli@^3.2.1:
     v8-compile-cache "^2.0.2"
     yargs "^12.0.4"
 
-webpack-merge@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.1.tgz#5e923cf802ea2ace4fd5af1d3247368a633489b4"
-  dependencies:
-    lodash "^4.17.5"
-
 webpack-sources@^1.1.0, webpack-sources@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10226,6 +10226,12 @@ webpack-cli@^3.2.1:
     v8-compile-cache "^2.0.2"
     yargs "^12.0.4"
 
+webpack-merge@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.1.tgz#5e923cf802ea2ace4fd5af1d3247368a633489b4"
+  dependencies:
+    lodash "^4.17.5"
+
 webpack-sources@^1.1.0, webpack-sources@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

Refactor injection of the content-script from the background script to the panel, giving the panel control over what code injected; this also reduces the number of files included in the bundle and loaded by the extension.

As part of this change the build is now done in two passes; first to create the content-script bundle, then to create the extension bundle which raw-loads the content-script bundle.

Bundle for testing:
* [extension-browser-pr-1801.zip](https://github.com/webhintio/hint/files/2814725/extension-browser-pr-1801.zip)


Co-authored-by: Tony Ross <antross@gmail.com>