### PR TITLE
Chore: Remove `@types/file-url` and update `import`

### DIFF
--- a/packages/hint/package.json
+++ b/packages/hint/package.json
@@ -19,7 +19,6 @@
     "css-select": "^2.0.2",
     "eventemitter2": "^5.0.1",
     "file-type": "^10.11.0",
-    "file-url": "^3.0.0",
     "globby": "^9.2.0",
     "is-ci": "^2.0.0",
     "is-svg": "^4.1.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@types/configstore": "^4.0.0",
     "@types/debug": "^4.1.4",
-    "@types/file-url": "^2.0.0",
     "@types/mime-db": "^1.27.0",
     "@types/parse5": "^5.0.0",
     "@types/parse5-htmlparser2-tree-adapter": "^5.0.1",

--- a/packages/utils/src/network/as-uri.ts
+++ b/packages/utils/src/network/as-uri.ts
@@ -1,8 +1,9 @@
 import * as url from 'url';
 import { URL } from 'url'; // this is necessary to avoid TypeScript mixes types.
 
-import compact = require('lodash/compact');
-import fileUrl = require('file-url'); // `require` used because `file-url` exports a function
+import * as fileUrl from 'file-url';
+import compact = require('lodash/compact'); // `require` used because `lodash/compact` exports a function
+
 
 import { debug as d } from '../debug';
 import * as logger from '../logging';

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,11 +605,6 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
-"@types/file-url@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/file-url/-/file-url-2.0.0.tgz#23d00a219b5064d903d4baa0cf7558692ea0eeb6"
-  integrity sha512-9YqUM3izkmwtCbq6ANdcHJiU2mpDvPm3WuHOcJ5ZouHw7CoYcyY/KvZm6dmYTIurfrRsmBIvHr6y1jpBjDd4Jg==
-
 "@types/filesystem@*":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.29.tgz#ee3748eb5be140dcf980c3bd35f11aec5f7a3748"


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

`file-url` comes now with its own type definition so `@types/file-url`
is no longer needed. Also `hint` depends on `file-url` which is not
needed any more.
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
