### PR TITLE
Fix: HTML Formatter Print Styles

### DIFF
--- a/packages/formatter-html/src/assets/styles/scan/scan-results.css
+++ b/packages/formatter-html/src/assets/styles/scan/scan-results.css
@@ -468,31 +468,6 @@ a > .rule-tile:hover {
     }
 }
 
-@media print {
-
-    .rule-categories {
-        position: relative;
-    }
-
-    .show-categories {
-        display: none;
-    }
-
-    .rule-doc-buttons {
-        position: relative;
-    }
-
-    .rule-result--details__body p {
-        font-size: 85%;
-    }
-
-    .rule-result__code {
-        border: 1px solid #f4f4f4;
-    }
-
-}
-
-
 /* SCAN DETAILS */
 
 .rule-result {
@@ -690,8 +665,6 @@ button {
 
 .rule-result__code code {
     background-color: #f4f4f4;
-    margin-top: 1.4rem;
-    padding-left: 1.4rem;
 }
 
 @media (min-width: 48.75em) {
@@ -814,4 +787,85 @@ button {
 
 .scan-error {
     margin-top: 2.4rem;
+}
+
+/* PRINT STYLES */
+
+@media print {
+
+    .rule-categories {
+        position: relative;
+        margin: 1.2rem 0 0 0;
+        padding: 0;
+    }
+
+    .show-categories {
+        display: none;
+    }
+
+    .rule-tiles {
+        padding: .6rem 1.2rem;
+    }
+
+    .button-expand-all {
+        display: none;
+    }
+
+    .rule-doc-buttons {
+        position: relative;
+    }
+
+    .rule-doc-button,
+    .rule-doc-button:nth-child(2) {
+        border: 1px solid #4046dd;
+        color: #4046dd;
+        background-color: #fff;
+        padding: .6rem;
+    }
+
+    .rule-doc-icon {
+        display: none;
+    }
+
+    .rule-result--details,
+    .rule-result--details__hint-link,
+    .rule-result--details__footer-msg {
+        font-size: 75%;
+    }
+
+    .rule-result--details__body {
+        border-top: 1px solid #d6d6d6;
+    }
+
+    .rule-content div:nth-child(2) {
+        border-top: none;
+    }
+
+    .rule-result--details__body p {
+        margin: .6rem 0 0 0;
+    }
+
+    .rule-result__code {
+        border: 1px solid #d6d6d6;
+        margin: 1.2rem 0 0 0;
+        padding: 1.2rem;
+    }
+
+    .rule-result--details__footer-msg {
+        margin: .6rem 0 1.2rem 3rem;
+    }
+
+    .rule-result--details__footer-msg img.axe-logo {
+        width: 3rem;
+    }
+
+    .rule-title {
+        padding-left: 0;
+    }
+
+    .hint-link::after,
+    .rule-title::before {
+        display: none;
+    }
+
 }

--- a/packages/formatter-html/src/assets/styles/scan/scan-results.css
+++ b/packages/formatter-html/src/assets/styles/scan/scan-results.css
@@ -370,7 +370,9 @@ a > .rule-tile:hover {
     z-index: 10;
 }
 
+
 @media (min-width: 33.75em) {
+
     .module.module--categories {
         float: none;
     }
@@ -391,6 +393,7 @@ a > .rule-tile:hover {
 }
 
 @media (min-width: 48em) {
+
     .module.module--categories {
         float: right;
         margin-top: 2.4rem;
@@ -426,6 +429,7 @@ a > .rule-tile:hover {
 }
 
 @media (min-width: 48em) and (max-width: 82.5em) {
+
     .rule-tile__info {
         flex-direction: column;
         justify-content: center;
@@ -463,6 +467,31 @@ a > .rule-tile:hover {
         font-size: 1.2rem;
     }
 }
+
+@media print {
+
+    .rule-categories {
+        position: relative;
+    }
+
+    .show-categories {
+        display: none;
+    }
+
+    .rule-doc-buttons {
+        position: relative;
+    }
+
+    .rule-result--details__body p {
+        font-size: 85%;
+    }
+
+    .rule-result__code {
+        border: 1px solid #f4f4f4;
+    }
+
+}
+
 
 /* SCAN DETAILS */
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

Fixes issue 588 in the webhint.io repo. This only fixes the print styles issue with the category hint summary covering the scan results across multiple pages. Other items that were mentioned in that issue were created into new issues. 

I also adjusted some styles so that things look a little bit better while printing and the "why is this important" and "how to fix this" button stay in place and don't randomly overlap other information on the page.

Here's a PDF printed from the page with updated styles/adjustments.

[Page Title-4.pdf](https://github.com/webhintio/hint/files/2882441/Page.Title-4.pdf)
