### PR TITLE
Fix: Consider base tag when resolving URLs

### DIFF
--- a/packages/hint-sri/src/hint.ts
+++ b/packages/hint-sri/src/hint.ts
@@ -469,6 +469,14 @@ Actual:   ${integrities.join(', ')}`;
      * or element::link
      */
     private async validateElement(evt: ElementFound) {
+        const createResourceURL = (resource: string) => {
+            const pageDOM: any = this.context.pageDOM;
+            const baseTags: NodeListOf<HTMLElement> = pageDOM.querySelectorAll('base');
+            const hrefAttribute = (baseTags.length === 0) ? null : baseTags[0].getAttribute('href');
+
+            return (hrefAttribute === null) ? new URL(resource) : new URL(hrefAttribute, new URL(resource));
+        };
+
         const isScriptOrLink = await this.isScriptOrLink(evt as FetchEnd);
 
         if (!isScriptOrLink) {
@@ -482,7 +490,7 @@ Actual:   ${integrities.join(', ')}`;
          * 'this.isScriptOrLink' has already checked
          * that the src or href attribute exists, so it is safe to use !.
          */
-        evt.resource = new URL(evt.element.getAttribute('src')! || evt.element.getAttribute('href')!, evt.resource).href;
+        evt.resource = createResourceURL(evt.element.getAttribute('src')! || evt.element.getAttribute('href')!).href;
 
         const content: NetworkData = {
             request: {} as Request,

--- a/packages/hint-sri/tests/tests-https.ts
+++ b/packages/hint-sri/tests/tests-https.ts
@@ -58,6 +58,13 @@ const configOriginAllTestsHttps: HintTest[] = [
         }
     },
     {
+        name: `NEW: Page with a same-origin and a base tag and SRI sha512 passes`,
+        serverConfig: {
+            '/': generateHTMLPage('<base href="nested/"><link rel="stylesheet" href="/styles.css" integrity="sha512-qC6bbhWZ7Rr0ACjhjfJpavLUm3oAUCbcheJUYNSb4DKASapgeWGLZBGXLTsoaASFg1VeCzTKs1QIMkWaL1ewsA==">'),
+            '/nested/styles.css': styles
+        }
+    },
+    {
         name: `Page with a same-origin alternate stylesheet and SRI sha512 passes`,
         serverConfig: {
             '/': generateHTMLPage('<link rel=" stylesheet alternate " href="/styles.css" integrity="sha512-qC6bbhWZ7Rr0ACjhjfJpavLUm3oAUCbcheJUYNSb4DKASapgeWGLZBGXLTsoaASFg1VeCzTKs1QIMkWaL1ewsA==">'),


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Hi @molant, this is meant to fix #2465 at some point but I think I need some guidance first.

For now I more or less copy/pasted a method out of the `no-broken-links` hint. The function is originally defined here: https://github.com/webhintio/hint/blob/master/packages/hint-no-broken-links/src/hint.ts#L162

Do you think it makes sense to move it to a central place? Also it looks a bit misplaced in the `sri` hint as this is written as a class with methods and properties whereas the `no-broken-links` hint defines all functionality within the constructor.

For some reason I had to change the type definitions of the code inside the function body. Do you know why that was necessary?

I also added a first test just to prove it's working. I guess I need to add other tests as well later on.

Thanks for your help.