### PR TITLE
Fix: Honor `--debug` parameter even when `DEBUG` env is set

### DIFF
--- a/packages/hint/src/bin/hint.ts
+++ b/packages/hint/src/bin/hint.ts
@@ -4,7 +4,7 @@
  * @fileoverview Main CLI that is run via the hint command. Based on ESLint.
  */
 
-/* eslint no-console:off, no-process-exit:off */
+/* eslint-disable no-console, no-process-exit, no-process-env */
 
 /*
  * ------------------------------------------------------------------------------
@@ -12,21 +12,12 @@
  * ------------------------------------------------------------------------------
  */
 
-const debug = (process.argv.includes('--debug'));
 const tracking = (/--tracking[=\s]+([^\s]*)/i).exec(process.argv.join(' '));
-const analyticsDebug = process.argv.includes('--analytics-debug');
-
-import * as d from 'debug';
 
 import * as insights from '../lib/utils/app-insights';
 import * as configStore from '../lib/utils/config-store';
 
-// This initialization needs to be done *before* other requires in order to work.
-if (debug) {
-    d.enable('hint:*');
-}
-
-const trackingEnv = process.env.HINT_TRACKING; // eslint-disable-line no-process-env
+const trackingEnv = process.env.HINT_TRACKING;
 let enableTracking;
 
 if (tracking) {
@@ -52,10 +43,6 @@ if (typeof enableTracking !== 'undefined') {
     } else {
         insights.disable();
     }
-}
-
-if (analyticsDebug && !debug) {
-    d.enable('hint:utils:appinsights');
 }
 
 /*
@@ -96,9 +83,7 @@ ${source.stack}`);
 
 const run = async () => {
     process.exitCode = await cli.execute(process.argv);
-    if (debug) {
-        console.log(`Exit code: ${process.exitCode}`);
-    }
+
     process.exit(process.exitCode);
 };
 

--- a/packages/hint/src/lib/utils/debug.ts
+++ b/packages/hint/src/lib/utils/debug.ts
@@ -1,12 +1,25 @@
+/* eslint-disable no-process-env */
 import * as path from 'path';
+
+const debugging = (process.argv.includes('--debug'));
+const debugTarget = process.env.DEBUG || 'hint:*';
+const analyticsDebug = process.argv.includes('--analytics-debug');
+
+/**
+ * If the environment variable `DEBUG` is set, the `debug` package
+ * will get enabled so it is removed unless the `--debug` parameter
+ * is used.
+ */
+if (!debugging && process.env.DEBUG) {
+    delete process.env.DEBUG;
+}
 
 import * as d from 'debug';
 
-const debugEnabled: boolean = (process.argv.includes('--debug'));
-
-// must do this initialization *before* other requires in order to work
-if (debugEnabled) {
-    d.enable('hint:*');
+if (debugging) {
+    d.enable(debugTarget);
+} else if (analyticsDebug) {
+    d.enable('hint:utils:appinsights');
 }
 
 export const debug = (filePath: string): d.IDebugger => {
@@ -43,5 +56,4 @@ export const debug = (filePath: string): d.IDebugger => {
     }
 
     return d(`hint:${output}`);
-
 };


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

Debug output was being printed when the environment variable `DEBUG`
was set, even if `--debug` parameter was not used.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #1349

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
