### PR TITLE
Fix: Remove old `axe` hint reference

### DIFF
--- a/packages/configuration-development/index.json
+++ b/packages/configuration-development/index.json
@@ -10,7 +10,6 @@
     ],
     "hints": {
         "apple-touch-icons": "off",
-        "axe": "error",
         "babel-config/is-valid": "error",
         "button-type": "error",
         "create-element-svg": "error",


### PR DESCRIPTION
Fixes error about missing `hint-axe` affecting the VS Code extension.
This configuration already extends `configuration-accessibility` and
does not need to specify `axe` hints directly.

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
