### PR TITLE
Chore: Correct node binary path for nvm installs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+scripts-prepend-node-path=auto


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [X] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

~For non-trivial changes, please make sure you also:~

- [x] ~Added/Updated related documentation.~
- [x] ~Added/Updated related tests.~

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Without the `scripts-prepend-node-path` flag, yarn did not use the
node installed using nvm.

Fix #2219
