### PR TITLE
Build: Run `brew update` in all macOS pipelines

### DIFF
--- a/azure-pipelines/standard.yml
+++ b/azure-pipelines/standard.yml
@@ -1,6 +1,5 @@
 steps:
-  - script:
-      brew cask install google-chrome
+  - script: brew update && brew cask install google-chrome
     condition: eq(variables['Agent.OS'], 'Darwin')
     displayName: 'Install Chrome'
   - script: |


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

Run `brew update` in all macOS pipelines. It was missing for PRs and I believe that's the cause where it was failing to install chrome even though the `cask` was updated a day ago.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
