### PR TITLE
Fix button cutoff and misc a11y issue

### DIFF
--- a/packages/formatter-html/src/assets/styles/scan/scan-results.css
+++ b/packages/formatter-html/src/assets/styles/scan/scan-results.css
@@ -468,31 +468,6 @@ a > .rule-tile:hover {
     }
 }
 
-@media print {
-
-    .rule-categories {
-        position: relative;
-    }
-
-    .show-categories {
-        display: none;
-    }
-
-    .rule-doc-buttons {
-        position: relative;
-    }
-
-    .rule-result--details__body p {
-        font-size: 85%;
-    }
-
-    .rule-result__code {
-        border: 1px solid #f4f4f4;
-    }
-
-}
-
-
 /* SCAN DETAILS */
 
 .rule-result {

--- a/packages/formatter-html/src/assets/styles/scan/scan-results.css
+++ b/packages/formatter-html/src/assets/styles/scan/scan-results.css
@@ -256,17 +256,14 @@
 }
 
 .rule-categories {
-    background-color: #fff;
-    bottom: calc(-100% + 5rem);
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    height: calc(100% - 5rem);
+    position: fixed;
     left: 0;
     padding: 0 2rem;
-    position: fixed;
     width: 100%;
+    background-color: #fff;
     z-index: 5;
+    bottom: calc(-100% + 5rem);
+    height: calc(100% - 5rem);
     transition: bottom .5s ease-out;
 }
 
@@ -506,7 +503,7 @@ a > .rule-tile:hover {
 }
 
 .button-expand-all.closed {
-    background-position: 0 -23px;
+    background-position: 0 -2.4rem;
 }
 
 .rule-result h3 {

--- a/packages/formatter-html/src/assets/styles/scan/scan-results.css
+++ b/packages/formatter-html/src/assets/styles/scan/scan-results.css
@@ -468,6 +468,31 @@ a > .rule-tile:hover {
     }
 }
 
+@media print {
+
+    .rule-categories {
+        position: relative;
+    }
+
+    .show-categories {
+        display: none;
+    }
+
+    .rule-doc-buttons {
+        position: relative;
+    }
+
+    .rule-result--details__body p {
+        font-size: 85%;
+    }
+
+    .rule-result__code {
+        border: 1px solid #f4f4f4;
+    }
+
+}
+
+
 /* SCAN DETAILS */
 
 .rule-result {

--- a/packages/formatter-html/src/views/partials/scan-result.ejs
+++ b/packages/formatter-html/src/views/partials/scan-result.ejs
@@ -50,7 +50,7 @@
         </div>
     </div>
     <% if(!result.showError) { %>
-    <section id="results-container" class="section container" role="main" aria-labelledby="hints" aria-live="polite">
+    <section id="results-container" class="section container" aria-labelledby="hints" aria-live="polite">
         <h2 id="hints">Hints</h2>
         <div class="layout layout--basic--offset--alt">
             <div class="module module--secondary module--categories">


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

Fix #1985 and a misc accessibility bug. 

This PR fixes the expand all, close all button being cut off. Also removes an unnecessary` role="main" `on the results container. There is already a `<main>` element being used so the use of `role="main"` on a different container is of no value. Ran an accessibility checker that flagged this. 