### PR TITLE
Fix: Don't allow Breaking commits to span multiple packages

### DIFF
--- a/scripts/check-commit-message.js
+++ b/scripts/check-commit-message.js
@@ -119,7 +119,7 @@ const checkPackagesModified = (files) => {
     }, new Set());
 
     if (packages.size > 1) {
-        issues.push(`[Line 1] A breaking change cannot affect to more than one package. Packages affected:\n    - ${[...packages].join('\n    - ')}`);
+        issues.push(`A breaking change cannot affect to more than one package. Packages affected:\n    - ${[...packages].join('\n    - ')}`);
     }
 
     return issues;


### PR DESCRIPTION
Fix #2415

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
