### PR TITLE
Add hint `hint-scoped-svg-styles` to warn about styles bleeding across inline SVGs

### DIFF
--- a/packages/hint-scoped-svg-styles/.npmrc
+++ b/packages/hint-scoped-svg-styles/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/hint-scoped-svg-styles/LICENSE.txt
+++ b/packages/hint-scoped-svg-styles/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright JS Foundation and other contributors, https://js.foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/hint-scoped-svg-styles/README.md
+++ b/packages/hint-scoped-svg-styles/README.md
@@ -1,0 +1,127 @@
+# scoped-svg-styles (`@hint/hint-scoped-svg-styles`)
+
+Scoped SVG Styles checks if SVG styles affect any other elements outside the svg.
+
+## Why is this important?
+
+As `<style>` inside inline `<svg>` elements are not scoped to `<svg>`,
+these can affect elements of dom outside the SVG. So it is important to
+detect if any style (CSS rule or selector) inside `<svg>` selects
+elements outside it.
+
+## What does the hint check?
+
+This hint checks if styles inside SVG affect any other elements outside
+it. If any such style is found, it reports the CSS rule that is
+affecting and html elements that are being affected.
+
+### Examples that **trigger** the hint
+
+Any style rule inside SVG that selects elements outside it will trigger
+the hint.
+
+Example:
+
+```html
+<html>
+    <body>
+        <h1 class="my-style">Heading</h1>
+
+        <svg>
+            <style>
+                .my-style {
+                    opacity: 0.5;
+                }
+            </style>
+            <text class="my-style">SVG text</text>
+        </svg>
+    </body>
+</html>
+```
+
+### Examples that **pass** the hint
+
+If in document, all styles inside SVGs are scoped to SVG only and are
+not affecting any element outside it, hint will pass.
+
+Example:
+
+```html
+<html>
+    <body>
+        <h1 class="html-style">Heading</h1>
+
+        <svg>
+            <style>
+                .svg-style {
+                    opacity: 0.5;
+                }
+            </style>
+            <text class="svg-style">SVG text</text>
+        </svg>
+    </body>
+</html>
+```
+
+## Can the hint be configured?
+
+This hint can be configured to limit the number of HTML elements reported
+per CSS rule. If the hint finds an affecting CSS rule, it generates one report
+related to that rule and an additional report for each HTML element
+matched by that rule.
+
+If the `maxReportsPerCSSRule` option is passed to this hint, it will limit the
+number of reports related to affected elements, but reports related to the
+CSS rule will still be there.
+
+### How to pass `maxReportsPerCSSRule` option to hint
+
+`maxReportsPerCSSRule` can be added in `.hintrc` as given below:
+
+```json
+    ...
+    "hints": {
+            "scoped-svg-styles": [
+                    "warning", {
+                        "maxReportsPerCSSRule": 5
+                    }
+            ]
+        },
+    ...
+```
+
+In above example, for every affecting rule, there can be a maximum of six
+reports. One report related to the CSS rule itself and a maximum of
+five reports related to affected elements.
+
+## How to use this hint?
+
+To use it you will have to install it via `npm`:
+
+```bash
+npm install @hint/hint-scoped-svg-styles
+```
+
+Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
+parameter, or to install it globally, you can use the `-g` parameter. For
+other options see
+[`npm`'s documentation](https://docs.npmjs.com/cli/install).
+
+And then activate it via the [`.hintrc`][hintrc]
+configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "parsers": [...],
+    "hints": {
+        "scoped-svg-styles": "error"
+    },
+    ...
+}
+```
+
+<!-- Link labels: -->
+
+[hintrc]: https://webhint.io/docs/user-guide/configuring-webhint/summary/

--- a/packages/hint-scoped-svg-styles/package.json
+++ b/packages/hint-scoped-svg-styles/package.json
@@ -1,0 +1,77 @@
+{
+  "ava": {
+    "failFast": false,
+    "files": [
+      "dist/tests/**/*.js"
+    ],
+    "timeout": "1m"
+  },
+  "description": "Scoped SVG Styles checks if SVG styles affect any other elements outside the svg.",
+  "dependencies": {
+    "@hint/utils": "^4.0.0"
+  },
+  "devDependencies": {
+    "@hint/parser-css": "^3.0.7",
+    "@hint/utils-tests-helpers": "^5.0.5",
+    "@types/debug": "^4.1.4",
+    "@types/node": "^12.6.8",
+    "@typescript-eslint/eslint-plugin": "^1.13.0",
+    "@typescript-eslint/parser": "^1.12.0",
+    "ava": "^1.4.1",
+    "cpx": "^1.5.0",
+    "eslint": "^5.15.1",
+    "eslint-plugin-markdown": "^1.0.0",
+    "hint": "^5.1.2",
+    "npm-run-all": "^4.1.5",
+    "nyc": "^14.1.0",
+    "postcss": "^7.0.17",
+    "rimraf": "^2.6.3",
+    "typescript": "^3.5.1"
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "files": [
+    "dist/src"
+  ],
+  "homepage": "https://webhint.io/",
+  "keywords": [
+    "hint",
+    "hint",
+    "scoped-svg-styles",
+    "scoped-svg-styles-hint"
+  ],
+  "license": "Apache-2.0",
+  "main": "dist/src/hint.js",
+  "name": "@hint/hint-scoped-svg-styles",
+  "nyc": {
+    "extends": "../../.nycrc"
+  },
+  "peerDependencies": {
+    "@hint/parser-css": "^3.0.7",
+    "hint": "^5.1.2"
+  },
+  "private": true,
+  "repository": "webhintio/hint",
+  "scripts": {
+    "build": "npm run i18n && npm-run-all build:*",
+    "build-release": "npm run clean && npm run i18n && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
+    "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
+    "build:ts": "tsc -b",
+    "clean": "rimraf dist",
+    "i18n": "node ../../scripts/create-i18n.js",
+    "lint": "npm-run-all lint:*",
+    "lint:js": "eslint . --cache --ext js --ext md --ext ts --ignore-path ../../.eslintignore --report-unused-disable-directives",
+    "lint:dependencies": "node ../../scripts/lint-dependencies.js",
+    "lint:md": "node ../../scripts/lint-markdown.js",
+    "test": "npm run lint && npm run build && npm run test-only",
+    "test-only": "nyc ava",
+    "test-release": "npm run lint && npm run clean && npm run build:assets && tsc && npm run test-only",
+    "init": "npm install && npm run build",
+    "watch": "npm run build && npm-run-all --parallel -c watch:*",
+    "watch:assets": "npm run build:assets -- -w --no-initial",
+    "watch:test": "ava --watch",
+    "watch:ts": "npm run build:ts -- --watch"
+  },
+  "version": "1.0.0"
+}

--- a/packages/hint-scoped-svg-styles/src/_locales/en/messages.json
+++ b/packages/hint-scoped-svg-styles/src/_locales/en/messages.json
@@ -1,0 +1,18 @@
+{
+    "description": {
+        "description": "Metadata description",
+        "message": "Scoped SVG Styles checks if SVG styles affect any other elements outside the svg."
+    },
+    "name": {
+        "description": "Metadata name",
+        "message": "Scoped SVG Styles"
+    },
+    "reportRuleImpacting": {
+        "description": "Report rule message when the validation fails",
+        "message": "A '<style>' inside '<svg>' should not affect elements outside of that subtree."
+    },
+    "reportImpactedElement": {
+        "description": "Report affected element message when the validation fails",
+        "message": "Styles from an unrelated SVG subtree matched this element using the following selector: '$1'"
+    }
+}

--- a/packages/hint-scoped-svg-styles/src/hint.ts
+++ b/packages/hint-scoped-svg-styles/src/hint.ts
@@ -1,0 +1,131 @@
+/**
+ * @fileoverview Scoped SVG Styles checks if SVG styles affect any other elements outside the svg.
+ */
+
+import { HintContext } from 'hint/dist/src/lib/hint-context';
+import { IHint, ProblemLocation } from 'hint/dist/src/lib/types';
+import { debug as d, HTMLElement } from '@hint/utils';
+
+import { StyleEvents, StyleParse } from '@hint/parser-css';
+import { getCSSCodeSnippet } from '@hint/utils/dist/src/report/get-css-code-snippet';
+import { Rule } from 'postcss';
+
+import meta from './meta';
+import { getMessage } from './i18n.import';
+
+const debug: debug.IDebugger = d(__filename);
+
+const findParentSVGElement = (element: HTMLElement): HTMLElement | null => {
+    if (!element.parentElement) {
+        return null;
+    }
+
+    if (element.parentElement.nodeName === 'svg') {
+        return element.parentElement;
+    }
+
+    return findParentSVGElement(element.parentElement);
+};
+
+const isOutsideParentSVG = (parentSVG: HTMLElement) => {
+    return (element: HTMLElement): boolean => {
+        const elementsParentSVG = findParentSVGElement(element);
+
+        if (!elementsParentSVG) {
+            return true;
+        }
+        if (!elementsParentSVG.isSame(parentSVG)) {
+            return true;
+        }
+
+        return false;
+    };
+};
+
+const getLocation = (rule: Rule): ProblemLocation | null => {
+    const start = rule.source && rule.source.start;
+
+    if (start) {
+        return {
+            column: start.column - 1,
+            line: start.line - 1
+        };
+    }
+
+    return null;
+};
+
+/*
+ * ------------------------------------------------------------------------------
+ * Public
+ * ------------------------------------------------------------------------------
+ */
+
+export default class ScopedSvgStylesHint implements IHint {
+    public static readonly meta = meta;
+
+    public constructor(context: HintContext<StyleEvents>) {
+        /** Generate a report message from elements matched outside the SVG. */
+        const formatRuleMessage = (numberOfElementsOutsideSVG: number): string => {
+            return getMessage('reportRuleImpacting', context.language, [
+                `${numberOfElementsOutsideSVG}`
+            ]);
+        };
+
+        const formatElementMessage = (codeSnippet: string): string => {
+            return getMessage('reportImpactedElement', context.language, [
+                codeSnippet
+            ]);
+        };
+
+        const validateStyle = ({ ast, element, resource }: StyleParse) => {
+            // proceed only if it is inline style
+            if (!element) {
+                return;
+            }
+
+            const parentSVG = findParentSVGElement(element);
+
+            // proceed only if style is inside svg element
+            if (!parentSVG) {
+                return;
+            }
+
+            debug('Validating hint scoped-svg-styles');
+
+            ast.walkRules((rule) => {
+                const selectors = rule.selectors;
+
+                for (const selector of selectors) {
+                    const matchingElements = element.ownerDocument.querySelectorAll(selector);
+                    const matchingElementsOutsideParentSVG = matchingElements.filter(isOutsideParentSVG(parentSVG));
+
+                    if (matchingElementsOutsideParentSVG.length) {
+                        const message = formatRuleMessage(matchingElementsOutsideParentSVG.length);
+                        const location = getLocation(rule);
+                        const codeSnippet = getCSSCodeSnippet(rule);
+
+                        context.report(resource, message, {
+                            codeLanguage: 'css',
+                            codeSnippet,
+                            element,
+                            location
+                        });
+
+                        let maxReportsPerCSSRule = Infinity;
+
+                        if (context.hintOptions && context.hintOptions.maxReportsPerCSSRule !== undefined) {
+                            maxReportsPerCSSRule = context.hintOptions.maxReportsPerCSSRule;
+                        }
+
+                        for (let i = 0; (i < matchingElementsOutsideParentSVG.length && i < maxReportsPerCSSRule); i++) {
+                            context.report(resource, formatElementMessage(codeSnippet), { element: matchingElementsOutsideParentSVG[i] });
+                        }
+                    }
+                }
+            });
+        };
+
+        context.on('parse::end::css', validateStyle);
+    }
+}

--- a/packages/hint-scoped-svg-styles/src/meta.ts
+++ b/packages/hint-scoped-svg-styles/src/meta.ts
@@ -1,0 +1,31 @@
+import { Category } from 'hint/dist/src/lib/enums/category';
+import { HintScope } from 'hint/dist/src/lib/enums/hint-scope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+import { getMessage } from './i18n.import';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.pitfalls,
+        description: getMessage('description', 'en'),
+        name: getMessage('name', 'en')
+    },
+    /* istanbul ignore next */
+    getDescription(language: string) {
+        return getMessage('description', language);
+    },
+    /* istanbul ignore next */
+    getName(language: string) {
+        return getMessage('name', language);
+    },
+    id: 'scoped-svg-styles',
+    schema: [
+        {
+            additionalProperties: false,
+            properties: { maxReportsPerCSSRule: { type: 'number' } }
+        }
+    ],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-scoped-svg-styles/tests/fixtures/elements-inside-unrelated-svg.html
+++ b/packages/hint-scoped-svg-styles/tests/fixtures/elements-inside-unrelated-svg.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Valid Page</title>
+  </head>
+  <body>
+    <svg>
+      <g class="test-another-svg-class">
+          <text>Text with class 'test-html-class'</text>
+      </g>
+    </svg>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+      version="1.1"
+      width="121px"
+      height="61px"
+      viewBox="-0.5 -0.5 121 61"
+      content='&lt;mxfile modified="2019-08-06T23:04:02.391Z" host="www.draw.io" agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.87 Safari/537.36" etag="jdYWiFO8gPZRTxJDSTkM" version="11.1.2" type="device"&gt;&lt;diagram id="x_gK4VS6IC4G04AUg0Ot" name="Page-1"&gt;jZJNT8MwDIZ/TY5IbTJ17MoYgwMgUWlwjRrTBCVNlXm049eTrm67apo0KQfn8Uec12Zi7dptkLV+9Qos44lqmXhknKcLzll3EnXsyTITPSiDURQ0gdz8AcGE6MEo2M8C0XuLpp7DwlcVFDhjMgTfzMO+vZ2/WssSLkBeSHtJP41C3dN7vpz4M5hSDy+n2ar3ODkE00/2WirfnCGxYWIdvMfecu0abCfeoEuf93TFOzYWoMJbEjL4QvXjdh8LtxC4emte9u93VOVX2gN9OHfylJbvttQ3Hgcxgj9UCrp6CRMPjTYIeS2LztvE8Uem0dl4S6NJlSEgtFdbTkch4gaBd4DhGEMoYdSOlocndG+mUaRDjD4bQ0ZM0vTLsfQkUDRIo+E6zeLkO9tosfkH&lt;/diagram&gt;&lt;/mxfile&gt;'
+      style="background-color: rgb(255, 255, 255);"
+    >
+      <defs />
+      <g>
+        <rect
+          x="0"
+          y="0"
+          width="120"
+          height="60"
+          fill="#ffffff"
+          stroke="#000000"
+          pointer-events="none"
+        />
+        <style>
+            .test-svg-class {
+                color: white;
+            }
+
+            .test-another-svg-class {
+              opacity: 0.5;
+            }
+        </style>
+        <g transform="translate(30.5,23.5)">
+          <switch>
+            <foreignObject
+              style="overflow:visible;"
+              pointer-events="all"
+              width="58"
+              height="12"
+              requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+              ><div
+                xmlns="http://www.w3.org/1999/xhtml"
+                style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 60px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
+              >
+                <div xmlns="http://www.w3.org/1999/xhtml" class="test-svg-class">
+                  Small SVG
+                </div>
+              </div>
+            </foreignObject>
+            <text
+              x="29"
+              y="12"
+              fill="#000000"
+              text-anchor="middle"
+              font-size="12px"
+              font-family="Helvetica"
+            >
+              Small SVG
+            </text>
+          </switch>
+        </g>
+      </g>
+    </svg>
+  </body>
+</html>

--- a/packages/hint-scoped-svg-styles/tests/fixtures/elements-outside-svg.html
+++ b/packages/hint-scoped-svg-styles/tests/fixtures/elements-outside-svg.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Valid Page</title>
+    <style>
+      .text-html-class {
+        font-size: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1 class="test-html-class">Testing SVG styles</h1>
+    <p>html content</p>
+    <p class="test-html-class">paragraph</p>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+      version="1.1"
+      width="121px"
+      height="61px"
+      viewBox="-0.5 -0.5 121 61"
+      content='&lt;mxfile modified="2019-08-06T23:04:02.391Z" host="www.draw.io" agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.87 Safari/537.36" etag="jdYWiFO8gPZRTxJDSTkM" version="11.1.2" type="device"&gt;&lt;diagram id="x_gK4VS6IC4G04AUg0Ot" name="Page-1"&gt;jZJNT8MwDIZ/TY5IbTJ17MoYgwMgUWlwjRrTBCVNlXm049eTrm67apo0KQfn8Uec12Zi7dptkLV+9Qos44lqmXhknKcLzll3EnXsyTITPSiDURQ0gdz8AcGE6MEo2M8C0XuLpp7DwlcVFDhjMgTfzMO+vZ2/WssSLkBeSHtJP41C3dN7vpz4M5hSDy+n2ar3ODkE00/2WirfnCGxYWIdvMfecu0abCfeoEuf93TFOzYWoMJbEjL4QvXjdh8LtxC4emte9u93VOVX2gN9OHfylJbvttQ3Hgcxgj9UCrp6CRMPjTYIeS2LztvE8Uem0dl4S6NJlSEgtFdbTkch4gaBd4DhGEMoYdSOlocndG+mUaRDjD4bQ0ZM0vTLsfQkUDRIo+E6zeLkO9tosfkH&lt;/diagram&gt;&lt;/mxfile&gt;'
+      style="background-color: rgb(255, 255, 255);"
+    >
+      <defs />
+      <g>
+        <rect
+          x="0"
+          y="0"
+          width="120"
+          height="60"
+          fill="#ffffff"
+          stroke="#000000"
+          pointer-events="none"
+        />
+        <style>
+            .test-svg-class {
+                color: white;
+            }
+
+            .test-html-class {
+              color: red;
+            }
+        </style>
+        <g transform="translate(30.5,23.5)">
+          <switch>
+            <foreignObject
+              style="overflow:visible;"
+              pointer-events="all"
+              width="58"
+              height="12"
+              requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+              ><div
+                xmlns="http://www.w3.org/1999/xhtml"
+                style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 60px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
+              >
+                <div xmlns="http://www.w3.org/1999/xhtml" class="test-svg-class">
+                  Small SVG
+                </div>
+              </div>
+            </foreignObject>
+            <text
+              x="29"
+              y="12"
+              fill="#000000"
+              text-anchor="middle"
+              font-size="12px"
+              font-family="Helvetica"
+            >
+              Small SVG
+            </text>
+          </switch>
+        </g>
+      </g>
+    </svg>
+  </body>
+</html>

--- a/packages/hint-scoped-svg-styles/tests/fixtures/valid-page.html
+++ b/packages/hint-scoped-svg-styles/tests/fixtures/valid-page.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Valid Page</title>
+  </head>
+  <body>
+    <h1 class="test-html-class">Testing SVG styles</h1>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+      version="1.1"
+      width="121px"
+      height="61px"
+      viewBox="-0.5 -0.5 121 61"
+      content='&lt;mxfile modified="2019-08-06T23:04:02.391Z" host="www.draw.io" agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.87 Safari/537.36" etag="jdYWiFO8gPZRTxJDSTkM" version="11.1.2" type="device"&gt;&lt;diagram id="x_gK4VS6IC4G04AUg0Ot" name="Page-1"&gt;jZJNT8MwDIZ/TY5IbTJ17MoYgwMgUWlwjRrTBCVNlXm049eTrm67apo0KQfn8Uec12Zi7dptkLV+9Qos44lqmXhknKcLzll3EnXsyTITPSiDURQ0gdz8AcGE6MEo2M8C0XuLpp7DwlcVFDhjMgTfzMO+vZ2/WssSLkBeSHtJP41C3dN7vpz4M5hSDy+n2ar3ODkE00/2WirfnCGxYWIdvMfecu0abCfeoEuf93TFOzYWoMJbEjL4QvXjdh8LtxC4emte9u93VOVX2gN9OHfylJbvttQ3Hgcxgj9UCrp6CRMPjTYIeS2LztvE8Uem0dl4S6NJlSEgtFdbTkch4gaBd4DhGEMoYdSOlocndG+mUaRDjD4bQ0ZM0vTLsfQkUDRIo+E6zeLkO9tosfkH&lt;/diagram&gt;&lt;/mxfile&gt;'
+      style="background-color: rgb(255, 255, 255);"
+    >
+      <defs />
+      <g>
+        <rect
+          x="0"
+          y="0"
+          width="120"
+          height="60"
+          fill="#ffffff"
+          stroke="#000000"
+          pointer-events="none"
+        />
+        <style>
+            .test-svg-class {
+                color: white;
+            }
+        </style>
+        <g transform="translate(30.5,23.5)">
+          <switch>
+            <foreignObject
+              style="overflow:visible;"
+              pointer-events="all"
+              width="58"
+              height="12"
+              requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"
+              ><div
+                xmlns="http://www.w3.org/1999/xhtml"
+                style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; vertical-align: top; width: 60px; white-space: nowrap; overflow-wrap: normal; text-align: center;"
+              >
+                <div xmlns="http://www.w3.org/1999/xhtml" class="test-svg-class">
+                  Small SVG
+                </div>
+              </div>
+            </foreignObject>
+            <text
+              x="29"
+              y="12"
+              fill="#000000"
+              text-anchor="middle"
+              font-size="12px"
+              font-family="Helvetica"
+            >
+              Small SVG
+            </text>
+          </switch>
+        </g>
+      </g>
+    </svg>
+  </body>
+</html>

--- a/packages/hint-scoped-svg-styles/tests/hint.ts
+++ b/packages/hint-scoped-svg-styles/tests/hint.ts
@@ -1,0 +1,87 @@
+import { test, fs } from '@hint/utils';
+import { HintTest, testHint } from '@hint/utils-tests-helpers';
+
+const { readFile } = fs;
+const { generateHTMLPage, getHintPath } = test;
+const hintPath = getHintPath(__filename);
+
+const generateConfig = (fileName: string) => {
+    if (fileName.endsWith('.html')) {
+        return readFile(`${__dirname}/fixtures/${fileName}`);
+    }
+
+    const styles = readFile(`${__dirname}/fixtures/${fileName}.css`);
+
+    return {
+        '/': generateHTMLPage(
+            `<link rel="stylesheet" href="styles/${fileName}">`
+        ),
+        [`/styles/${fileName}`]: {
+            content: styles,
+            headers: { 'Content-Type': 'text/css' }
+        }
+    };
+};
+
+const defaultTests: HintTest[] = [
+    {
+        name: 'This test should pass for empty html page',
+        serverConfig: generateHTMLPage()
+    },
+    {
+        name: 'SVG with scoped styles and no leakage should pass',
+        serverConfig: generateConfig('valid-page.html')
+    },
+    {
+        name: 'SVG style affecting elements in dom outside the SVG should fail',
+        reports: [
+            {
+                message: `A '<style>' inside '<svg>' should not affect elements outside of that subtree.`,
+                position: { match: '.test-html-class' }
+            },
+            {
+                message: `Styles from an unrelated SVG subtree matched this element using the following selector: '.test-html-class { }'`,
+                position: { match: 'p class="test-html-class"' }
+            },
+            {
+                message: `Styles from an unrelated SVG subtree matched this element using the following selector: '.test-html-class { }'`,
+                position: { match: 'h1 class="test-html-class"' }
+            }
+        ],
+        serverConfig: generateConfig('elements-outside-svg.html')
+    },
+    {
+        name: 'SVG style affecting elements in another SVG',
+        reports: [
+            {
+                message: `A '<style>' inside '<svg>' should not affect elements outside of that subtree.`,
+                position: { match: '.test-another-svg-class' }
+            },
+            {
+                message: `Styles from an unrelated SVG subtree matched this element using the following selector: '.test-another-svg-class { }'`,
+                position: { match: 'g class="test-another-svg-class"' }
+            }
+        ],
+        serverConfig: generateConfig('elements-inside-unrelated-svg.html')
+    }
+];
+
+const testsWithMaxReportsConfig: HintTest[] = [
+    {
+        name: 'SVG style affecting elements in dom outside the SVG should fail with 1 html report only',
+        reports: [
+            {
+                message: `A '<style>' inside '<svg>' should not affect elements outside of that subtree.`,
+                position: { match: '.test-html-class' }
+            },
+            {
+                message: `Styles from an unrelated SVG subtree matched this element using the following selector: '.test-html-class { }'`,
+                position: { match: 'h1 class="test-html-class"' }
+            }
+        ],
+        serverConfig: generateConfig('elements-outside-svg.html')
+    }
+];
+
+testHint(hintPath, defaultTests, { parsers: ['css'] });
+testHint(hintPath, testsWithMaxReportsConfig, { hintOptions: { maxReportsPerCSSRule: 1 }, parsers: ['css'] });

--- a/packages/hint-scoped-svg-styles/tsconfig.json
+++ b/packages/hint-scoped-svg-styles/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "dist",
+        "strict": true
+    },
+    "exclude": [
+        "dist",
+        "node_modules"
+    ],
+    "extends": "../../tsconfig.json",
+    "include": [
+        "src/**/*.ts",
+        "tests/**/*.ts"
+    ],
+    "references": [
+        { "path": "../hint" },
+        { "path": "../parser-css" },
+        { "path": "../utils" },
+        { "path": "../utils-tests-helpers" }
+    ]
+}

--- a/packages/utils/src/dom/html.ts
+++ b/packages/utils/src/dom/html.ts
@@ -43,6 +43,16 @@ export class HTMLElement {
         return result;
     }
 
+    public get parentElement(): HTMLElement | null {
+        const parent = this._element.parent;
+
+        if (!parent || (parent.type !== 'tag' && parent.type !== 'script' && parent.type !== 'style')) {
+            return null;
+        }
+
+        return new HTMLElement(parent, this.ownerDocument);
+    }
+
     public get nodeName(): string {
         return this._element.name;
     }

--- a/packages/utils/tests/dom/html.ts
+++ b/packages/utils/tests/dom/html.ts
@@ -93,3 +93,17 @@ test('HTMLElement.innerHTML should return the element content', (t) => {
 
     t.is(item.innerHTML, 'Title');
 });
+
+test('HTMLElement.parentElement should return the parent element if it exists', (t) => {
+    const item = t.context.document.querySelectorAll('.title')[0];
+
+    const parentNodeName = item.parentElement && item.parentElement.nodeName;
+
+    t.is(parentNodeName, 'body');
+});
+
+test('HTMLElement.parentElement should return `null` if parent doesn\'t exists (for root level elements)', (t) => {
+    const dom = t.context.document.documentElement;
+
+    t.is(dom.parentElement, null);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -85,6 +85,7 @@
         { "path": "packages/hint-no-protocol-relative-urls" },
         { "path": "packages/hint-no-vulnerable-javascript-libraries" },
         { "path": "packages/hint-performance-budget" },
+        { "path": "packages/hint-scoped-svg-styles" },
         { "path": "packages/hint-sri" },
         { "path": "packages/hint-ssllabs" },
         { "path": "packages/hint-strict-transport-security" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -869,6 +869,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.9.tgz#ffeee23afdc19ab16e979338e7b536fdebbbaeaf"
   integrity sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==
 
+"@types/node@^12.6.8":
+  version "12.7.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.1.tgz#3b5c3a26393c19b400844ac422bd0f631a94d69d"
+  integrity sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==
+
 "@types/node@^8.0.7":
   version "8.10.50"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.50.tgz#f3d68482b1f54b5f4fba8daaac385db12bb6a706"


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

Added new hint `scoped-svg-styles`.

Resolves: #2729 

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
