### PR TITLE
New: Show version in browser extension

### DIFF
--- a/packages/extension-browser/src/devtools/views/powered-by.tsx
+++ b/packages/extension-browser/src/devtools/views/powered-by.tsx
@@ -8,6 +8,8 @@ type Props = {
     className?: string;
 };
 
+const { version } = require('../../manifest.json');
+
 const PoweredBy = ({ className }: Props) => {
     return (
         <div className={className || ''}>
@@ -16,6 +18,8 @@ const PoweredBy = ({ className }: Props) => {
             <ExternalLink href="https://webhint.io">
                 webhint
             </ExternalLink>
+            {' '}
+            v{version}
         </div>
     );
 };


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] ~Added/Updated related documentation.~
- [ ] ~Added/Updated related tests.~

## Short description of the change(s)

Resolves #2643 
The webhint version used should be displayed in browser extension next to "powered by webhint" text.