### PR TITLE
Breaking: Replace `chrome` with `puppeteer`

### DIFF
--- a/packages/configuration-progressive-web-apps/index.json
+++ b/packages/configuration-progressive-web-apps/index.json
@@ -1,9 +1,6 @@
 {
     "connector": {
-        "name": "jsdom",
-        "options": {
-            "waitFor": 5000
-        }
+        "name": "puppeteer"
     },
     "formatters": [
         "html",

--- a/packages/configuration-progressive-web-apps/package.json
+++ b/packages/configuration-progressive-web-apps/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@hint/connector-chrome": "^4.0.2",
+    "@hint/connector-puppeteer": "^1.0.0",
     "@hint/connector-jsdom": "^4.0.2",
     "@hint/formatter-html": "^4.0.2",
     "@hint/formatter-summary": "^3.0.2",

--- a/packages/configuration-web-recommended/index.json
+++ b/packages/configuration-web-recommended/index.json
@@ -1,9 +1,6 @@
 {
     "connector": {
-        "name": "jsdom",
-        "options": {
-            "waitFor": 5000
-        }
+        "name": "puppeteer"
     },
     "formatters": [
         "html",

--- a/packages/configuration-web-recommended/package.json
+++ b/packages/configuration-web-recommended/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@hint/connector-chrome": "^4.0.2",
+    "@hint/connector-puppeteer": "^1.0.0",
     "@hint/connector-jsdom": "^4.0.2",
     "@hint/connector-local": "^3.0.2",
     "@hint/formatter-html": "^4.0.2",


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

I'm also making puppeteer the default connector here. This should hopefully give the user a better experience and less issues with brotli and canvas.

Fix #2254

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
