### PR TITLE
Breaking: Split error messages

### DIFF
--- a/packages/hint-http-cache/src/hint.ts
+++ b/packages/hint-http-cache/src/hint.ts
@@ -355,17 +355,26 @@ export default class HttpCacheHint implements IHint {
 
             const longCache = compareToMaxAge(usedDirectives, maxAgeResource) >= 0;
             const immutable = usedDirectives.has('immutable');
+            let validates = true;
 
             // We want long caches with "immutable" for static resources
-            if (usedDirectives.has('no-cache') || !(longCache && immutable)) {
-                const message: string = `Static resources should have a long cache value (${maxAgeResource}) and use the immutable directive:\n${header}`;
+            if (usedDirectives.has('no-cache') || !longCache) {
+                const message: string = `Static resources should have a long cache value (${maxAgeResource}):\nDirectives used: ${header}`;
 
                 await context.report(resource, message, { element });
 
-                return false;
+                validates = false;
             }
 
-            return true;
+            if (!immutable) {
+                const message: string = `Static resources should use the "immutable" directive:\nDirectives used: ${header}`;
+
+                await context.report(resource, message, { element });
+
+                validates = false;
+            }
+
+            return validates;
         };
 
         /**

--- a/packages/hint-http-cache/tests/tests.ts
+++ b/packages/hint-http-cache/tests/tests.ts
@@ -181,7 +181,9 @@ const defaultTests: HintTest[] = [
     },
     {
         name: 'JS with "Cache-Control: no-cache" fails',
-        reports: [{ message: 'Static resources should have a long cache value (31536000) and use the immutable directive:\nno-cache' }],
+        reports: [
+            { message: 'Static resources should have a long cache value (31536000):\nDirectives used: no-cache' },
+            { message: 'Static resources should use the "immutable" directive:\nDirectives used: no-cache' }],
         serverConfig: {
             '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><script src="/script.123.js"></script>'),
             '/favicon.123.ico': {
@@ -196,7 +198,9 @@ const defaultTests: HintTest[] = [
     },
     {
         name: 'JS with short max-age fails',
-        reports: [{ message: 'Static resources should have a long cache value (31536000) and use the immutable directive:\nmax-age=100' }],
+        reports: [
+            { message: 'Static resources should have a long cache value (31536000):\nDirectives used: max-age=100' },
+            { message: 'Static resources should use the "immutable" directive:\nDirectives used: max-age=100' }],
         serverConfig: {
             '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><script src="/script.123.js"></script>'),
             '/favicon.123.ico': {
@@ -211,7 +215,7 @@ const defaultTests: HintTest[] = [
     },
     {
         name: 'JS with long max-age but no immutable fails',
-        reports: [{ message: 'Static resources should have a long cache value (31536000) and use the immutable directive:\nmax-age=31536000' }],
+        reports: [{ message: 'Static resources should use the "immutable" directive:\nDirectives used: max-age=31536000' }],
         serverConfig: {
             '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><script src="/script.123.js"></script>'),
             '/favicon.123.ico': {
@@ -369,7 +373,7 @@ const defaultTests: HintTest[] = [
 
     {
         name: 'CSS with max-age but no immutable fails',
-        reports: [{ message: 'Static resources should have a long cache value (31536000) and use the immutable directive:\nmax-age=31536000' }],
+        reports: [{ message: 'Static resources should use the "immutable" directive:\nDirectives used: max-age=31536000' }],
         serverConfig: {
             '/': generateHTMLPage('<link rel="icon" href="/favicon.123.ico"><link rel="stylesheet" href="styles.123.css">'),
             '/favicon.123.ico': {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- [x] Added/Updated related tests.

## Short description of the change(s)

Split the error message reported when a static resource is not cached
long enough or it does not use the `immutable` directive into two to
make it clearer what the cause of the failure is.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #1074


<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
