### PR TITLE
Fix: Force `formatters` to be an `Array` only

### DIFF
--- a/packages/hint/docs/user-guide/concepts/formatters.md
+++ b/packages/hint/docs/user-guide/concepts/formatters.md
@@ -11,7 +11,7 @@ name inside the property `formatters`:
 
 ```json
 {
-    "formatters": "formatter1"
+    "formatters": ["formatter1"]
 }
 ```
 

--- a/packages/hint/src/lib/config.ts
+++ b/packages/hint/src/lib/config.ts
@@ -426,7 +426,7 @@ export class Configuration {
             }
 
             return result;
-        }, { invalid: [] as string[], valid: [] as string[]});
+        }, { invalid: [] as string[], valid: [] as string[] });
 
         return validateResult;
     }

--- a/packages/hint/src/lib/config/config-schema.json
+++ b/packages/hint/src/lib/config/config-schema.json
@@ -38,14 +38,11 @@
         },
         "formatters": {
             "description": "The formatter(s) to use for the results",
-            "oneOf": [
-                {
-                    "type": "array"
-                },
-                {
-                    "type": "string"
-                }
-            ]
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
         },
         "parsers": {
             "description": "The parsers to be used with the connector to gather information for specific file types",

--- a/packages/hint/tests/lib/config/config-validator.ts
+++ b/packages/hint/tests/lib/config/config-validator.ts
@@ -8,7 +8,7 @@ const validConfig = {
         name: 'chrome',
         options: { waitFor: 1000 }
     },
-    formatters: 'json',
+    formatters: ['json'],
     hints: {
         'disallowed-headers': ['warning', {}],
         'manifest-exists': 1,
@@ -26,7 +26,7 @@ const validHintsConfig = {
         name: 'chrome',
         options: { waitFor: 1000 }
     },
-    formatters: 'json',
+    formatters: ['json'],
     hints: [
         'disallowed-headers:warning',
         '?manifest-exists',
@@ -99,14 +99,15 @@ test(`If hint severity isn't valid, it should return false`, (t) => {
     t.false(valid);
 });
 
-test('config with one formatters is valid', (t) => {
-    const valid = configValidator.validateConfig(validConfig as any);
+test('config with one formatter as a string is invalid', (t) => {
+    const invalidConfig = Object.assign({}, validConfig, { formatters: 'json' });
+    const valid = configValidator.validateConfig(invalidConfig as any);
 
-    t.true(valid);
+    t.false(valid);
 });
 
 test('config with 2 formatters is valid', (t) => {
-    const validConfigs = Object.assign({ formatters: ['json', 'stylish'] }, validConfig);
+    const validConfigs = Object.assign({}, validConfig, { formatters: ['json', 'stylish'] });
     const valid = configValidator.validateConfig(validConfigs as any);
 
     t.true(valid);


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

Fix #1865

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
