### PR TITLE
Fix: Error getting favicon with puppeteer in node 8 with headless

### DIFF
--- a/packages/connector-puppeteer/src/lib/get-favicon.ts
+++ b/packages/connector-puppeteer/src/lib/get-favicon.ts
@@ -1,7 +1,10 @@
-import { Fetcher } from './create-fetchend-payload';
+import { URL } from 'url';
 
 import { debug as d, HTMLDocument } from '@hint/utils';
 import { Engine } from 'hint';
+
+import { Fetcher } from './create-fetchend-payload';
+
 const debug: debug.IDebugger = d(__filename);
 
 /**


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
