### PR TITLE
Fix: Point to right entry point

### DIFF
--- a/packages/create-hint/tests/create-hint.ts
+++ b/packages/create-hint/tests/create-hint.ts
@@ -121,9 +121,9 @@ test('It creates a hint if the option multiple hints is false', async (t) => {
     t.true(fsExtraCopyStub.args[0][0].endsWith('files'), 'Unexpected path for official files');
     t.is(fsExtraCopyStub.args[0][1], path.join(root, 'hint-awesome-hint'), 'Copy path is not the expected one');
 
-    // index.ts, package.json, readme.md, tsconfig.json, hint.ts, meta.ts, tests/hint.ts
-    t.is(handlebarsCompileTemplateStub.callCount, 7, `Handlebars doesn't complile the right number of files`);
-    t.is(miscWriteFileAsyncStub.callCount, 7, 'Invalid number of files created');
+    // package.json, readme.md, tsconfig.json, hint.ts, meta.ts, tests/hint.ts
+    t.is(handlebarsCompileTemplateStub.callCount, 6, `Handlebars doesn't complile the right number of files`);
+    t.is(miscWriteFileAsyncStub.callCount, 6, 'Invalid number of files created');
 
     t.true(result);
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- [x] Added/Updated related tests.

## Short description of the change(s)

If the user creates a new individual hint, `package.json` will point to
`dist/src/hint.js` instead of `dist/src/index.js` and will no longer
create an `index.js`. This is consistent with the format of the other
hints.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #1916