### PR TITLE
New: Add telemetry with user opt-in

### DIFF
--- a/packages/extension-vscode/.vscodeignore
+++ b/packages/extension-vscode/.vscodeignore
@@ -2,4 +2,9 @@
 **/*.ts
 **/tsconfig.base.json
 **/tsconfig.json
+**/tsconfig.tsbuildinfo
 .vscode/**
+.nyc_output/**
+coverage/**
+dist/tests/**
+.eslintcache

--- a/packages/extension-vscode/package.json
+++ b/packages/extension-vscode/package.json
@@ -45,7 +45,7 @@
   "displayName": "webhint",
   "engines": {
     "node": ">=8.0.0",
-    "vscode": "^1.30.0"
+    "vscode": "^1.31.0"
   },
   "homepage": "https://webhint.io/",
   "icon": "icon.png",

--- a/packages/extension-vscode/src/extension.ts
+++ b/packages/extension-vscode/src/extension.ts
@@ -1,4 +1,6 @@
-import { workspace, ExtensionContext } from 'vscode';
+import { env, workspace, ExtensionContext, Uri } from 'vscode';
+
+import * as vscode from 'vscode';
 
 import {
     LanguageClient,
@@ -49,6 +51,18 @@ export const activate = (context: ExtensionContext) => {
     client = new LanguageClient('webhint', serverOptions, clientOptions);
 
     client.onReady().then(() => {
+
+        // Listen for requests to open a URI for this extension.
+        client.onNotification(notifications.openExternal, (uri: string) => {
+            env.openExternal(Uri.parse(uri));
+
+            const listener = vscode.window.onDidChangeWindowState((e) => {
+                if (e.focused) {
+                    client.sendNotification(notifications.openExternalComplete);
+                    listener.dispose();
+                }
+            });
+        });
 
         // Listen for requests to show the output panel for this extension.
         client.onNotification(notifications.showOutput, () => {

--- a/packages/extension-vscode/src/notifications.ts
+++ b/packages/extension-vscode/src/notifications.ts
@@ -1,2 +1,8 @@
+// Open the provided URI in the default application.
+export const openExternal = 'vscode-webhint/open-external';
+
+// Fired when focus returns to VS Code after opening an external URI.
+export const openExternalComplete = 'vscode-webhint/open-external-complete';
+
 // Reveal the output panel for this extension.
 export const showOutput = 'vscode-webhint/show-output';

--- a/packages/extension-vscode/src/utils/analytics.ts
+++ b/packages/extension-vscode/src/utils/analytics.ts
@@ -1,0 +1,111 @@
+import { IHintConstructor, Problem } from 'hint';
+import { appInsights } from '@hint/utils';
+
+export type ResultData = {
+    hints: IHintConstructor[];
+    problems: Problem[];
+};
+
+const enum HintStatus {
+    passed = 'passed',
+    failed = 'failed',
+    fixed = 'fixed',
+    fixing = 'fixing'
+}
+
+type HintStatusMap = {
+    [hintKey: string]: HintStatus;
+};
+
+type ProblemCountMap = {
+    [hintId: string]: number;
+};
+
+// Remember per-document results for analytics.
+const prevProblems = new Map<string, ProblemCountMap>();
+const nextProblems = new Map<string, ProblemCountMap>();
+const lastSaveTimes = new Map<string, number>();
+const twoMinutes = 1000 * 60 * 2;
+
+const determineHintStatus = (prev: ProblemCountMap, next: ProblemCountMap) => {
+    const status: HintStatusMap = {};
+
+    for (const id of Object.keys(next)) {
+        const hintKey = `hint-${id}`;
+        const prevCount = prev[id] || 0;
+        const nextCount = next[id] || 0;
+
+        if (nextCount) {
+            if (prevCount > nextCount) {
+                status[hintKey] = HintStatus.fixing;
+            } else {
+                status[hintKey] = HintStatus.failed;
+            }
+        } else if (prevCount > 0) {
+            status[hintKey] = HintStatus.fixed;
+        } else {
+            status[hintKey] = HintStatus.passed;
+        }
+    }
+
+    return status;
+};
+
+const toTrackedResult = (data: ResultData) => {
+    const result: ProblemCountMap = {};
+    const ids = data.hints.map((hint) => {
+        return hint.meta.id;
+    });
+
+    for (const id of ids) {
+        result[id] = data.problems.filter((problem) => {
+            return problem.hintId === id;
+        }).length;
+    }
+
+    return result;
+};
+
+const trackOpen = (result: ProblemCountMap) => {
+    appInsights.trackEvent('vscode-open', determineHintStatus({}, result));
+};
+
+export const trackClose = (uri: string) => {
+    prevProblems.delete(uri);
+    nextProblems.delete(uri);
+    lastSaveTimes.delete(uri);
+};
+
+export const trackResult = (uri: string, result: ResultData) => {
+    const problems = toTrackedResult(result);
+
+    if (prevProblems.has(uri)) {
+        nextProblems.set(uri, problems);
+    } else {
+        prevProblems.set(uri, problems);
+        trackOpen(problems);
+    }
+};
+
+export const trackSave = (uri: string) => {
+    const prev = prevProblems.get(uri);
+    const next = nextProblems.get(uri);
+    const lastSave = lastSaveTimes.get(uri);
+    const now = Date.now();
+
+    if (!prev || !next) {
+        return;
+    }
+
+    // Throttle tracking saves to reduce redundant reports when autosave is on.
+    if (lastSave && now - lastSave < twoMinutes) {
+        return;
+    }
+
+    prevProblems.set(uri, next);
+    nextProblems.delete(uri);
+
+    appInsights.trackEvent('vscode-save', determineHintStatus(prev, next));
+
+    lastSaveTimes.set(uri, now);
+};

--- a/packages/extension-vscode/tests/fixtures/mocks.ts
+++ b/packages/extension-vscode/tests/fixtures/mocks.ts
@@ -24,6 +24,7 @@ export type Connection = {
     listen: () => void;
     onDidChangeWatchedFiles: (fn: FileWatcher) => void;
     onInitialize: (fn: Initializer) => void;
+    onNotification: () => void;
     sendDiagnostics: (params: PublishDiagnosticsParams) => void;
     sendNotification: () => void;
     window: Window;
@@ -48,10 +49,17 @@ export type FilesType = {
 };
 
 export const mocks = () => {
+    const analytics = {
+        trackClose() { },
+        trackResult() { },
+        trackSave() { }
+    };
+
     const analyzer = {
         analyze(endpoints: Endpoint): Promise<AnalyzerResult[]> {
             return Promise.resolve([]);
-        }
+        },
+        resources: { hints: [] }
     };
 
     class Analyzer {
@@ -84,6 +92,11 @@ export const mocks = () => {
     };
 
     const hintUtils = {
+        appInsights: {
+            isConfigured() {
+                return true;
+            }
+        },
         hasYarnLock(directory: string): Promise<boolean> {
             return Promise.resolve(false);
         }
@@ -100,6 +113,7 @@ export const mocks = () => {
         onInitialize(fn: typeof initializer) {
             initializer = fn;
         },
+        onNotification() {},
         sendDiagnostics(params: PublishDiagnosticsParams) { },
         sendNotification() { },
         window: {
@@ -149,7 +163,9 @@ export const mocks = () => {
         listen() { },
         onDidChangeContent(fn: typeof contentWatcher) {
             contentWatcher = fn;
-        }
+        },
+        onDidClose() { },
+        onDidSave() { }
     };
 
     return {
@@ -162,6 +178,7 @@ export const mocks = () => {
          */
         Analyzer: Analyzer as any,
         analyzer,
+        analytics,
         child_process,
         connection,
         createConnection,

--- a/packages/extension-vscode/tests/server.ts
+++ b/packages/extension-vscode/tests/server.ts
@@ -17,6 +17,7 @@ const mockContext = () => {
     const mocks = mock.mocks();
 
     proxyquire('../src/server', {
+        './utils/analytics': mocks.analytics,
         '@hint/utils': mocks.hintUtils,
         child_process: mocks.child_process, // eslint-disable-line camelcase
         'vscode-languageserver': {

--- a/packages/extension-vscode/tests/utils/analytics.ts
+++ b/packages/extension-vscode/tests/utils/analytics.ts
@@ -1,0 +1,153 @@
+import * as proxyquire from 'proxyquire';
+import * as sinon from 'sinon';
+import test from 'ava';
+
+import * as _analytics from '../../src/utils/analytics';
+import { IHintConstructor, Problem } from 'hint';
+
+const mock = () => {
+    const appInsights = { trackEvent: (name: string, properties: object) => {} };
+    const analytics = proxyquire('../../src/utils/analytics', { '@hint/utils': { appInsights } }) as typeof _analytics;
+
+    return { analytics, appInsights };
+};
+
+test('It tracks the first result for each document when opened', (t) => {
+    const { analytics, appInsights } = mock();
+    const trackEventSpy = sinon.spy(appInsights, 'trackEvent');
+
+    // First result should be tracked.
+    analytics.trackResult('test.html', {
+        hints: [
+            { meta: { id: 'foo' } } as IHintConstructor
+        ],
+        problems: [
+            {
+                hintId: 'foo',
+                message: 'This should not be logged'
+            } as Problem
+        ]
+    });
+
+    // Second result should not be tracked (will be cached for 'onSave').
+    analytics.trackResult('test.html', {
+        hints: [
+            { meta: { id: 'foo' } } as IHintConstructor
+        ],
+        problems: []
+    });
+
+    // First result for another document should be tracked.
+    analytics.trackResult('test.css', {
+        hints: [
+            { meta: { id: 'bar' } } as IHintConstructor
+        ],
+        problems: []
+    });
+
+    t.true(trackEventSpy.calledTwice);
+    t.is(trackEventSpy.firstCall.args[0], 'vscode-open');
+    t.deepEqual(trackEventSpy.firstCall.args[1], { 'hint-foo': 'failed' });
+    t.is(trackEventSpy.secondCall.args[0], 'vscode-open');
+    t.deepEqual(trackEventSpy.secondCall.args[1], { 'hint-bar': 'passed' });
+});
+
+test('It tracks the delta between the first and last results on save', (t) => {
+    const { analytics, appInsights } = mock();
+    const trackEventSpy = sinon.spy(appInsights, 'trackEvent');
+
+    // First result should be tracked.
+    analytics.trackResult('test.html', {
+        hints: [
+            { meta: { id: 'bar' } } as IHintConstructor,
+            { meta: { id: 'baz' } } as IHintConstructor,
+            { meta: { id: 'foo' } } as IHintConstructor
+        ],
+        problems: [
+            { hintId: 'bar' } as Problem,
+            { hintId: 'bar' } as Problem,
+            { hintId: 'foo' } as Problem,
+            { hintId: 'foo' } as Problem,
+            { hintId: 'foo' } as Problem
+        ]
+    });
+
+    // Second result should not be tracked (will be cached for 'onSave').
+    analytics.trackResult('test.html', {
+        hints: [
+            { meta: { id: 'bar' } } as IHintConstructor,
+            { meta: { id: 'baz' } } as IHintConstructor,
+            { meta: { id: 'foo' } } as IHintConstructor
+        ],
+        problems: [
+            { hintId: 'bar' } as Problem,
+            { hintId: 'bar' } as Problem
+        ]
+    });
+
+    // First result for another document should be tracked.
+    analytics.trackResult('test.html', {
+        hints: [
+            { meta: { id: 'bar' } } as IHintConstructor,
+            { meta: { id: 'baz' } } as IHintConstructor,
+            { meta: { id: 'foo' } } as IHintConstructor
+        ],
+        problems: [
+            { hintId: 'foo' } as Problem
+        ]
+    });
+
+    analytics.trackSave('test.html');
+
+    // Verify multiple saves only submit once with no new results.
+    analytics.trackSave('test.html');
+
+    t.true(trackEventSpy.calledTwice);
+    t.is(trackEventSpy.firstCall.args[0], 'vscode-open');
+    t.deepEqual(trackEventSpy.firstCall.args[1], {
+        'hint-bar': 'failed',
+        'hint-baz': 'passed',
+        'hint-foo': 'failed'
+    });
+    t.is(trackEventSpy.secondCall.args[0], 'vscode-save');
+    t.deepEqual(trackEventSpy.secondCall.args[1], {
+        'hint-bar': 'fixed',
+        'hint-baz': 'passed',
+        'hint-foo': 'fixing'
+    });
+});
+
+test('It tracks results again for a document when re-opened', (t) => {
+    const { analytics, appInsights } = mock();
+    const trackEventSpy = sinon.spy(appInsights, 'trackEvent');
+
+    // First result should be tracked.
+    analytics.trackResult('test.html', {
+        hints: [
+            { meta: { id: 'foo' } } as IHintConstructor
+        ],
+        problems: [
+            {
+                hintId: 'foo',
+                message: 'This should not be logged'
+            } as Problem
+        ]
+    });
+
+    // Closing the document should clear the internal result cache.
+    analytics.trackClose('test.html');
+
+    // Second result should be tracked because document was re-opened.
+    analytics.trackResult('test.html', {
+        hints: [
+            { meta: { id: 'foo' } } as IHintConstructor
+        ],
+        problems: []
+    });
+
+    t.true(trackEventSpy.calledTwice);
+    t.is(trackEventSpy.firstCall.args[0], 'vscode-open');
+    t.deepEqual(trackEventSpy.firstCall.args[1], { 'hint-foo': 'failed' });
+    t.is(trackEventSpy.secondCall.args[0], 'vscode-open');
+    t.deepEqual(trackEventSpy.secondCall.args[1], { 'hint-foo': 'passed' });
+});

--- a/packages/hint/docs/user-guide/telemetry/summary.md
+++ b/packages/hint/docs/user-guide/telemetry/summary.md
@@ -11,7 +11,8 @@ If you answer `yes`, you will grant `webhint` permission to send the
 following information:
 
 * The configuration used.
-* Unhandled/Uncaught exceptions when runing `webhint`.
+* Scan status of individual hints: `"passed"|"failed"|"fixing"|"fixed"`.
+* Unhandled/Uncaught exceptions when running `webhint`.
 * Missed or incompatible packages.
 * When a new hint is created using `npm create hint`.
 * When there is an error creating a hint using `npm create hint`.


### PR DESCRIPTION
Test package: [vscode-webhint-1.0.5.zip](https://github.com/webhintio/hint/files/3454062/vscode-webhint-1.0.5.zip)

Adds two new events: `vscode-open` and `vscode-save`
corresponding to when a user first opens a file and each time it gets
saved, respectively. Hint status is calculated on save by comparing the
initial open state to the most recent scan before saving.

- - - - - - - - - -

Fix #2712

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->