### PR TITLE
Fix: Tie more elements from DOM snapshot back to original source

### DIFF
--- a/packages/connector-chrome/tests/collect.ts
+++ b/packages/connector-chrome/tests/collect.ts
@@ -28,7 +28,10 @@ test.beforeEach((t) => {
         emit(): boolean {
             return false;
         },
-        async emitAsync(): Promise<any> { }
+        async emitAsync(): Promise<any> { },
+        on(): Engine {
+            return null as any;
+        }
     } as any;
 
     t.context.engineEmitSpy = sinon.spy(engine, 'emit');

--- a/packages/connector-chrome/tests/evaluate.ts
+++ b/packages/connector-chrome/tests/evaluate.ts
@@ -53,6 +53,9 @@ test(`[${name}] Evaluate JavaScript`, async (t) => {
             return false;
         },
         async emitAsync(): Promise<any> { },
+        on(): Engine {
+            return null as any;
+        },
         timeout: 10000
     } as any;
 

--- a/packages/connector-chrome/tests/events.ts
+++ b/packages/connector-chrome/tests/events.ts
@@ -206,7 +206,10 @@ test.beforeEach((t) => {
         emit(): boolean {
             return false;
         },
-        async emitAsync(): Promise<any> { }
+        async emitAsync(): Promise<any> { },
+        on(): Engine {
+            return null as any;
+        }
     } as any;
 
     t.context.engineEmitAsyncSpy = sinon.spy(engine, 'emitAsync');

--- a/packages/connector-chrome/tests/fetch-content.ts
+++ b/packages/connector-chrome/tests/fetch-content.ts
@@ -18,7 +18,10 @@ test(`[${name}] Fetch Content`, async (t) => {
         emit(): boolean {
             return false;
         },
-        async emitAsync(): Promise<any> { }
+        async emitAsync(): Promise<any> { },
+        on(): Engine {
+            return null as any;
+        }
     } as any;
 
     const file = fs.readFileSync(path.join(__dirname, './fixtures/common/nellie.png'));

--- a/packages/connector-chrome/tests/invalid-url.ts
+++ b/packages/connector-chrome/tests/invalid-url.ts
@@ -13,7 +13,10 @@ test(`[${name}] Load an invalid url throws an error`, async (t) => {
         emit(): boolean {
             return false;
         },
-        async emitAsync(): Promise<any> { }
+        async emitAsync(): Promise<any> { },
+        on(): Engine {
+            return null as any;
+        }
     } as any;
 
     const connector: IConnector = new ChromeConnector(engine, {});

--- a/packages/connector-chrome/tests/request-response.ts
+++ b/packages/connector-chrome/tests/request-response.ts
@@ -39,7 +39,10 @@ test(`[${name}] requestResponse`, async (t) => {
         emit(): boolean {
             return false;
         },
-        async emitAsync(): Promise<any> { }
+        async emitAsync(): Promise<any> { },
+        on(): Engine {
+            return null as any;
+        }
     } as any;
 
     const engineEmitAsyncSpy = sinon.spy(engine, 'emitAsync');

--- a/packages/connector-jsdom/package.json
+++ b/packages/connector-jsdom/package.json
@@ -15,6 +15,7 @@
   },
   "description": "hint connector for JSDOM",
   "devDependencies": {
+    "@hint/parser-html": "^2.0.2",
     "@hint/utils-create-server": "^3.0.0",
     "@types/jsdom": "^12.2.3",
     "@types/lodash": "^4.14.123",

--- a/packages/connector-jsdom/tests/collect.ts
+++ b/packages/connector-jsdom/tests/collect.ts
@@ -29,7 +29,10 @@ test.beforeEach((t) => {
         emit(): boolean {
             return false;
         },
-        async emitAsync(): Promise<any> { }
+        async emitAsync(): Promise<any> { },
+        on(): Engine {
+            return null as any;
+        }
     } as any;
 
     t.context.engineEmitSpy = sinon.spy(engine, 'emit');

--- a/packages/connector-jsdom/tests/evaluate.ts
+++ b/packages/connector-jsdom/tests/evaluate.ts
@@ -53,6 +53,9 @@ test(`[${name}] Evaluate JavaScript`, async (t) => {
             return false;
         },
         async emitAsync(): Promise<any> { },
+        on(): Engine {
+            return null as any;
+        },
         timeout: 10000
     } as any;
     const connector: IConnector = new JSDOMConnector(engine, {});

--- a/packages/connector-jsdom/tests/events.ts
+++ b/packages/connector-jsdom/tests/events.ts
@@ -197,7 +197,10 @@ test(`[${name}] Events`, async (t) => {
         emit(): boolean {
             return false;
         },
-        async emitAsync(): Promise<any> { }
+        async emitAsync(): Promise<any> { },
+        on(): Engine {
+            return null as any;
+        }
     } as any;
 
     const engineEmitAsyncSpy = sinon.spy(engine, 'emitAsync');

--- a/packages/connector-jsdom/tests/fetch-content.ts
+++ b/packages/connector-jsdom/tests/fetch-content.ts
@@ -19,7 +19,10 @@ test(`[${name}] Fetch Content`, async (t) => {
         emit(): boolean {
             return false;
         },
-        async emitAsync(): Promise<any> { }
+        async emitAsync(): Promise<any> { },
+        on(): Engine {
+            return null as any;
+        }
     } as any;
 
     const connector: IConnector = new JSDOMConnector(engine, {});

--- a/packages/connector-jsdom/tests/invalid-url.ts
+++ b/packages/connector-jsdom/tests/invalid-url.ts
@@ -13,7 +13,10 @@ test(`[${name}] Load an invalid url throws an error`, async (t) => {
         emit(): boolean {
             return false;
         },
-        async emitAsync(): Promise<any> { }
+        async emitAsync(): Promise<any> { },
+        on(): Engine {
+            return null as any;
+        }
     } as any;
 
     const connector: IConnector = new JSDOMConnector(engine, {});

--- a/packages/connector-jsdom/tests/request-response.ts
+++ b/packages/connector-jsdom/tests/request-response.ts
@@ -39,7 +39,10 @@ test(`[${name}] requestResponse`, async (t) => {
         emit(): boolean {
             return false;
         },
-        async emitAsync(): Promise<any> { }
+        async emitAsync(): Promise<any> { },
+        on(): Engine {
+            return null as any;
+        }
     } as any;
 
     const engineEmitAsyncSpy = sinon.spy(engine, 'emitAsync');

--- a/packages/connector-jsdom/tsconfig.json
+++ b/packages/connector-jsdom/tsconfig.json
@@ -14,6 +14,7 @@
     ],
     "references": [
         { "path": "../hint" },
+        { "path": "../parser-html" },
         { "path": "../utils-connector-tools" },
         { "path": "../utils-create-server" }
     ]

--- a/packages/connector-local/src/connector.ts
+++ b/packages/connector-local/src/connector.ts
@@ -267,7 +267,7 @@ export default class LocalConnector implements IConnector {
         return new JSDOM(html, {
 
             /** Needed to provide line/column positions for elements. */
-            includeNodeLocations: true,
+            // includeNodeLocations: true, // TODO: re-enable once locations can be copied from snapshot.
 
             /**
              * Needed to let hints run script against the DOM.
@@ -280,14 +280,10 @@ export default class LocalConnector implements IConnector {
 
     /* istanbul ignore next */
     private async onParseHTML(event: HTMLParse) {
-        const document = event.document;
-        const jsdom: JSDOM = this.createJsdom(document.pageHTML());
+        this._document = event.document;
+        this._evaluate = this.createJsdom(event.html).window.eval;
 
-        this._evaluate = jsdom.window.eval;
-
-        this._document = document;
-
-        await traverse(document, this.engine, event.resource);
+        await traverse(this._document, this.engine, event.resource);
 
         await this.engine.emitAsync('can-evaluate::script', { resource: this._href } as CanEvaluateScript);
     }

--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -31,6 +31,7 @@
     "@hint/hint-validate-set-cookie-header": "^2.1.2",
     "@hint/hint-x-content-type-options": "^3.0.1",
     "@hint/parser-css": "^2.1.0",
+    "@hint/parser-html": "^2.0.2",
     "@hint/parser-javascript": "^2.1.0",
     "@hint/parser-manifest": "^2.0.2",
     "@hint/utils-create-server": "^3.0.0",

--- a/packages/extension-browser/src/content-script/webhint.ts
+++ b/packages/extension-browser/src/content-script/webhint.ts
@@ -8,6 +8,7 @@ import { Configuration } from 'hint/dist/src/lib/config';
 import { HintResources, HintsConfigObject, IHintConstructor } from 'hint/dist/src/lib/types';
 
 import CSSParser from '@hint/parser-css';
+import HTMLParser from '@hint/parser-html';
 import JavaScriptParser from '@hint/parser-javascript';
 import ManifestParser from '@hint/parser-manifest';
 
@@ -71,7 +72,7 @@ const main = async (userConfig: Config) => {
         hints: hintsConfig,
         hintsTimeout: 10000,
         ignoredUrls: determineIgnoredUrls(userConfig.ignoredUrls),
-        parsers: ['css', 'javascript', 'manifest']
+        parsers: ['css', 'html', 'javascript', 'manifest']
     };
 
     const resources: HintResources = {
@@ -82,6 +83,7 @@ const main = async (userConfig: Config) => {
         missing: [],
         parsers: [
             CSSParser as any,
+            HTMLParser as any,
             JavaScriptParser as any,
             ManifestParser as any
         ]

--- a/packages/extension-browser/tsconfig.json
+++ b/packages/extension-browser/tsconfig.json
@@ -37,6 +37,7 @@
         { "path": "../hint-validate-set-cookie-header" },
         { "path": "../hint-x-content-type-options" },
         { "path": "../parser-css" },
+        { "path": "../parser-html" },
         { "path": "../parser-javascript" },
         { "path": "../parser-manifest" },
         { "path": "../utils-create-server" }

--- a/packages/hint/src/lib/hint-context.ts
+++ b/packages/hint/src/lib/hint-context.ts
@@ -102,7 +102,7 @@ export class HintContext<E extends Events = Events> {
     }
 
     /** Finds the approximative location in the page's HTML for a match in an element. */
-    public findProblemLocation(element: HTMLElement): ProblemLocation {
+    public findProblemLocation(element: HTMLElement): ProblemLocation | null {
         return element.getLocation();
     }
 

--- a/packages/hint/src/lib/utils/dom/create-html-document.ts
+++ b/packages/hint/src/lib/utils/dom/create-html-document.ts
@@ -2,11 +2,11 @@ import { HTMLDocument } from '../../types/html';
 import * as parse5 from 'parse5';
 import * as htmlparser2Adapter from 'parse5-htmlparser2-tree-adapter';
 
-export default (html: string): HTMLDocument => {
+export default (html: string, originalDocument?: HTMLDocument): HTMLDocument => {
     const dom = parse5.parse(html, {
-        sourceCodeLocationInfo: true,
+        sourceCodeLocationInfo: !originalDocument,
         treeAdapter: htmlparser2Adapter
     });
 
-    return new HTMLDocument(dom);
+    return new HTMLDocument(dom, originalDocument);
 };

--- a/packages/hint/src/lib/utils/dom/find-original-element.ts
+++ b/packages/hint/src/lib/utils/dom/find-original-element.ts
@@ -1,0 +1,73 @@
+import { HTMLDocument, HTMLElement } from '../../types/html';
+
+type Predicate = (element: HTMLElement) => boolean;
+
+/**
+ * Find all elements matching the provided query and test in the target document.
+ */
+const findMatches = (document: HTMLDocument, query: string, test?: Predicate): HTMLElement[] => {
+    let matches = document.querySelectorAll(query);
+
+    if (test) {
+        matches = matches.filter((match) => {
+            return test(match);
+        });
+    }
+
+    return matches;
+};
+
+/**
+ * Find the best matching element for the provided query and test in the target document.
+ */
+const findMatch = (document: HTMLDocument, element: HTMLElement, query: string, test?: Predicate): HTMLElement | null => {
+    const matches = findMatches(document, query, test);
+    let matchIndex = 0;
+
+    // Handle duplicates by aligning on the nth match across current and original docs.
+    if (matches.length > 1 && element.ownerDocument) {
+        const ownerMatches = findMatches(element.ownerDocument, query, test);
+
+        matchIndex = ownerMatches.findIndex((match) => {
+            return match.isSame(element);
+        });
+    }
+
+    // Return the nth match if possible, or the first match otherwise.
+    return matches[matchIndex] || matches[0] || null;
+};
+
+/**
+ * Perform a best-effort search to find an element in the provided document
+ * which is likely the original source for the provided element. Used to
+ * resolve element locations to the original HTML when possible.
+ */
+export default (document: HTMLDocument, element: HTMLElement): HTMLElement | null => {
+
+    // Elements with attributes whose values are typically unique (e.g. IDs or URLs).
+    for (const attribute of ['id', 'name', 'data', 'href', 'src', 'srcset', 'charset']) {
+        const value = element.getAttribute(attribute);
+
+        if (value) {
+            /*
+             * Return when a unique attribute exists regardless of whether a match is found.
+             * This ensures later tests don't match elements with different IDs or URLs.
+             */
+            return findMatch(document, element, `${element.nodeName}[${attribute}="${value}"]`);
+        }
+    }
+
+    // Elements that typically only occur once.
+    if (['base', 'body', 'head', 'html', 'title'].includes(element.nodeName)) {
+        return findMatch(document, element, element.nodeName);
+    }
+
+    // Elements with content that is typically unique.
+    if (['audio', 'button', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'script', 'style', 'video'].includes(element.nodeName)) {
+        return findMatch(document, element, element.nodeName, (potentialMatch) => {
+            return potentialMatch.innerHTML() === element.innerHTML();
+        });
+    }
+
+    return null;
+};

--- a/packages/hint/tests/lib/types/html.ts
+++ b/packages/hint/tests/lib/types/html.ts
@@ -69,8 +69,8 @@ test('HTMLElement.getLocation() should return the element location', (t) => {
     const item = t.context.document.querySelectorAll('.title')[0];
     const location = item.getLocation();
 
-    t.is(location.line, 3);
-    t.is(location.column, 9);
+    t.is(location && location.line, 3);
+    t.is(location && location.column, 9);
 });
 
 test('HTMLElement.isSame() should return if an item is the same or not', (t) => {

--- a/packages/hint/tests/lib/utils/dom/find-original-element.ts
+++ b/packages/hint/tests/lib/utils/dom/find-original-element.ts
@@ -1,0 +1,154 @@
+import test from 'ava';
+
+import createHTMLDocument from '../../../../src/lib/utils/dom/create-html-document';
+import findOriginalElement from '../../../../src/lib/utils/dom/find-original-element';
+
+const compare = (originalSource: string, snapshotSource: string) => {
+    const originalDocument = createHTMLDocument(originalSource);
+    const snapshotDocument = createHTMLDocument(snapshotSource);
+
+    const originalElement = originalDocument.querySelectorAll('.original')[0] || null;
+    const snapshotElement = snapshotDocument.querySelectorAll('.snapshot')[0];
+
+    const foundElement = findOriginalElement(originalDocument, snapshotElement);
+
+    const result = originalElement && foundElement ? originalElement.isSame(foundElement) : originalElement === foundElement;
+
+    if (!result) {
+        console.log(`Match: 
+            ${originalElement && originalElement.outerHTML()}
+            ${foundElement && foundElement.outerHTML()}`);
+    }
+
+    return result;
+};
+
+test('Find by URL match (src)', (t) => {
+    const result = compare(
+        `
+            <img class="original" src="test2.png">
+        `,
+        `
+            <img src="test1.png">
+            <img class="snapshot" src="test2.png">
+            <img src="test3.png">
+        `
+    );
+
+    t.true(result);
+});
+
+test('Find by URL no match (src)', (t) => {
+    const result = compare(
+        `
+            <img src="test1.png">
+        `,
+        `
+            <img src="test1.png">
+            <img class="snapshot" src="test2.png">
+            <img src="test3.png">
+        `
+    );
+
+    t.true(result);
+});
+
+test('Find by nth URL match (src)', (t) => {
+    const result = compare(
+        `
+            <img src="test2.png">
+            <img class="original" src="test2.png">
+        `,
+        `
+            <img src="test1.png">
+            <img src="test2.png">
+            <img class="snapshot" src="test2.png">
+            <img src="test3.png">
+        `
+    );
+
+    t.true(result);
+});
+
+test('Find by URL match (href)', (t) => {
+    const result = compare(
+        `
+            <link class="original" src="test2.css">
+        `,
+        `
+            <link src="test1.css">
+            <link class="snapshot" src="test2.css">
+            <link src="test3.css">
+        `
+    );
+
+    t.true(result);
+});
+
+test('Find by content match (script)', (t) => {
+    const result = compare(
+        `
+            <script class="original">var foo2 = 'bar';</script>
+        `,
+        `
+            <script>var foo1 = 'bar';</script>
+            <script class="snapshot">var foo2 = 'bar';</script>
+            <script>var foo3 = 'bar';</script>
+        `
+    );
+
+    t.true(result);
+});
+
+test('Find by URL or content no match (script)', (t) => {
+    const result = compare(
+        `
+            <script src="test2.js"></script>
+        `,
+        `
+            <script class="snapshot" src="test1.js"></script>
+            <script src="test2.js"></script>
+        `
+    );
+
+    t.true(result);
+});
+
+test('Find by nth content match (button)', (t) => {
+    const result = compare(
+        `
+            <button>OK</button>
+            <button class="original">OK</button>
+        `,
+        `
+            <button>OK</button>
+            <button>Cancel</button>
+            <button class="snapshot">OK</button>
+            <button>Cancel</button>
+        `
+    );
+
+    t.true(result);
+});
+
+test('Find by singleton match (html)', (t) => {
+    const result = compare(
+        `
+            <html class="original">
+                Test
+            </html>
+        `,
+        `
+            <html class="snapshot">
+                <head>
+                    <title></title>
+                </head>
+                <body>
+                    Test
+                </body>
+            </html>
+        `
+    );
+
+    t.true(result);
+});

--- a/packages/utils-debugging-protocol-common/package.json
+++ b/packages/utils-debugging-protocol-common/package.json
@@ -8,6 +8,7 @@
   },
   "description": "hint debugging protocol common functionality",
   "devDependencies": {
+    "@hint/parser-html": "^2.0.2",
     "@types/lodash": "^4.14.123",
     "@types/node": "11.11.1",
     "@typescript-eslint/eslint-plugin": "^1.4.2",

--- a/packages/utils-debugging-protocol-common/src/debugging-protocol-connector.ts
+++ b/packages/utils-debugging-protocol-common/src/debugging-protocol-connector.ts
@@ -67,6 +67,7 @@ export class Connector implements IConnector {
     private _errorWithPage: boolean = false;
     /** The DOM abstraction on top of adapter. */
     private _dom: HTMLDocument | undefined;
+    private _originalDocument: HTMLDocument | undefined;
     /** A collection of requests with their initial data. */
     private _pendingResponseReceived: Function[];
     /** List of all the tabs used by the connector. */
@@ -108,6 +109,12 @@ export class Connector implements IConnector {
 
         this._waitForTarget = new Promise((resolve) => {
             this._targetReceived = resolve;
+        });
+
+        (engine as Engine<import('@hint/parser-html').HTMLEvents>).on('parse::end::html', (event) => {
+            if (!this._originalDocument) {
+                this._originalDocument = event.document;
+            }
         });
     }
 
@@ -589,7 +596,7 @@ export class Connector implements IConnector {
 
                 const node = await this._client.DOM.getDocument!({ depth: -1 });
                 const html = (await this._client.DOM.getOuterHTML!({ nodeId: node.root.nodeId })).outerHTML;
-                const dom: HTMLDocument = createHTMLDocument(html);
+                const dom = createHTMLDocument(html, this._originalDocument);
 
                 this._dom = dom;
 

--- a/packages/utils-debugging-protocol-common/tsconfig.json
+++ b/packages/utils-debugging-protocol-common/tsconfig.json
@@ -15,6 +15,7 @@
     ],
     "references": [
         { "path": "../hint" },
+        { "path": "../parser-html" },
         { "path": "../utils-connector-tools" }
     ]
 }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~Added/Updated related documentation.~
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Ref #1956 

Also fix some cases where use of the snapshot vs. original document were
inconsistent between connectors (except connector-local which needs to
be different).

Notable changes:
* All connectors now use `parser-html` to obtain an original source document
  * Should we consider making `parser-html` fully built-in since HTML handling is so special?
* Snapshots are created with a reference to the original source document for locations
  * This means we no longer use locations from the snapshot itself (I turned off locations for snapshots to ensure this)
  * A new `findOriginalElement` helper was added to take an element from the snapshot and build a selector (plus filter function) to identify the same element in the original source (if one exists).
* If an element was dynamically created, we no longer try to produce a location for it.
  * This avoids producing invalid locations that don't point anywhere in actual source.
  * In future updates some contexts (e.g. the browser extension) may link to the actual element reference instead in these cases.

Marking as "Draft" while I wait for test results which may require some updates.