### PR TITLE
Fix: Snapshot template element content as children

### DIFF
--- a/packages/utils/src/types/snapshot.ts
+++ b/packages/utils/src/types/snapshot.ts
@@ -1,12 +1,13 @@
 import { ElementLocation, Location } from 'parse5';
 
-export type ChildData = CommentData | DoctypeData | ElementData | TextData;
+export type ChildData = CommentData | DoctypeData | DocumentFragmentData | ElementData | TextData;
 export type NodeData = DocumentData | ChildData;
+export type ParentData = DocumentData | DocumentFragmentData | ElementData;
 
 type BaseData = {
     id?: number;
     next: ChildData | null;
-    parent: DocumentData | ElementData | null;
+    parent: ParentData | null;
     prev: ChildData | null;
 };
 
@@ -31,6 +32,12 @@ export type DocumentData = {
     name: 'root';
     type: 'root';
     'x-mode': 'no-quirks' | 'quirks' | 'limited-quirks';
+};
+
+export type DocumentFragmentData = BaseData & {
+    children: ChildData[];
+    name: 'root';
+    type: 'root';
 };
 
 export type ElementData = BaseData & {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~Added/Updated related documentation.~
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Test bundle: 
[extension-pr2443.zip](https://github.com/webhintio/hint/files/3184266/extension-pr2443.zip)


----

Fix #2427

Aligns with parse5 behavior for parse5-htmlparser2-tree-adapter.