### PR TITLE
Chore: Add dimension to svg in tests

### DIFF
--- a/packages/hint-content-type/tests/tests.ts
+++ b/packages/hint-content-type/tests/tests.ts
@@ -10,7 +10,7 @@ const { generateHTMLPage, getHintPath } = test;
 const hintPath = getHintPath(__filename);
 
 const pngImage = fs.readFileSync(`${__dirname}/fixtures/image.png`); // eslint-disable-line no-sync
-const svgImage = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M1,1"/></svg>';
+const svgImage = '<svg xmlns="http://www.w3.org/2000/svg" width="1px" height="1px"><path d="M1,1"/></svg>';
 
 const incorrectCharsetErrorMessage = `'content-type' header charset value should be 'utf-8', not 'iso-8859-1'.`;
 const invalidMediaTypeErrorMessage = `'content-type' header value should be valid (invalid media type).`;


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

`canvas` 2.4.1 has a problem on macOS where it crashes if an svg does
not have dimensions. This sets the dimensions to 1x1

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #2113
Ref https://github.com/Automattic/node-canvas/issues/1400

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
