### PR TITLE
Fix: Ensure we are clossing subprocesses in jsdom.

### DIFF
--- a/packages/connector-jsdom/src/connector.ts
+++ b/packages/connector-jsdom/src/connector.ts
@@ -297,7 +297,7 @@ export default class JSDOMConnector implements IConnector {
             debug(`Exception ignored while closing JSDOM connector (most likely pending network requests)`);
             debug(e);
         } finally {
-            // Kill any subprocess that is still alive.
+            // Kill any subprocess that are still alive.
             this.killAllSubprocesses();
         }
 

--- a/packages/connector-jsdom/src/connector.ts
+++ b/packages/connector-jsdom/src/connector.ts
@@ -288,9 +288,6 @@ export default class JSDOMConnector implements IConnector {
     public close() {
         try {
             this._window.close();
-
-            // Kill any subprocess that is still alive.
-            this.killAllSubprocesses();
         } catch (e) {
             /*
              * We could have some pending network requests and this could fail.
@@ -299,6 +296,9 @@ export default class JSDOMConnector implements IConnector {
              */
             debug(`Exception ignored while closing JSDOM connector (most likely pending network requests)`);
             debug(e);
+        } finally {
+            // Kill any subprocess that is still alive.
+            this.killAllSubprocesses();
         }
 
         return Promise.resolve();


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

Under some circumstances, the method to kill all subprocesses in jsdom was not executed because the property `this._window` was not initialized.

rel https://github.com/webhintio/online-service/issues/195
