### PR TITLE
Fix: Load latest versions from package in `create-hint` templates

### DIFF
--- a/packages/create-hint/package.json
+++ b/packages/create-hint/package.json
@@ -12,6 +12,8 @@
   "dependencies": {},
   "description": "webhint's hint initializer package",
   "devDependencies": {
+    "@hint/utils-tests-helpers": "^5.0.3",
+    "@types/debug": "^4.1.4",
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.12.0",
     "@types/mkdirp": "^0.5.2",

--- a/packages/create-hint/src/handlebars-utils.ts
+++ b/packages/create-hint/src/handlebars-utils.ts
@@ -1,23 +1,21 @@
 import * as Handlebars from 'handlebars';
-
 import { fs } from '@hint/utils';
-import { utils } from 'hint';
+import { loadCreateHintPackage } from './utils';
 
-const { packages: { loadHintPackage } } = utils;
 const { readFileAsync } = fs;
 
-const pkg = loadHintPackage();
+const pkg = loadCreateHintPackage();
 
 /**
- * Searches the current version used for a package in `hint` and uses that version or the `defaultVersion`.
+ * Searches package version in `create-hint/package.json` for given `packageName` and uses that version or the `defaultVersion`.
+ *
+ * It is recommended to add package as `devDependencies` in `create-hint/package.json` whenever new `package` is added to `package.hbs` template.
  *
  * This is used when creating a new hint via the CLI to make sure the dependencies are up-to-date in the moment
  * of creation.
  */
 Handlebars.registerHelper('dependencyVersion', (packageName, defaultVersion): string => {
-    const version = packageName === 'hint' ?
-        `^${pkg.version}` :
-        pkg.dependencies[packageName] ||
+    const version = pkg.dependencies[packageName] ||
         pkg.devDependencies[packageName] ||
         defaultVersion;
 

--- a/packages/create-hint/src/shared-templates/package.hbs
+++ b/packages/create-hint/src/shared-templates/package.hbs
@@ -8,20 +8,20 @@
   },
   "description": "{{description}}",
   "devDependencies": {
-    {{{dependencyVersion "@hint/utils-tests-helpers" "^2.0.3"}}},
-    {{{dependencyVersion "@types/debug" "0.0.31"}}},
-    {{{dependencyVersion "@types/node" "11.12.0"}}},
-    {{{dependencyVersion "@typescript-eslint/eslint-plugin" "^1.3.0"}}},
-    {{{dependencyVersion "@typescript-eslint/parser" "^1.3.0"}}},
-    {{{dependencyVersion "ava" "^1.2.0"}}},
-    {{{dependencyVersion "cpx" "^1.5.0"}}},
-    {{{dependencyVersion "eslint" "^5.13.0"}}},
-    {{{dependencyVersion "eslint-plugin-markdown" "^1.0.0"}}},
-    {{{dependencyVersion "npm-run-all" "^4.1.5"}}},
-    {{{dependencyVersion "nyc" "^13.1.0"}}},
-    {{{dependencyVersion "rimraf" "^2.6.3"}}},
+    {{{dependencyVersion "@hint/utils-tests-helpers"}}},
+    {{{dependencyVersion "@types/debug"}}},
+    {{{dependencyVersion "@types/node"}}},
+    {{{dependencyVersion "@typescript-eslint/eslint-plugin"}}},
+    {{{dependencyVersion "@typescript-eslint/parser"}}},
+    {{{dependencyVersion "ava"}}},
+    {{{dependencyVersion "cpx"}}},
+    {{{dependencyVersion "eslint"}}},
+    {{{dependencyVersion "eslint-plugin-markdown"}}},
+    {{{dependencyVersion "npm-run-all"}}},
+    {{{dependencyVersion "nyc"}}},
+    {{{dependencyVersion "rimraf"}}},
     {{{dependencyVersion "hint"}}},
-    {{{dependencyVersion "typescript" "^3.3.1"}}}
+    {{{dependencyVersion "typescript"}}}
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/create-hint/src/utils.ts
+++ b/packages/create-hint/src/utils.ts
@@ -1,0 +1,16 @@
+import { packages } from '@hint/utils';
+
+const { findPackageRoot } = packages;
+
+/** Returns an object that represents the `package.json` version of `create-hint` */
+export const loadCreateHintPackage = () => {
+    // webpack will embed the package.json
+    /* istanbul ignore if */
+    if (process.env.webpack) { // eslint-disable-line no-process-env
+        return require('../package.json');
+    }
+
+    const pkgRoot = findPackageRoot(__dirname, 'package.json');
+
+    return require(`${pkgRoot}/package.json`);
+};


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- ~~[ ] Added/Updated related tests.~~

## Short description of the change(s)
This PR improves the process of creating new hint in main repo in following two ways:

1. It loads package versions from `create-hint/package.json` while creating new hint.
As package versions in `package.json` will always remain updated, it seems good idea to load versions from it instead of updating manually in template file.
Thoughts?

2. ~~`webpack` is added to create-hint build script. When user run `npm create hint` in `hint/packages` of main repo, it doesn't work. It requires to run `webpack` after `yarn && yarn build` to create executable `create-hint` binary.~~
This is removed as test cases are failing if we add webpack step in build script.

Fix: #2657 
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
