### PR TITLE
Fix: Enable JavaScript parser for related hints

### DIFF
--- a/packages/configuration-web-recommended/index.json
+++ b/packages/configuration-web-recommended/index.json
@@ -37,6 +37,7 @@
     },
     "hintsTimeout": 120000,
     "parsers": [
-        "css"
+        "css",
+        "javascript"
     ]
 }


### PR DESCRIPTION
Specifically enables `hint-create-element-svg` to run as part of the
default `configuration-web-recommended`. That hint was already part
of this configuration, but did not run by default since no JavaScript
parse events were being emitted.

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
