### PR TITLE
New: Allow `application/javascript` for JS resources by default

### DIFF
--- a/packages/hint-content-type/README.md
+++ b/packages/hint-content-type/README.md
@@ -27,6 +27,20 @@ The hint checks if responses include the `Content-Type` HTTP response
 header and its value contains the appropriate media type and charset
 for the response.
 
+### A note about `application/javascript`
+
+This hint recommends using a `Content-Type` of `text/javascript` for
+JavaScript resources as [noted in the HTML standard][html js mime].
+However this hint also allows `application/javascript` because that
+value was previously recommended by the IETF in [RFC 4329][rfc 4329].
+RFC 4329 has [an active draft proposed][ietf js mime draft] to also
+recommend `text/javascript` in the future.
+
+See the section
+[Can the hint be configured](#can-the-hint-be-configured) below for an
+example of how to require a specific `Content-Type` value for
+JavaScript resources if desired.
+
 ### Examples that **trigger** the hint
 
 `Content-Type` response header is not sent:
@@ -458,9 +472,12 @@ And then activate it via the [`.hintrc`][hintrc] configuration file:
 <!-- Link labels: -->
 
 [blocked resources]: https://www.fxsitecompat.com/en-CA/docs/2016/javascript-served-with-wrong-mime-type-will-be-blocked/
+[html js mime]: https://html.spec.whatwg.org/multipage/infrastructure.html#dependencies:mime-type
+[ietf js mime draft]: https://tools.ietf.org/html/draft-ietf-dispatch-javascript-mjs
 [incorrect rendering]: https://www.w3.org/International/questions/qa-what-is-encoding
 [mime sniffing spec]: https://mimesniff.spec.whatwg.org/
 [required media type]: https://developer.mozilla.org/en-US/docs/Web/HTML/Using_the_application_cache#Referencing_a_cache_manifest_file
+[rfc 4329]: https://tools.ietf.org/html/rfc4329
 [server configs]: https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Configuring_server_MIME_types
 [hintrc]: https://webhint.io/docs/user-guide/configuring-webhint/summary/
 

--- a/packages/hint-content-type/src/hint.ts
+++ b/packages/hint-content-type/src/hint.ts
@@ -126,13 +126,19 @@ export default class ContentTypeHint implements IHint {
             const charset: string = isTextMediaType(mediaType) ? 'utf-8' : response.charset;
 
             /*
+             * Allow `application/javascript` for JavaScript resources.
+             * See https://github.com/webhintio/hint/issues/2621
+             */
+            const allowApplicationJavaScript = mediaType === 'text/javascript' && originalMediaType === 'application/javascript';
+
+            /*
              * Check if the determined values differ
              * from the ones from the `Content-Type` header.
              */
 
             // * media type
 
-            if (mediaType && (mediaType !== originalMediaType)) {
+            if (mediaType && mediaType !== originalMediaType && !allowApplicationJavaScript) {
                 context.report(resource, `'content-type' header media type value should be '${mediaType}', not '${originalMediaType}'.`, { codeLanguage, codeSnippet });
             }
 

--- a/packages/hint-content-type/tests/tests.ts
+++ b/packages/hint-content-type/tests/tests.ts
@@ -177,10 +177,10 @@ const testsForDefaults: HintTest[] = [
     },
     {
         name: `Script is served with 'Content-Type' header with the wrong media type`,
-        reports: [{ message: generateIncorrectMediaTypeErrorMessage('text/javascript', 'application/javascript') }],
+        reports: [{ message: generateIncorrectMediaTypeErrorMessage('text/javascript', 'application/x-javascript') }],
         serverConfig: {
             '/': generateHTMLPageData(generateHTMLPage(undefined, '<script src="test.js"></script>')),
-            '/test.js': { headers: { 'Content-Type': 'application/javascript; charset=utf-8' } }
+            '/test.js': { headers: { 'Content-Type': 'application/x-javascript; charset=utf-8' } }
         }
     },
     {
@@ -284,6 +284,13 @@ const testsForDefaults: HintTest[] = [
         serverConfig: {
             '/': generateHTMLPageData(generateHTMLPage(undefined, '<script src="test.js"></script>')),
             '/test.js': { headers: { 'content-type': '   Text/JavaScript;   Charset=UTF-8' } }
+        }
+    },
+    {
+        name: `Script is served with allowed value for 'Content-Type' header`,
+        serverConfig: {
+            '/': generateHTMLPageData(generateHTMLPage(undefined, '<script src="test.js"></script>')),
+            '/test.js': { headers: { 'content-type': 'application/javascript; charset=utf-8' } }
         }
     },
     {


### PR DESCRIPTION
Fix #2621

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
