### PR TITLE
Fix: Avoid warning in Firefox about background.persistent

### DIFF
--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -115,7 +115,7 @@
     "build-release": "npm run clean && npm run bump-version && npm run build-release-packages",
     "build-release-packages": "npm run build:assets && tsc --inlineSourceMap false --removeComments true && npm-run-all build-release:*",
     "build-release:chromium": "webpack --env.release --env.design=fluent && web-ext build -s ./dist/bundle -a ./dist/chromium --overwrite-dest && npm run lint-bundle-size ./dist/chromium",
-    "build-release:firefox": "webpack --env.release --env.design=photon && web-ext build -s ./dist/bundle -a ./dist/firefox --overwrite-dest && npm run lint-bundle-size ./dist/firefox",
+    "build-release:firefox": "node scripts/drop-persistent-flag.js && webpack --env.release --env.design=photon && web-ext build -s ./dist/bundle -a ./dist/firefox --overwrite-dest && npm run lint-bundle-size ./dist/firefox",
     "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts),!(*.tsx),.!(tsx)}\" dist && npm-run-all prebuild:*",
     "build:ts": "tsc -b",
     "bump-version": "node scripts/bump-version.js",

--- a/packages/extension-browser/scripts/drop-persistent-flag.js
+++ b/packages/extension-browser/scripts/drop-persistent-flag.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+const manifest = require('../dist/bundle/manifest.json');
+
+// Remove the "persistent" flag when building for Firefox to avoid a warning.
+delete manifest.background.persistent;
+
+const filename = path.resolve(`${__dirname}/../dist/bundle/manifest.json`);
+const content = JSON.stringify(manifest, null, 2);
+
+fs.writeFile(filename, content, (err) => {
+    if (err) {
+        throw err;
+    } else {
+        console.log(`Removed \`background.persistent=false\` from: ${filename}`);
+    }
+});


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Release version only. Since the flag is ignored other than the warning
it does not need to be removed from debug builds.

- - - - - - - - - -

Fix #2592