### PR TITLE
Fix: Ignore prefixed properties when all browsers pass

### DIFF
--- a/packages/hint-compat-api/tests/css.ts
+++ b/packages/hint-compat-api/tests/css.ts
@@ -123,6 +123,19 @@ testHint(hintPath,
 testHint(hintPath,
     [
         {
+            name: 'Does not report prefixed CSS at-rules if unprefixed support exists',
+            serverConfig: generateCSSConfig('atrules')
+        }
+    ],
+    {
+        browserslist: ['ie 11'],
+        parsers: ['css']
+    }
+);
+
+testHint(hintPath,
+    [
+        {
             name: 'Reports overridden ignored CSS features',
             reports: [
                 {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~Added/Updated related documentation.~
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
When ALL targeted browsers pass for an unprefixed
version of a property, reports for prefixed versions of
that property in the same block are now ignored.

This was not happening before because no entry was
tracked in the reports map for a given block when all
browsers passed.
