### PR TITLE
Chore: Refactor location tests to match similar text

### DIFF
--- a/packages/hint-amp-validator/src/hint.ts
+++ b/packages/hint-amp-validator/src/hint.ts
@@ -73,7 +73,7 @@ export default class AmpValidatorHint implements IHint {
                     } else {
                         const location = {
                             column: error.col,
-                            line: error.line
+                            line: error.line - 1 // The validator uses 1-based lines (but 0-based columns)
                         };
 
                         context.report(resource, message, { location });

--- a/packages/hint-amp-validator/tests/tests.ts
+++ b/packages/hint-amp-validator/tests/tests.ts
@@ -25,11 +25,7 @@ const defaultTests: HintTest[] = [
         reports: [
             {
                 message: `The mandatory attribute '⚡' is missing in tag 'html'. (https://www.ampproject.org/docs/reference/spec#required-markup)`,
-                // TODO: position: { match: '<html lang="en">' } // { column: 0, line: 1 }
-                position: {
-                    column: 0,
-                    line: 2
-                }
+                position: { match: '<html lang="en">' }
             }
         ]
     },

--- a/packages/hint-amp-validator/tests/tests.ts
+++ b/packages/hint-amp-validator/tests/tests.ts
@@ -25,6 +25,7 @@ const defaultTests: HintTest[] = [
         reports: [
             {
                 message: `The mandatory attribute '⚡' is missing in tag 'html'. (https://www.ampproject.org/docs/reference/spec#required-markup)`,
+                // TODO: position: { match: '<html lang="en">' } // { column: 0, line: 1 }
                 position: {
                     column: 0,
                     line: 2

--- a/packages/hint-babel-config/tests/is-valid.ts
+++ b/packages/hint-babel-config/tests/is-valid.ts
@@ -16,10 +16,7 @@ const tests: HintLocalTest[] = [
         path: path.join(__dirname, 'fixtures', 'invalid-schema', '.babelrc'),
         reports: [{
             message: `'moduleId' should be 'string'.`,
-            position: {
-                column: 5,
-                line: 4
-            }
+            position: { match: 'moduleId' }
         }]
     },
     {
@@ -40,10 +37,7 @@ const tests: HintLocalTest[] = [
         path: path.join(__dirname, 'fixtures', 'has-invalid-babel-package-json', 'package.json'),
         reports: [{
             message: `'moduleId' should be 'string'.`,
-            position: {
-                column: 5,
-                line: 3
-            }
+            position: { match: 'moduleId' }
         }]
     },
     {
@@ -51,10 +45,7 @@ const tests: HintLocalTest[] = [
         path: path.join(__dirname, 'fixtures', 'has-additional-property', '.babelrc'),
         reports: [{
             message: `'root' should NOT have additional properties. Additional property found 'additional'.`,
-            position: {
-                column: 5,
-                line: 10
-            }
+            position: { match: 'additional' }
         }]
     },
     {
@@ -62,10 +53,7 @@ const tests: HintLocalTest[] = [
         path: path.join(__dirname, 'fixtures', 'has-invalid-enum-property', '.babelrc'),
         reports: [{
             message: `'sourceMaps' should be equal to one of the allowed values 'both, inline, true, false'. Value found 'invalidValue'`,
-            position: {
-                column: 5,
-                line: 14
-            }
+            position: { match: 'sourceMaps' }
         }]
     },
     {
@@ -74,10 +62,7 @@ const tests: HintLocalTest[] = [
         reports: [
             {
                 message: `Circular reference found in file ${path.join(__dirname, 'fixtures', 'circular-2', '.babelrc')}`,
-                position: {
-                    column: 3,
-                    line: 1
-                }
+                position: { match: 'extends' }
             }
         ]
     },
@@ -87,10 +72,7 @@ const tests: HintLocalTest[] = [
         reports: [
             {
                 message: `Unexpected token ' in JSON at position 191`,
-                position: {
-                    column: 3,
-                    line: 1
-                }
+                position: { match: 'extends' }
             }
         ]
     }

--- a/packages/hint-compat-api/tests/css-next.ts
+++ b/packages/hint-compat-api/tests/css-next.ts
@@ -170,9 +170,9 @@ const featureVersionAddedLaterThanTargetedBrowsers: HintTest[] = [
     {
         name: 'Features that were added after the targeted browser should fail.',
         reports: [
-            { message: 'keyframes is not supported by chrome 40.', position: { column: 0, line: 0 }},
-            { message: 'keyframes is not supported by chrome 40.', position: { column: 0, line: 6 }},
-            { message: 'keyframes is not supported by chrome 40.', position: { column: 0, line: 12 }}
+            { message: 'keyframes is not supported by chrome 40.', position: { match: '@keyframes name' }},
+            { message: 'keyframes is not supported by chrome 40.', position: { match: '@keyframes name2' }},
+            { message: 'keyframes is not supported by chrome 40.', position: { match: '@keyframes name3' }}
         ],
         serverConfig: generateCSSConfig('keyframes')
     }
@@ -183,7 +183,7 @@ hintRunner.testHint(hintPath, featureVersionAddedLaterThanTargetedBrowsers, { br
 const prefixedFeatureVersionAddedLaterThanTargetedBrowsers: HintTest[] = [
     {
         name: 'Prefixed features that were added after the targeted browser should fail.',
-        reports: [{ message: 'animation-duration prefixed with -webkit- is not supported by opera 12.', position: { column: 4, line: 1 }}],
+        reports: [{ message: 'animation-duration prefixed with -webkit- is not supported by opera 12.', position: { match: '-webkit-animation-duration' }}],
         serverConfig: generateCSSConfig('animation-duration-prefix')
     }
 ];
@@ -211,7 +211,7 @@ hintRunner.testHint(hintPath, prefixedFeaturesThatBecameStandardAndMarkedAsDepre
 const childFeatureAddedLaterThanTargetedBrowsers: HintTest[] = [
     {
         name: 'Child features that were added later than targeted browsers should fail.',
-        reports: [{ message: 'flex is not supported by chrome 26-28.', position: { column: 4, line: 1 } }],
+        reports: [{ message: 'flex is not supported by chrome 26-28.', position: { match: 'display: flex;' } }],
         serverConfig: generateCSSConfig('display-flex')
     }
 ];
@@ -221,7 +221,7 @@ hintRunner.testHint(hintPath, childFeatureAddedLaterThanTargetedBrowsers, { brow
 const childPrefixedFeatureAddedLaterThanTargetedBrowsers: HintTest[] = [
     {
         name: 'Child prefixed features that were added later than targeted browsers should fail.',
-        reports: [{ message: 'flex prefixed with -webkit- is not supported by chrome 17-19.', position: { column: 4, line: 1 } }],
+        reports: [{ message: 'flex prefixed with -webkit- is not supported by chrome 17-19.', position: { match: 'display: -webkit-flex;' } }],
         serverConfig: generateCSSConfig('display-flex-prefix')
     }
 ];
@@ -231,7 +231,7 @@ hintRunner.testHint(hintPath, childPrefixedFeatureAddedLaterThanTargetedBrowsers
 const notSupportedPropertiesAndValuesShouldNotSeparatelyLog: HintTest[] = [
     {
         name: 'Features not supported and not deprecated should not separately log the feature and value.',
-        reports: [{ message: 'appearance is not supported by ie.', position: { column: 4, line: 3 }}],
+        reports: [{ message: 'appearance is not supported by ie.', position: { match: 'appearance: none; /* Report */' }}],
         serverConfig: generateCSSConfig('appearance')
     }
 ];
@@ -242,8 +242,8 @@ const notSupportedFeaturesWithoutFallbackShouldSeparatelyLog: HintTest[] = [
     {
         name: 'Features not supported and not deprecated should separately log vendor prefixes if fallback is not defined.',
         reports: [
-            { message: 'appearance prefixed with -webkit- is not supported by ie.', position: { column: 4, line: 1 }},
-            { message: 'appearance prefixed with -moz- is not supported by ie.', position: { column: 4, line: 2 }}
+            { message: 'appearance prefixed with -webkit- is not supported by ie.', position: { match: '-webkit-appearance' }},
+            { message: 'appearance prefixed with -moz- is not supported by ie.', position: { match: '-moz-appearance' }}
         ],
         serverConfig: generateCSSConfig('appearance-only-prefixes')
     }
@@ -254,7 +254,7 @@ hintRunner.testHint(hintPath, notSupportedFeaturesWithoutFallbackShouldSeparatel
 const notSupportedAndNotDeprecatedFeature: HintTest[] = [
     {
         name: 'Features not supported and not deprecated should fail.',
-        reports: [{ message: 'cursor is not supported by webview_android.', position: { column: 4, line: 1 }}],
+        reports: [{ message: 'cursor is not supported by webview_android.', position: { match: 'cursor' }}],
         serverConfig: generateCSSConfig('cursor')
     }
 ];
@@ -269,9 +269,9 @@ const notSupportedFeaturesSplittedByCSSRuleBlock: HintTest[] = [
     {
         name: 'Should handle reports separately by CSS blocks.',
         reports: [
-            { message: 'appearance prefixed with -webkit- is not supported by ie.', position: { column: 4, line: 1 }},
-            { message: 'appearance prefixed with -moz- is not supported by ie.', position: { column: 4, line: 2 }},
-            { message: 'appearance is not supported by ie.', position: { column: 4, line: 6 }}
+            { message: 'appearance prefixed with -webkit- is not supported by ie.', position: { match: '-webkit-appearance' }},
+            { message: 'appearance prefixed with -moz- is not supported by ie.', position: { match: '-moz-appearance' }},
+            { message: 'appearance is not supported by ie.', position: { match: 'appearance: none; /* unprefixed */' }}
         ],
         serverConfig: generateCSSConfig('appearance-splitted')
     }
@@ -282,7 +282,7 @@ hintRunner.testHint(hintPath, notSupportedFeaturesSplittedByCSSRuleBlock, { brow
 const disorderedNotSupportedFeatures: HintTest[] = [
     {
         name: 'Should handle disordered vendor prefixes',
-        reports: [{ message: 'appearance is not supported by ie.', position: { column: 4, line: 1 }}],
+        reports: [{ message: 'appearance is not supported by ie.', position: { match: 'appearance' }}],
         serverConfig: generateCSSConfig('appearance-disordered-prefixes')
     }
 ];

--- a/packages/hint-compat-api/tests/css.ts
+++ b/packages/hint-compat-api/tests/css.ts
@@ -47,7 +47,7 @@ hintRunner.testHint(hintPath, prefixedFeatureNeverRemoved, { browserslist: ['saf
 const featureRemoved: HintTest[] = [
     {
         name: 'Features that were removed in versions before the targeted browsers should fail.',
-        reports: [{ message: 'padding-box is not supported by firefox 52.', position: { column: 4, line: 1 }}],
+        reports: [{ message: 'padding-box is not supported by firefox 52.', position: { match: 'box-sizing: padding-box;' }}],
         serverConfig: generateCSSConfig('box-sizing')
     }
 ];
@@ -57,7 +57,7 @@ hintRunner.testHint(hintPath, featureRemoved, { browserslist: ['firefox 52'], pa
 const prefixFeatureRemoved: HintTest[] = [
     {
         name: 'Prefixed features that were removed in versions before the targeted browsers should fail.',
-        reports: [{ message: 'box-lines prefixed with -webkit- is not supported by chrome 67-69.', position: { column: 4, line: 1 }}],
+        reports: [{ message: 'box-lines prefixed with -webkit- is not supported by chrome 67-69.', position: { match: '-webkit-box-lines' }}],
         serverConfig: generateCSSConfig('box-lines-prefix-current')
     }
 ];
@@ -85,7 +85,7 @@ hintRunner.testHint(hintPath, removedInEarlierVersionsAndAddedLater, { browsersl
 const removedForPrefixEqualToTargetedBrowsers: HintTest[] = [
     {
         name: 'Prefixed features that were removed in a version equal to the targeted browser should fail.',
-        reports: [{ message: 'keyframes prefixed with -o- is not supported by opera 15.', position: { column: 0, line: 2 }}],
+        reports: [{ message: 'keyframes prefixed with -o- is not supported by opera 15.', position: { match: '@-o-keyframes' }}],
         serverConfig: generateCSSConfig('keyframes-prefix-obsolete')
     }
 ];
@@ -95,7 +95,7 @@ hintRunner.testHint(hintPath, removedForPrefixEqualToTargetedBrowsers, { browser
 const removedForPrefixEarlierThanTargetedBrowsers: HintTest[] = [
     {
         name: 'Prefixed features that were removed in a version earlier than the targeted browser should fail.',
-        reports: [{ message: 'keyframes prefixed with -o- is not supported by opera 16, opera 18-19.', position: { column: 0, line: 2 }}],
+        reports: [{ message: 'keyframes prefixed with -o- is not supported by opera 16, opera 18-19.', position: { match: '@-o-keyframes' }}],
         serverConfig: generateCSSConfig('keyframes-prefix-obsolete')
     }
 ];
@@ -154,7 +154,7 @@ hintRunner.testHint(hintPath, prefixedFeatureThatBecameStandardAfterTarget, { br
 const prefixedFeaturesThatBecameStandardAndPrefixWasDeprecated: HintTest[] = [
     {
         name: 'Prefixed features that became deprecated before the targeted browser should fail.',
-        reports: [{ message: 'background-size prefixed with -moz- is not supported by firefox 4.', position: { column: 4, line: 1 }}],
+        reports: [{ message: 'background-size prefixed with -moz- is not supported by firefox 4.', position: { match: '-moz-background-size' }}],
         serverConfig: generateCSSConfig('background-size-prefix')
     }
 ];
@@ -164,7 +164,7 @@ hintRunner.testHint(hintPath, prefixedFeaturesThatBecameStandardAndPrefixWasDepr
 const featureVersionAddedFalse: HintTest[] = [
     {
         name: 'Features that have version added as false should fail.',
-        reports: [{ message: 'box-flex is not supported by ie.', position: { column: 4, line: 1}}],
+        reports: [{ message: 'box-flex is not supported by ie.', position: { match: 'box-flex' }}],
         serverConfig: generateCSSConfig('box-flex')
     }
 ];
@@ -174,7 +174,7 @@ hintRunner.testHint(hintPath, featureVersionAddedFalse, { browserslist: ['ie 11'
 const featureVersionAddedMixedFalseAndNullForDifferentBrowsers: HintTest[] = [
     {
         name: 'Features with unknown support (version added is null) and no support (version added is false) for different browsers should fail for unsupported browsers.',
-        reports: [{ message: 'box-lines is not supported by firefox, firefox_android.', position: { column: 4, line: 1}}],
+        reports: [{ message: 'box-lines is not supported by firefox, firefox_android.', position: { match: 'box-lines' }}],
         serverConfig: generateCSSConfig('box-lines')
     }
 ];
@@ -184,7 +184,7 @@ hintRunner.testHint(hintPath, featureVersionAddedMixedFalseAndNullForDifferentBr
 const mixedFeaturedCompatibility: HintTest[] = [
     {
         name: 'Features with mixed compatibility (version added null vs false) for different browsers should only throw errors for browsers in which the feature has never been added (false).',
-        reports: [{ message: 'box-lines is not supported by firefox.', position: { column: 4, line: 1 }}],
+        reports: [{ message: 'box-lines is not supported by firefox.', position: { match: 'box-lines' }}],
         serverConfig: generateCSSConfig('box-lines')
     }
 ];
@@ -194,7 +194,7 @@ hintRunner.testHint(hintPath, mixedFeaturedCompatibility, { browserslist: ['fire
 const featureVersionAddedFalseForAllTargetedBrowsers: HintTest[] = [
     {
         name: 'Features with no support (version added is false) for multiple targeted browsers should fail.',
-        reports: [{ message: 'box-lines is not supported by any of your target browsers.', position: { column: 4, line: 1}}],
+        reports: [{ message: 'box-lines is not supported by any of your target browsers.', position: { match: 'box-lines' }}],
         serverConfig: generateCSSConfig('box-lines')
     }
 ];
@@ -213,7 +213,7 @@ hintRunner.testHint(hintPath, notSupportedAndNotDeprecatedFeature, { browserslis
 const notSupportedFeaturesShouldNotSeparatelyLog: HintTest[] = [
     {
         name: 'Features not supported and not deprecated should not separately log the feature and value.',
-        reports: [{ message: 'box-flex is not supported by ie.', position: { column: 4, line: 3 }}],
+        reports: [{ message: 'box-flex is not supported by ie.', position: { match: 'box-flex: 1; /* Report */' }}],
         serverConfig: generateCSSConfig('box-flex-prefixes')
     }
 ];
@@ -240,7 +240,7 @@ hintRunner.testHint(hintPath, ignoredHintOptionsFeaturesShouldNotFail, {
 const enabledDefaultIgnoredFeaturesShouldFail: HintTest[] = [
     {
         name: 'Features included in the ignored HintOptions should fail.',
-        reports: [{ message: 'ime-mode is not supported by chrome.', position: { column: 4, line: 1}}],
+        reports: [{ message: 'ime-mode is not supported by chrome.', position: { match: 'ime-mode' }}],
         serverConfig: generateCSSConfig('ime-mode')
     }
 ];
@@ -254,7 +254,7 @@ hintRunner.testHint(hintPath, enabledDefaultIgnoredFeaturesShouldFail, {
 const enabledIgnoredHintOptionsFeaturesShouldFail: HintTest[] = [
     {
         name: 'Features included in the default ignored list should fail.',
-        reports: [{ message: 'box-flex is not supported by ie.', position: { column: 4, line: 1}}],
+        reports: [{ message: 'box-flex is not supported by ie.', position: { match: 'box-flex' }}],
         serverConfig: generateCSSConfig('box-flex')
     }
 ];

--- a/packages/hint-compat-api/tests/fixtures/css/appearance-splitted.css
+++ b/packages/hint-compat-api/tests/fixtures/css/appearance-splitted.css
@@ -4,5 +4,5 @@
 }
 
 .example2 {
-    appearance: none;
+    appearance: none; /* unprefixed */
 }

--- a/packages/hint-compat-api/tests/fixtures/css/appearance.css
+++ b/packages/hint-compat-api/tests/fixtures/css/appearance.css
@@ -1,5 +1,5 @@
 .example {
     -webkit-appearance: none;
     -moz-appearance: none;
-    appearance: none;
+    appearance: none; /* Report */
 }

--- a/packages/hint-compat-api/tests/fixtures/css/box-flex-prefixes.css
+++ b/packages/hint-compat-api/tests/fixtures/css/box-flex-prefixes.css
@@ -1,5 +1,5 @@
 .example {
     -webkit-box-flex: 1;
     -moz-box-flex: 1;
-    box-flex: 1;
+    box-flex: 1; /* Report */
 }

--- a/packages/hint-compat-api/tests/html-next.ts
+++ b/packages/hint-compat-api/tests/html-next.ts
@@ -41,7 +41,7 @@ hintRunner.testHint(hintPath, elementAttrAddedAlwaysTrue, { browserslist: ['> 1%
 const elementAttrVersionAddedFalse: HintTest[] = [
     {
         name: 'Element attributes that have version added as false and not deprecated should fail.',
-        reports: [{ message: 'srcset attribute of the img element is not supported by ie.', position: { column: 9, line: 6 } }],
+        reports: [{ message: 'srcset attribute of the img element is not supported by ie.', position: { match: 'img' } }],
         serverConfig: generateHTMLConfig('img-srcset')
     }
 ];
@@ -87,7 +87,7 @@ hintRunner.testHint(hintPath, elementAddedVersionOfTargetedBrowser, { browsersli
 const elementAddedInVersionAfterTargetedBrowserVersion: HintTest[] = [
     {
         name: 'Elements added in version after targeted browser should fail.',
-        reports: [{ message: 'video element is not supported by ie 8.', position: { column: 9, line: 6 } }],
+        reports: [{ message: 'video element is not supported by ie 8.', position: { match: 'video' } }],
         serverConfig: generateHTMLConfig('video')
     }
 ];
@@ -118,7 +118,7 @@ hintRunner.testHint(hintPath, globalAttrVersionAddedNull, { browserslist: ['last
 const globalAttrVersionAddedFalse: HintTest[] = [
     {
         name: 'Global attributes that have version added as false and not deprecated should fail.',
-        reports: [{ message: 'global attribute dropzone is not supported by edge, firefox, ie.', position: { column: 9, line: 6 } }],
+        reports: [{ message: 'global attribute dropzone is not supported by edge, firefox, ie.', position: { match: 'div' } }],
         serverConfig: generateHTMLConfig('global-attr-dropzone')
     }
 ];
@@ -146,7 +146,7 @@ hintRunner.testHint(hintPath, globalAttrAddedVersionOfTargetedBrowser, { browser
 const globalAttrAddedInVersionAfterTargetedBrowserVersion: HintTest[] = [
     {
         name: 'Global attributes added in version after targeted browser should fail.',
-        reports: [{ message: 'global attribute class is not supported by firefox 31.', position: { column: 9, line: 6 } }],
+        reports: [{ message: 'global attribute class is not supported by firefox 31.', position: { match: 'div' } }],
         serverConfig: generateHTMLConfig('div')
     }
 ];
@@ -169,7 +169,7 @@ hintRunner.testHint(hintPath, inputTypeVersionAddedNull, { browserslist: ['last 
 const inputTypeVersionAddedFalse: HintTest[] = [
     {
         name: 'Input types that have version added as false and not deprecated should fail.',
-        reports: [{ message: 'input type color is not supported by ie.', position: { column: 9, line: 6 } }],
+        reports: [{ message: 'input type color is not supported by ie.', position: { match: 'input' } }],
         serverConfig: generateHTMLConfig('input-color')
     }
 ];
@@ -179,7 +179,7 @@ hintRunner.testHint(hintPath, inputTypeVersionAddedFalse, { browserslist: ['ie 9
 const inputTypeVersionAddedAfterTargetedBrowsers: HintTest[] = [
     {
         name: 'Input types added in a version after the targeted browsers should fail.',
-        reports: [{ message: 'input type color is not supported by chrome 19, firefox 28.', position: { column: 9, line: 6 } }],
+        reports: [{ message: 'input type color is not supported by chrome 19, firefox 28.', position: { match: 'input' } }],
         serverConfig: generateHTMLConfig('input-color')
     }
 ];
@@ -193,7 +193,7 @@ hintRunner.testHint(hintPath, inputTypeVersionAddedAfterTargetedBrowsers, { brow
 const mixedFeaturedCompatibility: HintTest[] = [
     {
         name: 'Features with mixed compatibility (not supported for specific version and never supported) and not deprecated should throw errors for browsers in which the feature is not supported.',
-        reports: [{ message: 'integrity attribute of the link element is not supported by edge, ie, safari, safari_ios, samsunginternet_android 4, webview_android 4.', position: { column: 9, line: 6 } }],
+        reports: [{ message: 'integrity attribute of the link element is not supported by edge, ie, safari, safari_ios, samsunginternet_android 4, webview_android 4.', position: { match: 'link' } }],
         serverConfig: generateHTMLConfig('link-integrity')
     }
 ];

--- a/packages/hint-compat-api/tests/html.ts
+++ b/packages/hint-compat-api/tests/html.ts
@@ -50,7 +50,7 @@ hintRunner.testHint(hintPath, removedForFlags, { browserslist: ['firefox 34'] })
 const onlySupportedByFlags: HintTest[] = [
     {
         name: 'Elements only supported by flags should fail.',
-        reports: [{ message: 'shadow element is not supported by firefox 60.', position: { column: 9, line: 6 } }],
+        reports: [{ message: 'shadow element is not supported by firefox 60.', position: { match: 'shadow' } }],
         serverConfig: generateHTMLConfig('shadow')
     }
 ];
@@ -99,7 +99,7 @@ hintRunner.testHint(hintPath, elementRemovedVersionEarlierThanTargetedBrowser, {
 const elementVersionAddedFalse: HintTest[] = [
     {
         name: 'Elements that have version added as false should fail.',
-        reports: [{ message: 'blink element is not supported by chrome.', position: { column: 9, line: 6 } }],
+        reports: [{ message: 'blink element is not supported by chrome.', position: { match: 'blink' } }],
         serverConfig: generateHTMLConfig('blink')
     }
 ];
@@ -109,7 +109,7 @@ hintRunner.testHint(hintPath, elementVersionAddedFalse, { browserslist: ['last 2
 const featureVersionAddedFalseForAllTargetedBrowsers: HintTest[] = [
     {
         name: 'Features with no support (version added is false) for multiple targeted browsers should fail.',
-        reports: [{ message: 'element element is not supported by any of your target browsers.', position: { column: 9, line: 6 } }],
+        reports: [{ message: 'element element is not supported by any of your target browsers.', position: { match: 'element' } }],
         serverConfig: generateHTMLConfig('element')
     }
 ];
@@ -119,7 +119,7 @@ hintRunner.testHint(hintPath, featureVersionAddedFalseForAllTargetedBrowsers, { 
 const elementVersionAddedFalseForMultipleBrowsers: HintTest[] = [
     {
         name: 'Elements that have version added as false for multiple browsers should fail with one error.',
-        reports: [{ message: 'blink element is not supported by chrome, edge, ie.', position: { column: 9, line: 6 } }],
+        reports: [{ message: 'blink element is not supported by chrome, edge, ie.', position: { match: 'blink' } }],
         serverConfig: generateHTMLConfig('blink')
     }
 ];
@@ -129,7 +129,7 @@ hintRunner.testHint(hintPath, elementVersionAddedFalseForMultipleBrowsers, { bro
 const featureVersionAddedMixedFalseAndNullForDifferentBrowsers: HintTest[] = [
     {
         name: 'Features with unknown support (version added is null) and no support (version added is false) for different browsers should fail for unsupported browsers.',
-        reports: [{ message: 'element element is not supported by edge, firefox_android.', position: { column: 9, line: 6 } }],
+        reports: [{ message: 'element element is not supported by edge, firefox_android.', position: { match: 'element' } }],
         serverConfig: generateHTMLConfig('element')
     }
 ];

--- a/packages/hint-css-prefix-order/tests/fixtures/interleaved-prefixes.css
+++ b/packages/hint-css-prefix-order/tests/fixtures/interleaved-prefixes.css
@@ -1,5 +1,5 @@
 .example {
     -moz-appearance: none;
-    appearance: none;
+    appearance: none; /* Report */
     -webkit-appearance: none;
 }

--- a/packages/hint-css-prefix-order/tests/fixtures/mixed-with-prefixes-last.css
+++ b/packages/hint-css-prefix-order/tests/fixtures/mixed-with-prefixes-last.css
@@ -1,5 +1,5 @@
 .example {
-    appearance: none;
+    appearance: none; /* Report */
     background-color: #fff;
     -moz-appearance: none;
     -webkit-appearance: none;

--- a/packages/hint-css-prefix-order/tests/fixtures/multi-block.css
+++ b/packages/hint-css-prefix-order/tests/fixtures/multi-block.css
@@ -1,11 +1,11 @@
 .example1 {
-    appearance: none;
+    appearance: none; /* Report 1 */
     -moz-appearance: none;
     -webkit-appearance: none;
 }
 
 .example2 {
-    appearance: none;
+    appearance: none; /* Report 2 */
     -moz-appearance: none;
     -webkit-appearance: none;
 }

--- a/packages/hint-css-prefix-order/tests/fixtures/multi-property.css
+++ b/packages/hint-css-prefix-order/tests/fixtures/multi-property.css
@@ -1,7 +1,7 @@
 .example {
-    appearance: none;
+    appearance: none; /* Report 1 */
     -moz-appearance: none;
     -webkit-appearance: none;
-    background-size: cover;
+    background-size: cover; /* Report 2 */
     -moz-background-size: cover;
 }

--- a/packages/hint-css-prefix-order/tests/fixtures/prefixed-values-last.css
+++ b/packages/hint-css-prefix-order/tests/fixtures/prefixed-values-last.css
@@ -1,4 +1,4 @@
 .example {
-    display: grid;
+    display: grid; /* Report */
     display: -ms-grid;
 }

--- a/packages/hint-css-prefix-order/tests/fixtures/prefixes-last-moz.css
+++ b/packages/hint-css-prefix-order/tests/fixtures/prefixes-last-moz.css
@@ -1,5 +1,5 @@
 .example {
-    appearance: none;
+    appearance: none; /* Report */
     -webkit-appearance: none;
     -moz-appearance: none;
 }

--- a/packages/hint-css-prefix-order/tests/fixtures/prefixes-last-same-line.css
+++ b/packages/hint-css-prefix-order/tests/fixtures/prefixes-last-same-line.css
@@ -1,1 +1,1 @@
-.example { appearance: none; -moz-appearance: none; -webkit-appearance: none; }
+.example { appearance: none; /* Report */ -moz-appearance: none; -webkit-appearance: none; }

--- a/packages/hint-css-prefix-order/tests/fixtures/prefixes-last-webkit.css
+++ b/packages/hint-css-prefix-order/tests/fixtures/prefixes-last-webkit.css
@@ -1,5 +1,5 @@
 .example {
-    appearance: none;
+    appearance: none; /* Report */
     -moz-appearance: none;
     -webkit-appearance: none;
 }

--- a/packages/hint-css-prefix-order/tests/tests.ts
+++ b/packages/hint-css-prefix-order/tests/tests.ts
@@ -31,10 +31,7 @@ const tests: HintTest[] = [
         name: `Some prefixed properties listed first, but others last fail`,
         reports: [{
             message: `'appearance' should be listed after '-webkit-appearance'.`,
-            position: {
-                column: 4,
-                line: 2
-            }
+            position: { match: 'appearance: none; /* Report */' }
         }],
         serverConfig: generateConfig('interleaved-prefixes')
     },
@@ -46,10 +43,7 @@ const tests: HintTest[] = [
         name: 'Prefixed properties listed last with other properties mixed in pass',
         reports: [{
             message: `'appearance' should be listed after '-webkit-appearance'.`,
-            position: {
-                column: 4,
-                line: 1
-            }
+            position: { match: 'appearance: none; /* Report */' }
         }],
         serverConfig: generateConfig('mixed-with-prefixes-last')
     },
@@ -58,17 +52,11 @@ const tests: HintTest[] = [
         reports: [
             {
                 message: `'appearance' should be listed after '-webkit-appearance'.`,
-                position: {
-                    column: 4,
-                    line: 1
-                }
+                position: { match: 'appearance: none; /* Report 1 */' }
             },
             {
                 message: `'appearance' should be listed after '-webkit-appearance'.`,
-                position: {
-                    column: 4,
-                    line: 7
-                }
+                position: { match: 'appearance: none; /* Report 2 */' }
             }
         ],
         serverConfig: generateConfig('multi-block')
@@ -78,17 +66,11 @@ const tests: HintTest[] = [
         reports: [
             {
                 message: `'appearance' should be listed after '-webkit-appearance'.`,
-                position: {
-                    column: 4,
-                    line: 1
-                }
+                position: { match: 'appearance: none; /* Report 1 */' }
             },
             {
                 message: `'background-size' should be listed after '-moz-background-size'.`,
-                position: {
-                    column: 4,
-                    line: 4
-                }
+                position: { match: 'background-size: cover; /* Report 2 */' }
             }
         ],
         serverConfig: generateConfig('multi-property')
@@ -105,10 +87,7 @@ const tests: HintTest[] = [
         name: 'Prefixed values listed last fail',
         reports: [{
             message: `'display: grid' should be listed after 'display: -ms-grid'.`,
-            position: {
-                column: 4,
-                line: 1
-            }
+            position: { match: 'display: grid; /* Report */' }
         }],
         serverConfig: generateConfig('prefixed-values-last')
     },
@@ -124,10 +103,7 @@ const tests: HintTest[] = [
         name: 'Prefixed properties listed last fail (moz)',
         reports: [{
             message: `'appearance' should be listed after '-moz-appearance'.`,
-            position: {
-                column: 4,
-                line: 1
-            }
+            position: { match: 'appearance: none; /* Report */' }
         }],
         serverConfig: generateConfig('prefixes-last-moz')
     },
@@ -135,10 +111,7 @@ const tests: HintTest[] = [
         name: 'Prefixed properties listed last on same line fail',
         reports: [{
             message: `'appearance' should be listed after '-webkit-appearance'.`,
-            position: {
-                column: 11,
-                line: 0
-            }
+            position: { match: 'appearance: none; /* Report */' }
         }],
         serverConfig: generateConfig('prefixes-last-same-line')
     },
@@ -157,10 +130,7 @@ const tests: HintTest[] = [
         name: 'Prefixed properties listed last fail (webkit)',
         reports: [{
             message: `'appearance' should be listed after '-webkit-appearance'.`,
-            position: {
-                column: 4,
-                line: 1
-            }
+            position: { match: 'appearance: none; /* Report */' }
         }],
         serverConfig: generateConfig('prefixes-last-webkit')
     },

--- a/packages/hint-doctype/tests/tests.ts
+++ b/packages/hint-doctype/tests/tests.ts
@@ -12,7 +12,7 @@ const normalizeEOL = (text: string): string => {
 const tests: HintTest[] = [
     {
         name: `'doctype' is not in the first line should fail`,
-        reports: [{ message: `'doctype' should be specified before anything else.`, position: { column: 16, line: 2 } }],
+        reports: [{ message: `'doctype' should be specified before anything else.`, position: { match: '<!DOCTYPE html>' } }],
         serverConfig: {
             '/': {
                 content: normalizeEOL(`<p><span></span>
@@ -36,13 +36,13 @@ const tests: HintTest[] = [
     },
     {
         name: `'doctype' found more than once should fail`,
-        reports: [{ message: `'doctype' is not needed as one was already specified.`, position: { column: 16, line: 3 } }],
+        reports: [{ message: `'doctype' is not needed as one was already specified.`, position: { match: '<!DOCTYPE html><!-- Report -->' } }],
         serverConfig: {
             '/': {
                 content: normalizeEOL(`<!DOCTYPE html>
                 <p><span></span>
                 <head></head>
-                <!DOCTYPE html>
+                <!DOCTYPE html><!-- Report -->
                 `),
                 headers: { 'Content-Type': 'text/html' }
             }

--- a/packages/hint-manifest-is-valid/tests/tests.ts
+++ b/packages/hint-manifest-is-valid/tests/tests.ts
@@ -38,24 +38,15 @@ const defaultTests: HintTest[] = [
         reports: [
             {
                 message: `'root' should NOT have additional properties. Additional property found 'additionalProperty'.`,
-                position: {
-                    column: 2,
-                    line: 0
-                }
+                position: { match: 'additionalProperty' }
             },
             {
                 message: `'icons[0]' should NOT have additional properties. Additional property found 'density'.`,
-                position: {
-                    column: 63,
-                    line: 0
-                }
+                position: { match: 'density' }
             },
             {
                 message: `'name' should be 'string'.`,
-                position: {
-                    column: 110,
-                    line: 0
-                }
+                position: { match: 'name' }
             }
         ],
         serverConfig: {

--- a/packages/hint-no-protocol-relative-urls/tests/tests.ts
+++ b/packages/hint-no-protocol-relative-urls/tests/tests.ts
@@ -26,7 +26,7 @@ const tests: HintTest[] = [
         name: `'link' with initial // fails the hint`,
         reports: [{
             message: generateErrorMessage('//site.webmanifest'),
-            position: { column: 9, line: 3 }
+            position: { match: 'link rel="manifest" href="//site.webmanifest"' }
         }],
         serverConfig: generateHTMLPage('<link rel="manifest" href="//site.webmanifest">')
     },
@@ -46,7 +46,7 @@ const tests: HintTest[] = [
         name: `'script' with initial // fails the hint`,
         reports: [{
             message: generateErrorMessage('//script.js'),
-            position: { column: 9, line: 6 }
+            position: { match: 'script src="//script.js"' }
         }],
         serverConfig: generateHTMLPage(undefined, '<script src="//script.js"></script>')
     },
@@ -66,7 +66,7 @@ const tests: HintTest[] = [
         name: `'a' with initial // fails the hint`,
         reports: [{
             message: generateErrorMessage('//home'),
-            position: { column: 9, line: 6 }
+            position: { match: 'a href="//home"' }
         }],
         serverConfig: generateHTMLPage(undefined, '<a href="//home">home</a>')
     },

--- a/packages/hint-typescript-config/tests/is-valid.ts
+++ b/packages/hint-typescript-config/tests/is-valid.ts
@@ -25,10 +25,7 @@ const tests: HintLocalTest[] = [
         path: path.join(__dirname, 'fixtures', 'invalidschemaenum'),
         reports: [{
             message: `'compilerOptions.lib[3]' should be equal to one of the allowed values 'es5, es6, es2015, es7, es2016, es2017, es2018, esnext, dom, dom.iterable, webworker, scripthost, es2015.core, es2015.collection, es2015.generator, es2015.iterable, es2015.promise, es2015.proxy, es2015.reflect, es2015.symbol, es2015.symbol.wellknown, es2016.array.include, es2017.object, es2017.intl, es2017.sharedmemory, es2017.string, es2017.typedarrays, es2018.intl, es2018.promise, es2018.regexp, esnext.asynciterable, esnext.array, esnext.intl, esnext.symbol'. Value found 'invalidlib'`,
-            position: {
-                column: 12,
-                line: 9
-            }
+            position: { match: '"invalidlib"' }
         }]
     },
     {
@@ -37,10 +34,7 @@ const tests: HintLocalTest[] = [
         reports: [
             {
                 message: `'compilerOptions.target' should be equal to one of the allowed values 'es3, es5, es6, es2015, es2016, es2017, es2018, esnext'. Value found '"invalid"'. Or 'compilerOptions.target' should match pattern '^([eE][sS]([356]|(201[5678])|[nN][eE][xX][tT]))$'. Value found 'invalid'`,
-                position: {
-                    column: 9,
-                    line: 14
-                }
+                position: { match: 'target' }
             }
         ]
     },
@@ -50,10 +44,7 @@ const tests: HintLocalTest[] = [
         reports: [
             {
                 message: `Circular reference found in file ${path.join(__dirname, 'fixtures', 'circular-2', 'tsconfig.circular.json')}`,
-                position: {
-                    column: 5,
-                    line: 4
-                }
+                position: { match: 'extends' }
             }
         ]
     },
@@ -63,10 +54,7 @@ const tests: HintLocalTest[] = [
         reports: [
             {
                 message: `Unexpected token i in JSON at position 0`,
-                position: {
-                    column: 5,
-                    line: 4
-                }
+                position: { match: 'extends' }
             }
         ]
     }

--- a/packages/hint-typescript-config/tests/no-comments.ts
+++ b/packages/hint-typescript-config/tests/no-comments.ts
@@ -21,10 +21,7 @@ const tests: HintLocalTest[] = [
         path: path.join(__dirname, 'fixtures', 'extends-with-error'),
         reports: [{
             message: 'The compiler option "removeComments" should be enabled to reduce the output size.',
-            position: {
-                column: 5,
-                line: 4
-            }
+            position: { match: 'extends' }
         }]
     }
 ];

--- a/packages/hint/docs/contributor-guide/how-to/test-rules.md
+++ b/packages/hint/docs/contributor-guide/how-to/test-rules.md
@@ -29,7 +29,7 @@ const tests: HintTest[] = [
         serverConfig: 'HTML to use',
         reports: [{
             message: 'Message the error will have',
-            position: { column: 0, line: 0 } // Where the error will show.
+            position: { match: 'text' } // Source where error will show.
         }]
     },
     { ... }
@@ -71,6 +71,42 @@ There's more information and detail in the following sections.
   on each `Report` will be matched. This means you can decide to ignore some
   that are not relevant to you, i.e.: in the code above you could decide to
   remove `position` and the test engine will not try to validate that property.
+
+### `position`
+
+When specified, `position` can be a `ProblemLocation` or a string of text in
+the source to derive a `ProblemLocation` from. The latter is recommended when
+possible as it is less error-prone.
+
+```ts
+// `position` as a `ProblemLocation`
+const tests: HintTest[] = [
+    {
+        name: 'Name of the tests',
+        serverConfig: 'HTML to use',
+        reports: [{
+            message: 'Error message targeting the word "HTML"',
+            position: { column: 0, line: 0 }
+        }]
+    },
+    { ... }
+];
+```
+
+```ts
+// `position` as a `match`
+const tests: HintTest[] = [
+    {
+        name: 'Name of the tests',
+        serverConfig: 'HTML to use',
+        reports: [{
+            message: 'Error message targeting the word "HTML"',
+            position: { match: 'HTML' }
+        }]
+    },
+    { ... }
+];
+```
 
 ### Execute code `before` or `after` collecting the results
 

--- a/packages/utils-tests-helpers/src/hint-runner.ts
+++ b/packages/utils-tests-helpers/src/hint-runner.ts
@@ -8,12 +8,15 @@ import anyTest, { TestInterface, ExecutionContext } from 'ava';
 import { Server } from '@hint/utils-create-server';
 
 import { ids as connectors } from './connectors';
-import { IHintConstructor, HintsConfigObject, Problem } from 'hint/dist/src/lib/types';
+import { IHintConstructor, HintsConfigObject, Problem, ProblemLocation } from 'hint/dist/src/lib/types';
+import readFileAsync from 'hint/dist/src/lib/utils/fs/read-file-async';
+import { getAsUri } from 'hint/dist/src/lib/utils/network/as-uri';
+import asPathString from 'hint/dist/src/lib/utils/network/as-path-string';
+import requestAsync from 'hint/dist/src/lib/utils/network/request-async';
 import * as resourceLoader from 'hint/dist/src/lib/utils/resource-loader';
 import { HintTest, HintLocalTest, Report } from './hint-test-type';
 import { Engine } from 'hint/dist/src/lib/engine';
 import { Configuration } from 'hint/dist/src/lib/config';
-import { getAsUri } from 'hint/dist/src/lib/utils/network/as-uri';
 
 type HintRunnerContext = {
     server: Server;
@@ -34,6 +37,53 @@ const determineParsers = (parsers?: string[]) => {
     }
 
     return Array.from(new Set(['html', ...parsers]));
+};
+
+/**
+ * Generates a ProblemLocation based on the index of the first occurance
+ * of the provided substring.
+ */
+const findPosition = (source: string, match: string): ProblemLocation => {
+    const lines = source.split('\n');
+    const index = source.indexOf(match);
+
+    let line = 0;
+    let column = index;
+
+    while (line < lines.length && column >= lines[line].length) {
+        column -= (lines[line].length + 1);
+        line++;
+    }
+
+    return {
+        column,
+        line
+    };
+};
+
+/**
+ * Get the source code for the provided resource.
+ * Returns the empty string if resource was invalid.
+ */
+const requestSource = async (url: string, connector: string): Promise<string> => {
+    try {
+        if (connector === 'local') {
+            return await readFileAsync(asPathString(getAsUri(url)!));
+        } else {
+            /*
+            * Allow us to use our self-signed cert for testing.
+            * https://github.com/request/request/issues/418#issuecomment-23058601
+            */
+            return await requestAsync({
+                rejectUnauthorized: false,
+                strictSSL: false,
+                url
+            });
+        }
+    } catch (e) {
+        // Some tests deliberately use invalid URLs (e.g. `test:`).
+        return '';
+    }
 };
 
 /**
@@ -79,7 +129,7 @@ const createConfig = (id: string, connector: string, opts?: any): Configuration 
 };
 
 /** Validates that the results from the execution match the expected ones. */
-const validateResults = (t: ExecutionContext<HintRunnerContext>, results: Problem[], reports: Report[] | undefined) => {
+const validateResults = (t: ExecutionContext<HintRunnerContext>, sources: Map<string, string>, results: Problem[], reports?: Report[]) => {
     const server = t.context.server || {};
 
     if (!reports) {
@@ -109,19 +159,23 @@ const validateResults = (t: ExecutionContext<HintRunnerContext>, results: Proble
     const reportsCopy = reports.slice(0);
 
     results.forEach((result) => {
-        const { message } = result;
+        const { location, message, resource } = result;
         let index = 0;
 
         const found = reportsCopy.some((report, i) => {
             index = i;
 
-            if (report.message !== result.message) {
+            if (report.message !== message) {
                 return false;
             }
 
-            if (report.position && result.location) {
-                return report.position.column === result.location.column &&
-                    report.position.line === result.location.line;
+            if (report.position && location) {
+                const position = 'match' in report.position ?
+                    findPosition(sources.get(resource) || '', report.position.match) :
+                    report.position;
+
+                return position.column === location.column &&
+                    position.line === location.line;
             }
 
             return true;
@@ -131,7 +185,7 @@ const validateResults = (t: ExecutionContext<HintRunnerContext>, results: Proble
             reportsCopy.splice(index, 1);
         }
 
-        t.true(found, `No reports match "${message}" or its location.`);
+        t.true(found, `No reports match "${message}" or its location (${JSON.stringify(location)}).`);
     });
 };
 
@@ -175,10 +229,18 @@ export const testHint = (hintId: string, hintTests: HintTest[], configs: { [key:
             const engine = await createConnector(t, hintTest, connector);
             const results = await engine.executeOn(new URL(target));
 
+            const sources = new Map<string, string>();
+
+            for (const result of results) {
+                if (!sources.has(result.resource)) {
+                    sources.set(result.resource, await requestSource(result.resource, connector));
+                }
+            }
+
             await stopConnector(hintTest, engine);
             await server.stop();
 
-            return validateResults(t, results, Server.updateLocalhost(reports, server.port));
+            return validateResults(t, sources, results, Server.updateLocalhost(reports, server.port));
         } catch (e) {
             console.error(e);
 
@@ -218,8 +280,9 @@ export const testHint = (hintId: string, hintTests: HintTest[], configs: { [key:
 
 export const testLocalHint = (hintId: string, hintTests: HintLocalTest[], configs: { [key: string]: any } = {}) => {
     const Hint: IHintConstructor = resourceLoader.loadHint(hintId, []);
+    const connector = 'local';
 
-    if (Hint.meta.ignoredConnectors && Hint.meta.ignoredConnectors.includes('local')) {
+    if (Hint.meta.ignoredConnectors && Hint.meta.ignoredConnectors.includes(connector)) {
         return;
     }
 
@@ -232,7 +295,7 @@ export const testLocalHint = (hintId: string, hintTests: HintLocalTest[], config
      * If the tests for a hint ignores the connector, then we
      * skip the tests
      */
-    if (configs.ignoredConnectors && configs.ignoredConnectors.includes('local')) {
+    if (configs.ignoredConnectors && configs.ignoredConnectors.includes(connector)) {
         runner = test.skip;
     }
 
@@ -244,12 +307,13 @@ export const testLocalHint = (hintId: string, hintTests: HintLocalTest[], config
                 await hintTest.before(t);
             }
 
-            const hintConfig = createConfig(hintId, 'local', configs);
+            const hintConfig = createConfig(hintId, connector, configs);
             const resources = resourceLoader.loadResources(hintConfig);
             const engine = new Engine(hintConfig, resources);
 
             // Can assume `getAsUri(hintTest.path)` is not `null` since these are controlled test inputs.
-            const results = await engine.executeOn(getAsUri(hintTest.path)!);
+            const target = getAsUri(hintTest.path)!;
+            const results = await engine.executeOn(target);
 
             await engine.close();
 
@@ -257,7 +321,15 @@ export const testLocalHint = (hintId: string, hintTests: HintLocalTest[], config
                 await hintTest.after(t);
             }
 
-            return validateResults(t, results, hintTest.reports);
+            const sources = new Map<string, string>();
+
+            for (const result of results) {
+                if (!sources.has(result.resource)) {
+                    sources.set(result.resource, await requestSource(result.resource, connector));
+                }
+            }
+
+            return validateResults(t, sources, results, hintTest.reports);
         } catch (e) {
             console.error(e);
 
@@ -266,6 +338,6 @@ export const testLocalHint = (hintId: string, hintTests: HintLocalTest[], config
     };
 
     hintTests.forEach((hintTest) => {
-        runner(`[local] ${hintTest.name}`, runHint, hintTest, 'local');
+        runner(`[local] ${hintTest.name}`, runHint, hintTest, connector);
     });
 };

--- a/packages/utils-tests-helpers/src/hint-test-type.ts
+++ b/packages/utils-tests-helpers/src/hint-test-type.ts
@@ -2,10 +2,15 @@ import { ExecutionContext } from 'ava';
 
 import { ProblemLocation } from 'hint/dist/src/lib/types';
 
+export type MatchProblemLocation = {
+    /** A substring matching the location of the problem. */
+    match: string;
+};
+
 export type Report = {
     /** The message to validate */
     message: string;
-    position?: ProblemLocation;
+    position?: ProblemLocation | MatchProblemLocation;
 };
 
 export type HintTest = {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~Added/Updated related documentation.~
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Makes it easier to write tests with correct location
information by allowing tests to provide substrings
representing where a report should occur.

Previously tests had hard-coded locations which were
prone to mistakes due to difficulty visualizing how
they aligned with the actual text in a file.

----

This is fully functional, but I've only updated the tests for two hints so far to make it easier to adjust for feedback. If we like the approach I can convert the rest of our existing test positions before merging.

Pending test updates:
* ~Fix positions in hint-html-checker tests~
* [x] Fix off-by-one issue in hint-amp-validator
* [x] Fix incorrect positions in hint-compat-api
* [x] Fix incorrect positions in hint-no-protocol-relative-urls