### PR TITLE
New: Include additional check data from axe when available

### DIFF
--- a/packages/hint-axe/src/util/axe.ts
+++ b/packages/hint-axe/src/util/axe.ts
@@ -201,7 +201,7 @@ export const register = (context: HintContext, rules: string[], disabled: string
 
         for (const violation of result.violations) {
             for (const node of violation.nodes) {
-                const summary= getSummary(node);
+                const summary = getSummary(node);
                 const message = summary ? `${violation.help}: ${summary}` : violation.help;
                 const registration = ruleToRegistration.get(violation.id)!;
                 const element = getElement(context, node);

--- a/packages/hint-axe/src/util/axe.ts
+++ b/packages/hint-axe/src/util/axe.ts
@@ -1,4 +1,4 @@
-import { AxeResults, ImpactValue, NodeResult as AxeNodeResult } from 'axe-core';
+import { CheckResult, AxeResults, ImpactValue, NodeResult as AxeNodeResult } from 'axe-core';
 
 import { HTMLElement } from '@hint/utils/dist/src/dom/html';
 import { readFileAsync } from '@hint/utils/dist/src/fs/read-file-async';
@@ -37,6 +37,35 @@ const getElement = (context: HintContext, node: AxeNodeResult): HTMLElement => {
     const elements = context.querySelectorAll(selector);
 
     return elements[0];
+};
+
+/** Validate if an axe check result has data associated with it. */
+const hasCheckData = (result: CheckResult): boolean => {
+    return !!result.data;
+};
+
+/** Retrieve the message from an axe check result. */
+const toCheckMessage = (result: CheckResult): string => {
+    return result.message;
+};
+
+/**
+ * Combine only the node sub-check results containing data to
+ * create a summary. This avoids including sub-check messages
+ * stating static facts which are typically redundant with the
+ * help text for a rule.
+ *
+ * E.g. color contrast includes specific data about the calculated
+ * contrast value whereas checking for the lang on <html> just
+ * restates that the lang attribute was not found.
+ */
+const getSummary = (node: AxeNodeResult): string => {
+    const summary = [...node.all, ...node.any, ...node.none]
+        .filter(hasCheckData)
+        .map(toCheckMessage)
+        .join(' ');
+
+    return summary;
 };
 
 /**
@@ -172,11 +201,13 @@ export const register = (context: HintContext, rules: string[], disabled: string
 
         for (const violation of result.violations) {
             for (const node of violation.nodes) {
+                const summary= getSummary(node);
+                const message = summary ? `${violation.help}: ${summary}` : violation.help;
                 const registration = ruleToRegistration.get(violation.id)!;
                 const element = getElement(context, node);
                 const severity = Severity[registration.options[violation.id]] || toSeverity(violation.impact);
 
-                registration.context.report(resource, violation.help, { element, severity });
+                registration.context.report(resource, message, { element, severity });
             }
         }
     });

--- a/packages/hint-axe/tests/color.ts
+++ b/packages/hint-axe/tests/color.ts
@@ -1,0 +1,23 @@
+import { HintTest, testHint } from '@hint/utils-tests-helpers';
+import { test } from '@hint/utils';
+
+const { generateHTMLPage, getHintPath } = test;
+const hintPath = getHintPath(__filename, true);
+
+const tests: HintTest[] = [
+    {
+        name: `Text has insufficient color contrast and fails`,
+        reports: [
+            {
+                message: 'Elements must have sufficient color contrast: Element has insufficient color contrast of 1.16 (foreground color: #eeeeee, background color: #ffffff, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1',
+                position: { match: 'div id="text"' }
+            }
+        ],
+        serverConfig: generateHTMLPage(
+            `<style>#text { background-color: #fff; color: #eee; }</style>`,
+            `<div id="text">Text without sufficient contrast</div>`
+        )
+    }
+];
+
+testHint(hintPath, tests, { ignoredConnectors: ['jsdom'] });


### PR DESCRIPTION
Includes additional check messages from axe core when data is
associated with those messages. Some examples include the
calculated color contrast ratio and invalid values for ARIA attributes.

- - - - - - - - - -

Fix #2746

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
