### PR TITLE
New: Add a `schema` property for validation

### DIFF
--- a/packages/connector-local/src/connector.ts
+++ b/packages/connector-local/src/connector.ts
@@ -79,6 +79,17 @@ export default class LocalConnector implements IConnector {
     private filesPattern: string[];
     private watcher: chokidar.FSWatcher | null = null;
 
+    public static schema = {
+        additionalProperties: false,
+        properties: {
+            pattern: {
+                items: { type: 'string' },
+                type: 'array'
+            },
+            watch: { type: 'boolean' }
+        }
+    }
+
     public constructor(engine: Engine<HTMLEvents>, config: object) {
         this._options = Object.assign({}, defaultOptions, config);
         this.filesPattern = this.getFilesPattern();


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

`connector-local` didn't got the schema with the other updates. I've marked as `New:`  but maybe it should be `Breaking` as the others so we can start fresh (and catch if something is wrong in the logs?) @antross what do you think?

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
