### PR TITLE
Fix: Handle newlines in attribute values

### DIFF
--- a/packages/hint/tests/lib/utils/fixtures/test-page.html
+++ b/packages/hint/tests/lib/utils/fixtures/test-page.html
@@ -17,6 +17,9 @@
     <a href="https://www.duplicate.org">
     similar
     </a>
+
+    <div class="newline" foo="bar
+baz"></div>
 </body>
 
 </html>

--- a/packages/hint/tests/lib/utils/location-helpers.ts
+++ b/packages/hint/tests/lib/utils/location-helpers.ts
@@ -152,6 +152,15 @@ const findElementLocationEntries = [
             line: 17,
             column: 5
         }
+    },
+    {
+        name: 'element with newline in attribute',
+        selector: `div.newline`,
+        index: 0,
+        position: {
+            line: 21,
+            column: 5
+        }
     }
 ];
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~Added/Updated related documentation.~
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Fix #1792

Also gracefully handle invalid selectors when generating locations.