### PR TITLE
Fix: Use `language` from `CLI Options` if present

### DIFF
--- a/packages/hint/src/lib/cli/analyze.ts
+++ b/packages/hint/src/lib/cli/analyze.ts
@@ -189,7 +189,13 @@ const loadUserConfig = async (actions?: CLIOptions): Promise<UserConfig> => {
     }
 
     // If language is not in the config file or CLI options, get the language configure in the OS.
-    userConfig.language = (actions && actions.language) || userConfig.language || await osLocale();
+    if (actions && actions.language) {
+        userConfig.language = actions.language;
+        debug(`Using language option provided from command line: ${actions.language}`);
+    } else {
+        userConfig.language = userConfig.language || await osLocale();
+    }
+
     userConfig = mergeEnvWithOptions(userConfig) as UserConfig;
 
     return userConfig;
@@ -281,7 +287,6 @@ const actionsToOptions = (actions: CLIOptions): CreateAnalyzerOptions => {
     const options: CreateAnalyzerOptions = {
         formatters: actions.formatters ? actions.formatters.split(',') : undefined,
         hints: actions.hints ? actions.hints.split(',') : undefined,
-        language: actions.language,
         watch: actions.watch
     };
 

--- a/packages/hint/src/lib/cli/analyze.ts
+++ b/packages/hint/src/lib/cli/analyze.ts
@@ -188,8 +188,8 @@ const loadUserConfig = async (actions?: CLIOptions): Promise<UserConfig> => {
         userConfig = getDefaultConfiguration();
     }
 
-    // If language is not in the config file, get the language configure in the OS.
-    userConfig.language = userConfig.language || await osLocale();
+    // If language is not in the config file or CLI options, get the language configure in the OS.
+    userConfig.language = (actions && actions.language) || userConfig.language || await osLocale();
     userConfig = mergeEnvWithOptions(userConfig) as UserConfig;
 
     return userConfig;

--- a/packages/hint/src/lib/cli/analyze.ts
+++ b/packages/hint/src/lib/cli/analyze.ts
@@ -181,6 +181,27 @@ const askUserToInstallDependencies = async (resources: HintResources): Promise<b
     return answer;
 };
 
+/** Get language. If language is not in the config file or CLI options, get the language configure in the OS. */
+const getLanguage = async (userConfig?: UserConfig, actions?: CLIOptions): Promise<string> => {
+    if (actions && actions.language) {
+        debug(`Using language option provided from command line: ${actions.language}`);
+
+        return actions.language;
+    }
+
+    if (userConfig && userConfig.language) {
+        debug(`Using language option provided in user config file: ${userConfig.language}`);
+
+        return userConfig.language;
+    }
+
+    const osLanguage = await osLocale();
+
+    debug(`Using language option configured in the OS: ${osLanguage}`);
+
+    return osLanguage;
+};
+
 const loadUserConfig = async (actions?: CLIOptions): Promise<UserConfig> => {
     let userConfig = getUserConfig(actions && actions.config);
 
@@ -188,19 +209,7 @@ const loadUserConfig = async (actions?: CLIOptions): Promise<UserConfig> => {
         userConfig = getDefaultConfiguration();
     }
 
-    // If language is not in the config file or CLI options, get the language configure in the OS.
-    if (actions && actions.language) {
-        userConfig.language = actions.language;
-        debug(`Using language option provided from command line: ${actions.language}`);
-    } else if (userConfig.language) {
-        debug(`Using language option provided in user config file: ${userConfig.language}`);
-    } else {
-        const osLanguage = await osLocale();
-
-        userConfig.language = osLanguage;
-        debug(`Using language option configured in the OS: ${osLanguage}`);
-    }
-
+    userConfig.language = await getLanguage(userConfig, actions);
     userConfig = mergeEnvWithOptions(userConfig) as UserConfig;
 
     return userConfig;

--- a/packages/hint/src/lib/cli/analyze.ts
+++ b/packages/hint/src/lib/cli/analyze.ts
@@ -192,8 +192,13 @@ const loadUserConfig = async (actions?: CLIOptions): Promise<UserConfig> => {
     if (actions && actions.language) {
         userConfig.language = actions.language;
         debug(`Using language option provided from command line: ${actions.language}`);
+    } else if (userConfig.language) {
+        debug(`Using language option provided in user config file: ${userConfig.language}`);
     } else {
-        userConfig.language = userConfig.language || await osLocale();
+        const osLanguage = await osLocale();
+
+        userConfig.language = osLanguage;
+        debug(`Using language option configured in the OS: ${osLanguage}`);
     }
 
     userConfig = mergeEnvWithOptions(userConfig) as UserConfig;

--- a/packages/hint/src/lib/config.ts
+++ b/packages/hint/src/lib/config.ts
@@ -172,12 +172,6 @@ const updateConfigWithOptionsValues = (config: UserConfig, options: CreateAnalyz
         config.hints = buildHintsConfigFromHintNames(options.hints, 'error');
         debug(`Using hints option provided from command line: ${options.hints.join(', ')}`);
     }
-
-    // If language is provided, use it
-    if (options.language) {
-        config.language = options.language;
-        debug(`Using language option provided from command line: ${options.language}`);
-    }
 };
 
 export class Configuration {

--- a/packages/hint/src/lib/types/analyzer.ts
+++ b/packages/hint/src/lib/types/analyzer.ts
@@ -3,7 +3,6 @@ import { Problem } from '@hint/utils/dist/src/types/problems';
 export type CreateAnalyzerOptions = {
     formatters?: string[];
     hints?: string[];
-    language?: string;
     watch?: boolean;
 }
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] ~~Added/Updated related documentation.~~
- [ ] ~~Added/Updated related tests.~~

## Short description of the change(s)

Earlier, `language` of Analyzer was being taken from config file or OS Locale.
Now it is using CLI Options also, if `language` is present in them.

## Details
This bug was caught when `packages/hint` test case failed. 
In below screenshot, test case is expecting `en-US` as language of Analyzer. But it happens to be `en-GB`. This is because current logic of loading config in Analyzer is taking language either from config file or OS Locale. This makes the test case execution OS dependent as config file is always null here.

![actions-language-bug](https://user-images.githubusercontent.com/10244949/61990644-21b05a80-b062-11e9-8084-276afa572718.png)

Actually Analyzer should also consider CLI Options being passed. In test cases, we are already passing `language = 'en-US'` as actions (CLIOptions).
