### PR TITLE
Docs: Clarify package name usage; light copy edits

### DIFF
--- a/packages/hint/docs/contributor-guide/index.md
+++ b/packages/hint/docs/contributor-guide/index.md
@@ -22,6 +22,7 @@ The ins and outs of the different parts that make `webhint` plus some common sce
 * [Develop a parser](./how-to/parser.md)
 * [Develop a hint](./how-to/hint.md)
 * [Implement common hint scenarios](./how-to/common-hint-scenarios.md)
+<!-- TODO * [Build the docs locally]() -->
 
 ## Guides
 

--- a/packages/hint/docs/user-guide/concepts/configurations.md
+++ b/packages/hint/docs/user-guide/concepts/configurations.md
@@ -1,23 +1,23 @@
 # Configurations
 
-A `configuration` is a package that contains a `.hintrc`
-configuration file. This makes it easier and faster for users
-to have `webhint` up and running and it also facilitates sharing
-configurations for different things such as: related hints, URLs
-to ignore, etc. When installing a `configuration`, all its
-dependencies (`hint`s, `connnector`s, `formatter`s, `parser`s)
-should be installed automatically as well.
+A configuration is a way to share .hintrc values for different use
+cases, such as related hints, URLs to ignore, shared organization
+standards, etc. When installing a configuration, all of its dependencies
+(hints, connectors, formatters, parsers) should be installed
+automatically as well.
 
-To use a `configuration`, you have to:
+Conveniently, any configuration you choose when running
+`npm create hintrc` is automatically installed _and_ added to your
+.hintrc for you.
 
-1. After installing `hint`, install a configuration package. When
-   running `npm create hintrc`, the wizard will list you the official
-   configuration packages but you can search on `npm`. Any package
-   `@hint/configuration-` or `webhint-configuration-` should be a valid
-   candidate.
-2. Once installed, update your `.hintrc` to use it (this step is not
-   needed if you are using the wizard). Given an npm package called
-   `webhint-configuration-example1`, add the following:
+To add a configuration other than (or in addition to) those offered by
+running `npm create hintrc`, first install its package. Make sure the
+package name begins with `@hint/configuration-`,
+`webhint-configuration-`, or `@scope/webhint-configuration-`. Once
+installed, update your .hintrc to use it by adding your new configuration
+to the `extends` array. Packages within the `@hint/` namespace (like,
+for example, `@hint/configuration-example1`) can be added using their
+short name.
 
 ```json
 {
@@ -25,34 +25,52 @@ To use a `configuration`, you have to:
 }
 ```
 
-3. You are done!
-
-The property `extends` is `string[]` so you can extend from
-multiple configuration packages:
+Because the property `extends` is an array of strings, you can extend
+from multiple configuration packages. For example, if you wish to add
+`@hint/configuration-web-recommended`, `webhint-configuration-example2`,
+and `@orgname/webhint-configuration-example3`, your `extends` value will
+look like this:
 
 ```json
 {
-    "extends": ["example1", "example2"]
+    "extends": [
+        "web-recommended",
+        "webhint-configuration-example2",
+        "@orgname/webhint-configuration-example3"
+    ]
 }
 ```
 
-The priority applies from left to right. Any values in your `.hintrc`
-file will take precedence. For example, the following will always use
-the `summary` formatter:
+Configuration priority applies from left to right. Any values in your
+own .hintrc file will take precedence over those in an included
+configuration package. For example, the following will always use the
+`summary` formatter, regardless of the content of
+`webhint-configuration-example1` and `webhint-configuration-example2`
+configurations: (see Notes for more details)
 
 ```json
 {
-    "extends": ["example1", "example2"],
+    "extends": [
+        "webhint-configuration-example1",
+        "webhint-configuration-example2"
+    ],
     "formatters": ["summary"]
 }
 ```
 
 Notes:
 
-* If you define the property `formatters` when extending
-  a configuration, the formatters in the configuration will be
-  _replaced_ with the value you have defined.
+* If you define the property `formatters` when extending a
+  configuration, the formatters in the configuration will be _replaced_
+  with the value you have defined.
 
-* If you define the property `parsers` when extending a
-  configuration, the parsers in the configuration will be _appended_
-  to the values you have defined.
+* If you define the property `parsers` when extending a configuration,
+  the parsers in the configuration will be _appended_ to the values you
+  have defined.
+
+If you want to implement your own custom configuration, visit the
+[contributor guide][].
+
+<!-- Link labels: -->
+
+[contributor guide]: https://webhint.io/docs/contributor-guide/how-to/configuration/

--- a/packages/hint/docs/user-guide/concepts/connectors.md
+++ b/packages/hint/docs/user-guide/concepts/connectors.md
@@ -1,71 +1,91 @@
 # Connectors
 
-A `connector` is the interface between the `hint`s and the website
-you are testing. It is responsible for loading the website and exposing
-all the information to `webhint` such as resources, network data, etc.
+A connector is the interface between a .hintrc's configured hints and
+the website you are testing. It is responsible for loading and rendering
+that site, then exposing collected information to webhint such as
+resources, network data, etc.
 
-To configure a connector you need to update your `.hintrc` file to
-make it look like the following:
+To use a connector, first install its package. The package name should
+start with `@hint/connector-`, `webhint-connector-`, or
+`@scope/webhint-connector-`. Then, add the package name to the
+`connector` object within your .hintrc file. Packages within the
+`@hint/` namespace (like, for example, `@hint/connector-local`) can be
+added using their short name.
 
 ```json
 {
     "connector": {
-        "name": "connectorName"
+        "name": "local"
     }
 }
 ```
 
-Where `connectorName` is the name of the connector.
-
-## Official connectors and platform support
-
-All the built-in `connector`s run in any of the supported platforms:
-Linux, macOS, and Windows. The only caveat is that, for the `connector`
-that you specify in the`.hintrc` file, you will need to have the
-browser the `connector` is for installed as `webhint` will not
-install it for you.
-
-## List of official `connector`s
-
-The officially supported `connector`s that can be installed via `npm` are:
-
-* [`@hint/connector-chrome`][connector-chrome]. A connector to use Google
-  Chrome via the [chrome debugging protocol][cdp] in `webhint`.
-* [`@hint/connector-jsdom`][connector-jsdom]. A connector to use
-  [jsdom][jsdom] in `webhint`.
-* [`@hint/connector-local`][connector-local]. A local connector to analyze
-  the local files in your project
-  with `webhint`.
-* [`@hint/connector-puppeteer`][connector-puppeteer]. A connector that uses
-  [puppeteer][puppeteer] to communicate with the browsers in `webhint`.
-
-## Configuration
-
-`connector`s can be configured. Maybe you want to do a request with
-another `userAgent`, change some of the other defaults, etc. For that,
-you have to add the property `options` to your `connector` property
-with the values you want to modify:
+Otherwise, use the full package name. If you were to use the
+hypothetical connector `@orgName/webhint-connector-super-duper`, your
+`connector` object would look like this:
 
 ```json
-"connector": {
-    "name": "connectorName",
-    "options": {}
+{
+    "connector": {
+        "name": "@orgName/webhint-connector-super-duper"
+    }
 }
 ```
 
-Please check the [dedicated page][connectors] for each one to know
-more about the different options available for each `connector`.
+## Official connectors and platform support
+
+All of the _built-in_ connectors run in any of webhint's supported
+platforms: Linux, macOS, and Windows. The only caveat is that you need
+to already have the browser or other binary utilized by that connector
+installed; webhint cannot install it for you.
+
+## List of official connectors
+
+The officially supported connectors which can be installed using your
+preferred package manager are:
+
+* [`@hint/connector-jsdom`][connector-jsdom]. Uses [jsdom][].
+* [`@hint/connector-local`][connector-local]. Analyzes the local files
+  in your project.
+* [`@hint/connector-puppeteer`][connector-puppeteer]. Uses [puppeteer][]
+  to communicate with locally installed browsers.
+
+### Legacy connectors
+
+Note that [`@hint/connector-chrome`][connector-chrome] has been
+deprecated in favor of the [puppeteer connector][connector-puppeteer].
+
+## Configuration
+
+Connectors can be configured. Maybe you want to make a request with
+another userAgent, change some of the other defaults, etc. To customize
+the behavior of your selected connector, add the property `options` to
+your `connector` object with the values you want to modify:
+
+```json
+{
+    "connector": {
+        "name": "jsdom",
+        "options": {
+            "ignoreHTTPSError": false
+        }
+    }
+}
+```
+
+Check out the documentation for [each official connector][connectors]
+for more information about the options available.
+
+If you want to implement your own connector, visit the [contributor
+guide][].
 
 <!-- Link labels: -->
 
-[cdp]: https://chromedevtools.github.io/devtools-protocol/
 [connector-chrome]: https://webhint.io/docs/user-guide/connectors/connector-chrome/
 [connector-jsdom]: https://webhint.io/docs/user-guide/connectors/connector-jsdom/
 [connector-local]: https://webhint.io/docs/user-guide/connectors/connector-local/
 [connector-puppeteer]: https://webhint.io/docs/user-guide/connectors/connector-puppeteer/
-[connectors]: https://webhint.io/docs/user-guide/connectors/
-[how to connector]: ../../contributor-guide/how-to/connector.md
+[connectors]: #list-of-official-connectors
 [jsdom]: https://github.com/jsdom/jsdom
 [puppeteer]: https://pptr.dev/
-[request]: https://github.com/request/request
-[wsl-interop]: https://msdn.microsoft.com/en-us/commandline/wsl/release_notes#build-14951
+[contributor guide]: https://webhint.io/docs/contributor-guide/how-to/connector/

--- a/packages/hint/docs/user-guide/concepts/formatters.md
+++ b/packages/hint/docs/user-guide/concepts/formatters.md
@@ -1,72 +1,92 @@
 # Formatters
 
-A `formatter` takes the results of executing the configured hints and
-transforms them to be consumed by the user. A `formatter` can output
-the results via the `console` in different formats, a `JSON` file,
-`XML`, etc.
+A formatter takes the results of executing the configured hints and
+transforms them to be consumed by the user. A formatter can output
+results to a file or the console, in various styles.
 
-You can specify one or more `formatter`s as the output. E.g.: You want
-a summary in the screen as well as a text report. You need to add the
-name inside the property `formatters`:
+To choose a formatter, install its package and add that package name to
+the `formatters` array within your .hintrc file. Packages within the
+`@hint/` namespace (like, for example, `@hint/formatter-html`) can be
+added using their short name.
 
 ```json
 {
-    "formatters": ["formatter1"]
+    "formatters": ["html"]
 }
 ```
 
-or
+Since .hintrc accepts formatters as an array of strings, you can specify
+more than one. An example use case would be wanting a summary printed to
+the console as well as a full html report.
 
 ```json
 {
     "formatters": [
-        "formatter1",
-        "formatter2"
+        "summary",
+        "html"
     ]
 }
 ```
 
-## List of official `formatter`s
+Or perhaps you wish you use a custom formatter in addition to or instead
+of the official packages. Any package matching the pattern
+`@hint/formatter-`, `webhint-formatter-`, or
+`@scope/webhint-formatter-` should be a valid candidate.
 
-The officially supported `formatter`s that can be installed via `npm` are:
+```bash
+npm i -D @myOrg/webhint-formatter-bubble-letters
+```
+
+```json
+{
+    "formatters": [
+        "html",
+        "@myorg/webhint-formatter-bubble-letters"
+    ]
+}
+```
+
+## List of official formatters
+
+The officially supported formatters that can be installed via `npm` are:
 
 * [`@hint/formatter-json`][formatter-json] does a `JSON.stringify()` of
   the results. Output is not user friendly:
 
-![Example output for the json formatter](images/json-output.png)
+  ![Example output for the json formatter](images/json-output.png)
 
 * [`@hint/formatter-stylish`][formatter-stylish] prints the results in
   table format indicating the resource, line, and column:
 
-![Example output for the stylish formatter](images/stylish-output.png)
+  ![Example output for the stylish formatter](images/stylish-output.png)
 
 * [`@hint/formatter-codeframe`][formatter-codeframe] shows also the code
   where the error was found if applicable:
 
-![Example output for the codeframe formatter](images/codeframe.png)
+  ![Example output for the codeframe formatter](images/codeframe.png)
 
 * [`@hint/formatter-summary`][formatter-summary] shows a summary
   of all the warnings and errors found for all the resources:
 
-![Example output for the summary formatter](images/summary-output.png)
+  ![Example output for the summary formatter](images/summary-output.png)
 
 * [`@hint/formatter-excel`][formatter-excel] creates an Excel spreadsheet
-  with a sheet with the results per resource:
+  with a sheet containing the results per resource:
 
-![Example output for the summary sheet of the excel formatter](images/excel-summary.png)
+  ![Example output for the summary sheet of the excel formatter](images/excel-summary.png)
 
-![Example output for one of the details sheet of the excel formatter](images/excel-details.png)
+  ![Example output for one of the details sheet of the excel formatter](images/excel-details.png)
 
 * [`@hint/formatter-html`][formatter-html] creates an HTML page in
   the folder `hint-report/<url_analyzed>` with the result:
 
-![Example out for the HTML result of the html formatter](images/html-output.png)
+  ![Example out for the HTML result of the html formatter](images/html-output.png)
 
-Note: If you are running customs hints the buttons `Why is this important`
-and `How to solve it` will not work.
+  _Note: If you are running custom hints, the buttons "Why is this
+  important" and "How to solve it" will not work._
 
-If you want to implement your own `formatter`, visit the [contributor
-guide][contributor guide].
+If you want to implement your own formatter, visit the [contributor
+guide][].
 
 <!-- Link labels: -->
 

--- a/packages/hint/docs/user-guide/concepts/hints.md
+++ b/packages/hint/docs/user-guide/concepts/hints.md
@@ -1,29 +1,75 @@
 # Hints
 
-A `hint` is a test that your website needs to pass. `webhint` comes with
-a few [built in ones][hints], but you can create your own or download
+A hint is a test that your website needs to pass. Webhint comes with
+several [built in ones][hints], but you can create your own or download
 them from `npm`. You can read more about [how to create hints in the
 contributor guide][how to hint].
 
+## Installing hints
+
+To utilize a hint, install any package matching `@hint/hint-`,
+`webhint-hint-`, or `@scope/webhint-hint-`. Then, add that package's
+name to your .hintrc's `hints` array or object. Packages within the
+`@hint/` namespace (like, for example, `@hint/hint-html-checker`) can be
+added using their short name.
+
+For example, to use the [Nu HTML test][html-checker] first install its
+package:
+
+```bash
+npm i -D @hint/hint-html-checker
+```
+
+Then, add `@hint/hint-html-checker` to your .hintrc.
+
+```json
+{
+    "hints": [
+        "html-checker:error"
+    ]
+}
+```
+
+To add a hint from a developer outside of the hint namespace, add it
+using its full package name. If you ran the following to add hints to
+your package.json…
+
+```shell script
+npm -i -D @myOrg/webhint-hint-clever-custom-audit webhint-hint-another-example1
+```
+
+…add them to your .hintrc like so:
+
+```json
+{
+    "hints": [
+        "@myOrg/webhint-hint-clever-custom-audit",
+        "webhint-hint-another-example1"
+    ]
+}
+```
+
 ## Hint configuration
 
-When using `webhint`, you are always in control. This means that you can
-decide what hints are relevant to your use case and what severity a hint
-should have:
+When using the `hint` CLI, you are always in control. This means that
+you can decide which hints are relevant to your use case, as well as
+what severity a hint should have:
 
-* `off`: The hint will not be executed. This is the same as not having
-  the hint under the `hints` section of a `.hintrc` file.
+* `off`: The hint will not be executed. This is functionally the same as
+  entirely removing the hint from your .hintrc's `hints` array or
+  object.
 * `warning`: The hint will be executed but it will not change the exit
   status code if an issue is found.
 * `error`: The hint will be executed and will change the exit status
   code to `1` if an issue is found.
 
-Hints can be configured using the array or object syntax:
+Hints can be configured using the array or object syntax. For example,
+using an npm package called `@hint/hint-example1`:
 
 ```json
 {
     "hints": [
-        "hint1:warning"
+        "example1:warning"
     ]
 }
 ```
@@ -31,7 +77,7 @@ Hints can be configured using the array or object syntax:
 ```json
 {
     "hints": {
-        "hint1": "warning"
+        "example1": "warning"
     }
 }
 ```
@@ -42,42 +88,56 @@ characters `-` and `?` respectfully when using the array syntax:
 A hint that has the `off` severity applied:
 
 ```json
-"hints": [
-    "-hint1"
-]
+{
+    "hints": [
+        "-example1"
+    ]
+}
 ```
 
 A hint that has the `warning` severity applied:
 
 ```json
-"hints": [
-    "?hint1"
-]
+{
+    "hints": [
+        "?example1"
+    ]
+}
 ```
 
 Additionally, some hints allow further customization. The configuration
 in that case it will be similar to the following:
 
 ```json
-"hints": [
-    ["hint1:warning", {
-        "customization1": "value1",
-        "customization2": "value2"
-    }]
-]
+{
+    "hints": [
+        [
+            "example1:warning",
+            {
+                "customization1": "value1",
+                "customization2": "value2"
+            }
+        ]
+    ]
+}
 ```
 
 or
 
 ```json
-"hints": [
-    {
-       "hint1": ["warning", {
-         "customization1": "value1",
-         "customization2": "value2"
-       }]
-    }
-]
+{
+    "hints": [
+        {
+            "example1": [
+                "warning",
+                {
+                    "customization1": "value1",
+                    "customization2": "value2"
+                }
+            ]
+        }
+    ]
+}
 ```
 
 You can check which hints accept this kind of configuration by
@@ -87,3 +147,4 @@ visiting the [hints documentation][hints].
 
 [hints]: ../hints/index.md
 [how to hint]: ../../contributor-guide/how-to/hint.md
+[html-checker]: https://webhint.io/docs/user-guide/hints/hint-html-checker/

--- a/packages/hint/docs/user-guide/concepts/parsers.md
+++ b/packages/hint/docs/user-guide/concepts/parsers.md
@@ -1,55 +1,68 @@
 # Parsers
 
-A `parser` is capable of understanding more deeply a resource and expose
-that information via events so hints can be built on top of this information.
-E.g.: a `JavaScript` parser built on top of `ESLint` so hints for analyzing
-`JavaScript` files can be built.
+A parser is capable of understanding more deeply a resource and exposing
+that information via events so hints can be created to use and analyze
+this data. E.g.: the [official JavaScript parser][javascript] was built
+on top of ESLint so hints for analyzing JavaScript files could be
+written.
 
-You can specify what `parser`s you want to use via the `.hintrc`
-configuration file:
+To utilize a parser, first install its package. The package name should
+begin with `@hint/parser-`, `webhint-parser-`, or
+`@scope/webhint-parser-`. Once you've installed the appropriate
+package, specify which parsers you want to use by adding them to the
+`parsers` array in your .hintrc configuration file. Packages within the
+`@hint/` namespace (like, for example, `@hint/parser-html`) can be added
+using their short name.
+
+If you've installed `@hint/parser-example1` and
+`webhint-parser-example2`, add the following:
 
 ```json
 {
-    "parsers": ["parser1", "parser2"]
+    "parsers": [
+        "example1",
+        "webhint-parser-example2"
+    ]
 }
 ```
 
-## List of official `parser`s
+## List of official parsers
 
-* [`babel-config`][@hint/parser-babel-config] A `Babel configuration` parser
-  which validates the provided `json` so hints analyzing `.babelrc` files can
-  be built.
-
-* [`css`][@hint/parser-css]: A `CSS` parser built on top of
-  [PostCSS][postcss] so hints can analyze `CSS` files.
-
-* [`html`][@hint/parser-html]: An `HTML` parser built on top of `jsdom`.
-  This parser is only necessary if you are using the `local connector`
-  and analyzing local `HTML` files. Otherwise the related `HTML` events
-  are taken care directly by the other `connector`s.
-
-* [`javascript`][@hint/parser-javascript]: A `JavaScript`
-  parser built on top of `ESLint` so hints for analyzing `JavaScript`
+* [`@hint/parser-babel-config`][babel-config] A Babel configuration
+  parser which validates the provided json so hints analyzing .babelrc
   files can be built.
 
-* [`manifest`][@hint/parser-manifest]: A parser that validates if a
-  `web app manifest` is valid and emit information related to it.
+* [`@hint/parser-css`][css]: A CSS parser built on top of [PostCSS][] so
+  hints can analyze CSS files.
 
-* [`typescript-config`][@hint/parser-typescript-config]: A parser
-  that validates if the `TypeScript configuration` is valid.
+* [`@hint/parser-html`][html]: An HTML parser built on top of jsdom.
+  This parser is only necessary if you are using the [local connector][]
+  and analyzing local HTML files. Otherwise the related HTML events are
+  taken care directly by the other connectors.
+
+* [`@hint/parser-javascript`][javascript]: A JavaScript parser built on
+  top of ESLint so hints for analyzing JavaScript files can be built.
+
+* [`@hint/parser-manifest`][manifest]: A parser that checks validity of
+  a web app manifest and emits information related to said manifest.
+
+* [`@hint/parser-typescript-config`][typescript-config]: A parser that
+  checks validity of a TypeScript configuration.
 
 ## How to use a parser
 
-To use a parse you need to subscribe to the event(s) that the parser dispatches.
-Please check the details page of each parser to have more information about the
-events emitted by them.
+To utilize a parser when writing your own hints, subscribe to the
+event(s) it dispatches and consume the accompanying event payload. Check
+out the links below for more detailed documentation on each parser, or
+the [hint creation guide][] for more information on how to create a hint
+taking advantage of these events.
 
-### Example: `javascript` parser
+### Example: javascript parser
 
 To create a hint that understands JavaScript you will need to import the
-`ScriptEvents` object defining events emitted by the
-[`javascript parser`][@hint/parser-javascript], apply it to your
-`HintContext`, and register for the `parse::end::javascript` event.
+`ScriptEvents` object defining events emitted by the [javascript
+parser][javascript], apply it to your `HintContext`, and register for
+the `parse::end::javascript` event.
 
 ```typescript
 import { ScriptEvents } from `@hint/parser-javascript`;
@@ -62,18 +75,18 @@ public constructor(context: HintContext<ScriptEvents>) {
 }
 ```
 
-In this example the `event` is of type `ScriptParse` which has the following
-information:
+In this example the `event` is of type `ScriptParse` which has the
+following information:
 
-* `resource`: the parsed resource. If the JavaScript is in a `script tag`
+* `resource`: the parsed resource. If the JavaScript is in a script tag
   and not a file, the value will be `Internal javascript`.
-* `sourceCode`: a `eslint` `SourceCode` object.
+* `sourceCode`: an eslint `SourceCode` object.
 
-### Example: `css` and `javascript` parsers
+### Example: css and javascript parsers
 
-To create a hint that understands multiple resource types you will need to
-import the event definitions from all target `parser`s and apply each of them
-to your `HintContext` using a type intersection (`&`).
+To create a hint that understands multiple resource types you will need
+to import the event definitions from all target parsers and apply each
+of them to your `HintContext` using a type intersection (`&`).
 
 ```typescript
 import { StyleEvents } from `@hint/parser-css`;
@@ -92,10 +105,12 @@ public constructor(context: HintContext<StyleEvents & ScriptEvents>) {
 
 <!-- Link labels: -->
 
-[@hint/parser-babel-config]: https://npmjs.com/package/@hint/parser-babel-config/
-[@hint/parser-css]: https://npmjs.com/package/@hint/parser-css/
-[@hint/parser-html]: https://npmjs.com/package/@hint/parser-html/
-[@hint/parser-javascript]: https://npmjs.com/package/@hint/parser-javascript/
-[@hint/parser-manifest]: https://npmjs.com/package/@hint/parser-manifest/
-[@hint/parser-typescript-config]:https://npmjs.com/package/@hint/parser-typescript-config/
-[postcss]: https://postcss.org/
+[babel-config]: https://npmjs.com/package/@hint/parser-babel-config/
+[css]: https://npmjs.com/package/@hint/parser-css/
+[html]: https://npmjs.com/package/@hint/parser-html/
+[javascript]: https://npmjs.com/package/@hint/parser-javascript/
+[manifest]: https://npmjs.com/package/@hint/parser-manifest/
+[typescript-config]:https://npmjs.com/package/@hint/parser-typescript-config/
+[local connector]: https://webhint.io/docs/user-guide/connectors/connector-local/
+[PostCSS]: https://postcss.org/
+[hint creation guide]: https://webhint.io/docs/contributor-guide/guides/create-custom-hint/


### PR DESCRIPTION
This PR impacts the docs in two discrete ways.

1. Copy editing for clarity. i'd love to see some form of those changes get merged regardless and look forward to y'all's review. One specific detail is reserving ` backticks exclusively for indicating code, instead of using them for terminology, filenames, and proper nouns. I could go back and use italics for some of the terminology, my focus for this PR was strictly readability.
2. As is currently being discussed in #2774, using full package names in .hintrc. This could be split into two PRs, but I'd rather wait to see how that conversation goes since initially all these changes were worked as one problem.

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- ~~Added/Updated related tests.~~

## Short description of the change(s)

- Update hintrc config instructions to use fully-qualified package names
- Edit some copy for clairty
- Reduce usage of backticks, now only used to indicate code