### PR TITLE
Fix: Cancel scan when script injection fails

### DIFF
--- a/packages/extension-browser/src/background-script.ts
+++ b/packages/extension-browser/src/background-script.ts
@@ -38,7 +38,15 @@ const injectContentScript = (tabId: number, retries = 0) => {
                 injectContentScript(tabId, retries + 1);
             } else {
                 // Give up if retrying still doesn't inject the content script.
-                console.error('Failed to inject content script after retrying.');
+                const port = devtoolsPorts.get(tabId);
+                const message = 'Failed to inject content script after retrying.';
+                const event: Events = { error: { message, stack: '' } };
+
+                console.error(message);
+
+                if (port) {
+                    port.postMessage(event);
+                }
             }
         }
     });


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Found while experimenting with extension permissions. This was logging the error to the console, but the scan still waited until the timeout. 

Note some pages such as the extensions store block extension access entirely without producing an error - those are not covered by this change. 