### PR TITLE
Fix: Trim source snippets auto-generated from element references

### DIFF
--- a/packages/hint/src/lib/hint-context.ts
+++ b/packages/hint/src/lib/hint-context.ts
@@ -17,6 +17,7 @@ import {
 } from './types';
 import { ProblemLocation, Severity } from '@hint/utils/dist/src/types/problems';
 import { Category } from '@hint/utils/dist/src/types/category';
+import { getHTMLCodeSnippet } from '@hint/utils/dist/src/report/get-html-code-snippet';
 
 export type ReportOptions = {
     /** The source code to display (defaults to the `outerHTML` of `element`). */
@@ -124,7 +125,7 @@ export class HintContext<E extends Events = Events> {
         if (element) {
             // When element is provided, position is an offset in the content.
             position = this.findProblemLocation(element, position);
-            sourceCode = element.outerHTML.replace(/[\t]/g, '    ');
+            sourceCode = getHTMLCodeSnippet(element);
         }
 
         /*

--- a/packages/utils/src/report/get-html-code-snippet.ts
+++ b/packages/utils/src/report/get-html-code-snippet.ts
@@ -18,7 +18,7 @@ const getOpening = (html: string) => {
  * @param {number} threshold - Max number of charaters in the result.
  */
 export const getHTMLCodeSnippet = (element: HTMLElement, threshold = 100) => {
-    const outerHTML = element.outerHTML;
+    const outerHTML = element.outerHTML.replace(/[\t]/g, '    ');
 
     if (outerHTML.length <= threshold) {
         return outerHTML;


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~Added/Updated related documentation.~
- ~Added/Updated related tests.~

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Fix #2211