### PR TITLE
Fix: Correctly find resources when runnning globally

### DIFF
--- a/packages/hint/src/lib/utils/resource-loader.ts
+++ b/packages/hint/src/lib/utils/resource-loader.ts
@@ -38,16 +38,6 @@ const HINT_ROOT: string = findPackageRoot();
 const NODE_MODULES_ROOT: string = (() => {
     const root: string = findNodeModulesRoot();
 
-    // If the user is executing the command via `npx` or `npm init/create` we need to search in the globals folder
-    if (root.includes('_npx')) {
-        const npmPrefix = execSync('npm prefix -g')
-            .toString()
-            .trim();
-
-        // On Windows this should be something like C:\Users\USERNAME\AppData\Roaming\npm\node_modules
-        return path.join(npmPrefix, 'node_modules');
-    }
-
     return root;
 })();
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

When running globally (`npx` or `npm create`) the resources where
searched in the global installation folder instead of relative to where
the process is being run. This caused tools such as `npm create hintrc`
to never find any of the resources preinstalled which is not the
expected behavior.

While this might be considered a breaking change, global run with hints
outside the `hint` global folder never worked correctly.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #2263

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
