### PR TITLE
Chore: Use canary version of `axe`

### DIFF
--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -6,7 +6,7 @@
     ],
     "timeout": "1m"
   },
-  "bundleSize": 645000,
+  "bundleSize": 615000,
   "description": "webhint browser extension",
   "devDependencies": {
     "@hint/hint-axe": "^3.0.2",
@@ -53,6 +53,7 @@
     "@typescript-eslint/eslint-plugin": "^1.9.0",
     "@typescript-eslint/parser": "^1.7.0",
     "ava": "^1.4.1",
+    "axe-core": "3.2.2-canary.55820cf",
     "browserslist": "^4.6.0",
     "cpx": "^1.5.0",
     "css-loader": "^2.1.1",

--- a/packages/extension-browser/webpack.config.js
+++ b/packages/extension-browser/webpack.config.js
@@ -83,6 +83,7 @@ module.exports = (env) => {
         resolve: {
             alias: {
                 '@hint/utils/dist/src/network/request-async$': path.resolve(__dirname, 'dist/src/shims/request-async.js'),
+                'axe-core': path.resolve(__dirname, '../../node_modules/axe-core/axe.min.js'), // yarn 1.16 hoists the beta version
                 url$: path.resolve(__dirname, 'dist/src/shims/url.js')
             }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,6 +1910,11 @@ aws4@^1.6.0, aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axe-core@3.2.2-canary.55820cf:
+  version "3.2.2-canary.55820cf"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.2.2-canary.55820cf.tgz#ba841297bad0989863d036ce99f4e0145e860210"
+  integrity sha512-AIKxSxx/Xxj7fxb6eGmKGEoy6ZBRIDAxytBkbCZENDTpl00zrg7GeEJ5Z50x9fsMcOnqMShnmy0Wtj6CBgOd2g==
+
 axe-core@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.2.2.tgz#b06d6e9ae4636d706068843272bfaeed3fe97362"


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

The canary version of `axe` has some speed improvements that have not
yet been released in the stable channel. Using that version to reduce
the noise generated by timeouts when testing the extension during beta.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref https://github.com/webhintio/hint/issues/2316#issuecomment-496728632

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
