### PR TITLE
Fix: Show summary toggle in Firefox

### DIFF
--- a/packages/extension-browser/src/devtools/views/pages/results/hint.css
+++ b/packages/extension-browser/src/devtools/views/pages/results/hint.css
@@ -4,8 +4,8 @@
 
 .summary {
     cursor: pointer;
-    display: inline-block;
     line-height: 1.5rem; /* 24px */
+    width: max-content;
 }
 
 .summary:focus {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Aligns styling of `<summary>` with the HTML standard which uses
`display: list-item` to add the toggle icon. This means the icon
vanishes when changing `<summary>` to `display: inline-block` in
browsers that implement the standard correctly.

Now the desired effect is acheived using `width: max-content`.