### PR TITLE
Chore: Increase `timeout`

### DIFF
--- a/packages/connector-puppeteer/src/lib/lifecycle.ts
+++ b/packages/connector-puppeteer/src/lib/lifecycle.ts
@@ -19,6 +19,7 @@ let isLocked = false;
 const { readFileAsync, writeFileAsync } = fs;
 
 const infoFile = 'browser.info';
+const TIMEOUT = 30000;
 
 export type LifecycleLaunchOptions = LaunchOptions & {
     detached: boolean;
@@ -104,6 +105,8 @@ const connectToBrowser = async (currentInfo: BrowserInfo, options: LifecycleLaun
     debug(`Creating new page in existing browser`);
     const page = await browser.newPage();
 
+    page.setDefaultTimeout(options.timeout || TIMEOUT);
+
     return { browser, page };
 };
 
@@ -167,6 +170,8 @@ ${JSON.stringify(options, null, 2)}
     const page = pages.length > 0 ?
         await pages[0] :
         await browser.newPage();
+
+    page.setDefaultTimeout(options.timeout || TIMEOUT);
 
     return { browser, page };
 };

--- a/packages/utils-tests-helpers/src/hint-runner.ts
+++ b/packages/utils-tests-helpers/src/hint-runner.ts
@@ -109,11 +109,16 @@ const createConfig = (id: string, connector: string, opts?: any): Configuration 
         parsers: determineParsers(opts && opts.parsers)
     };
 
-    // Defaults needed to run the tests
+    /**
+     * Defaults needed to run the tests. All apply only to
+     * `puppeteer` except `ignoreHTTPSErrors` that's common
+     * to all.
+     */
     config.connector.options = {
-        detached: true, // This only applies to `puppeteer`
+        detached: true,
         ignoreHTTPSErrors: true,
-        waitUntil: 'networkidle0' // This only applies to `puppeteer`
+        puppeteerOptions: { timeout: 60000 },
+        waitUntil: 'networkidle0'
     };
 
     return Configuration.fromConfig(config);


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

Linux builds are failing from time to time with timeout navigations
(especially with `no-broken-links`) that go away after a retry. This
increases the Navigation timeout from 30s to 60s.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref: https://dev.azure.com/webhint/webhint/_build/results?buildId=4082&view=logs&jobId=9b571771-e73a-56cf-6cd2-9d9b8a35c940&taskId=3fc73644-a427-5aa2-c480-bc83d146d7cc&lineStart=5168&lineEnd=5169&colStart=1&colEnd=1

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
