### PR TITLE
Docs: Fix Outdated Info about Testing Hints

### DIFF
--- a/packages/hint/docs/contributor-guide/how-to/test-rules.md
+++ b/packages/hint/docs/contributor-guide/how-to/test-rules.md
@@ -7,35 +7,34 @@ testing a hint and how to configure the test server to do what you need.
 ## Getting started
 
 If you have used the built-in tools to create a new hint (core or custom),
-everything should already set up to use `hint-runner.ts` and the `testHint`
+everything should already set up to use `hint-runner.ts` under (`utils-tests-helpers`) and the `testHint`
 method.
 
 If not, you need to:
 
-1. Create a `tests.ts` file in a folder with the name of the hint
-   (e.g.: `src/tests/hints/<hint-id>/tests.ts`)
+1. Create a `tests.ts` file in the hint folder like `hint-<hint-id>/src/tests/tests.ts`.
 1. Have the following template:
 
 ```ts
-import { HintTest } from 'hint/dist/tests/helpers/hint-test-type';
-import * as hintRunner from 'hint/dist/tests/helpers/hint-runner';
-import { getHintPath } from 'hint/dist/src/lib/utils/hint-helpers';
+import { test } from '@hint/utils';
+import { HintTest, testHint } from '@hint/utils-tests-helpers';
 
+const { generateHTMLPage, getHintPath } = test;
 const hintPath = getHintPath(__filename);
 
 const tests: HintTest[] = [
     {
-        name: 'Name of the tests',
-        serverConfig: 'HTML to use',
-        reports: [{
-            message: 'Message the error will have',
-            position: { match: 'text' } // Source where error will show.
-        }]
+        name: 'This test should pass',
+        serverConfig: generateHTMLPage()
     },
-    { ... }
+    {
+        name: `This test should fail`,
+        reports: [{ message: `This should be your error message` }],
+        serverConfig: generateHTMLPage()
+    }
 ];
 
-hintRunner.testHint(hintPath, tests);
+testHint(hintPath, tests);
 ```
 
 The high level overview of what's is happening in the code above is as follows:
@@ -51,6 +50,8 @@ The high level overview of what's is happening in the code above is as follows:
    that particular test.
    The results from executing it are compared to those defined in
    `HintTest.reports`. If they match, then everything is good.
+ 1. If the `reports` property is not specified, the actual results of the
+    test will be logged. This can be used to debug what is being returned by the tests.
 
 There's more information and detail in the following sections.
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] ~Added/Updated related tests.~

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

1. Correct the location of the `tests.ts` file. Fixes #2314
2. Update the template of the `tests.ts` file
3. The absence of `reports` logs in docs
4. Document that removal of `reports` logs the actual results of the test.
