### PR TITLE
Fix: Add "Did you know that..." to the analyzing screen

### DIFF
--- a/packages/extension-browser/src/_locales/en/messages.json
+++ b/packages/extension-browser/src/_locales/en/messages.json
@@ -43,6 +43,10 @@
         "message": "Development",
         "description": "Name of category for development tests."
     },
+    "didYouKnowThat": {
+        "message": "Did you know that...",
+        "description": "Label for the analyzing screen."
+    },
     "differentOriginLabel": {
         "message": "Different origin",
         "description": "Label for option to ignore only external resources on the page."

--- a/packages/extension-browser/src/devtools/views/pages/analyze.css
+++ b/packages/extension-browser/src/devtools/views/pages/analyze.css
@@ -41,6 +41,12 @@
     font-size: var(--font-size-sm);
 }
 
+.message-title {
+    font-size: var(--font-size);
+    font-weight: var(--bold);
+    margin: 0.2rem 0;
+}
+
 .image {
     margin-top: -10%;
 }

--- a/packages/extension-browser/src/devtools/views/pages/analyze.css
+++ b/packages/extension-browser/src/devtools/views/pages/analyze.css
@@ -41,7 +41,7 @@
     font-size: var(--font-size-sm);
 }
 
-.message-title {
+.messageTitle {
     font-size: var(--font-size);
     font-weight: var(--bold);
     margin: 0.2rem 0;

--- a/packages/extension-browser/src/devtools/views/pages/analyze.tsx
+++ b/packages/extension-browser/src/devtools/views/pages/analyze.tsx
@@ -110,7 +110,7 @@ const Analyze = ({ config, onCancel, onError, onResults, onTimeout }: Props) => 
                 </h1>
                 <div className={styles.messages}>
                     <div className={styles.message}>
-                        <h2 className={styles['message-title']}>{getMessage('didYouKnowThat')}</h2>
+                        <h2 className={styles.messageTitle}>{getMessage('didYouKnowThat')}</h2>
                         <span>{status}</span>
                     </div>
                     <img className={styles.image} src={nellieWorkingSvg} />

--- a/packages/extension-browser/src/devtools/views/pages/analyze.tsx
+++ b/packages/extension-browser/src/devtools/views/pages/analyze.tsx
@@ -109,7 +109,10 @@ const Analyze = ({ config, onCancel, onError, onResults, onTimeout }: Props) => 
                     {getMessage('analyzingStatus')}
                 </h1>
                 <div className={styles.messages}>
-                    <div className={styles.message}>{status}</div>
+                    <div className={styles.message}>
+                        <h2 className={styles['message-title']}>{getMessage('didYouKnowThat')}</h2>
+                        <span>{status}</span>
+                    </div>
                     <img className={styles.image} src={nellieWorkingSvg} />
                 </div>
                 <ProgressBar className={styles.progress} />


### PR DESCRIPTION
Fix #2440

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
This change add the message "Did you know that..." to the analyzing screen in the browser scanner so people don't get confused by the messages.
