### PR TITLE
New: Improve VS Code first-run experience

### DIFF
--- a/packages/extension-vscode/package.json
+++ b/packages/extension-vscode/package.json
@@ -16,6 +16,28 @@
   "categories": [
     "Linters"
   ],
+  "contributes": {
+    "configuration": {
+      "title": "webhint",
+      "properties": {
+        "webhint.enableTelemetry": {
+          "type": "string",
+          "default": "ask",
+          "enum": [
+            "ask",
+            "enabled",
+            "disabled"
+          ],
+          "enumDescriptions": [
+            "Prompt to share limited usage data",
+            "Share limited usage data",
+            "Don't share limited usage data"
+          ],
+          "markdownDescription": "Controls whether to share [limited usage data](https://webhint.io/docs/user-guide/telemetry/summary/) to help improve webhint."
+        }
+      }
+    }
+  },
   "dependencies": {
     "vscode-languageclient": "^5.2.1",
     "vscode-languageserver": "^5.2.1"

--- a/packages/extension-vscode/src/extension.ts
+++ b/packages/extension-vscode/src/extension.ts
@@ -1,4 +1,4 @@
-import { workspace, ExtensionContext } from 'vscode';
+import { window, workspace, ExtensionContext, WorkspaceConfiguration } from 'vscode';
 
 import {
     LanguageClient,
@@ -7,7 +7,11 @@ import {
     TransportKind
 } from 'vscode-languageclient';
 
-import * as notifications from './notifications';
+import * as notifications from './utils/notifications';
+
+type TelemetryState = 'ask' | 'disabled' | 'enabled';
+
+const telemetryKey = 'enableTelemetry';
 
 // List of document types the extension will run against.
 const supportedDocuments = [
@@ -21,19 +25,50 @@ const supportedDocuments = [
 // Keep a reference to the client to stop it when deactivating.
 let client: LanguageClient;
 
-export const activate = (context: ExtensionContext) => {
+const configureTelemetry = (config: WorkspaceConfiguration, enableTelemetry: TelemetryState) => {
+    config.update(telemetryKey, enableTelemetry, true);
+    client.sendNotification(notifications.telemetryEnabledChanged, enableTelemetry);
+};
 
-    const serverModule = context.asAbsolutePath('dist/src/server.js');
+/* istanbul ignore next */
+const showTelemetryMessage = async (config: WorkspaceConfiguration, enableTelemetry: TelemetryState) => {
+    if (enableTelemetry !== 'ask') {
+        return;
+    }
+
+    const yesResponse = 'Enable telemetry';
+    const noResponse = 'No thanks';
+    const answer = await window.showInformationMessage(
+        'Help us improve webhint by sending [limited usage information](https://webhint.io/docs/user-guide/telemetry/summary/) (no personal information or URLs will be sent).',
+        { title: yesResponse },
+        { title: noResponse }
+    );
+
+    if (answer && answer.title === yesResponse) {
+        configureTelemetry(config, 'enabled');
+    } else if (answer && answer.title === noResponse) {
+        configureTelemetry(config, 'disabled');
+    }
+};
+
+export const activate = (context: ExtensionContext) => {
+    const config = workspace.getConfiguration('webhint', null);
+    const enableTelemetry: TelemetryState = config.get('enableTelemetry') || 'ask';
+    const args = [context.globalStoragePath, enableTelemetry];
+    const module = context.asAbsolutePath('dist/src/server.js');
+    const transport = TransportKind.ipc;
 
     const serverOptions: ServerOptions = {
         debug: {
-            module: serverModule,
+            args,
+            module,
             options: { execArgv: ['--nolazy', '--inspect=6009'] },
-            transport: TransportKind.ipc
+            transport
         },
         run: {
-            module: serverModule,
-            transport: TransportKind.ipc
+            args,
+            module,
+            transport
         }
     };
 
@@ -49,6 +84,8 @@ export const activate = (context: ExtensionContext) => {
     client = new LanguageClient('webhint', serverOptions, clientOptions);
 
     client.onReady().then(() => {
+        showTelemetryMessage(config, enableTelemetry);
+
         // Listen for requests to show the output panel for this extension.
         client.onNotification(notifications.showOutput, () => {
             client.outputChannel.clear();

--- a/packages/extension-vscode/src/notifications.ts
+++ b/packages/extension-vscode/src/notifications.ts
@@ -1,2 +1,0 @@
-// Reveal the output panel for this extension.
-export const showOutput = 'vscode-webhint/show-output';

--- a/packages/extension-vscode/src/utils/analytics.ts
+++ b/packages/extension-vscode/src/utils/analytics.ts
@@ -1,5 +1,5 @@
 import { IHintConstructor, Problem } from 'hint';
-import { appInsights } from '@hint/utils';
+import { trackEvent } from './app-insights';
 
 export type ResultData = {
     hints: IHintConstructor[];
@@ -67,7 +67,7 @@ const toTrackedResult = (data: ResultData) => {
 };
 
 const trackOpen = (result: ProblemCountMap) => {
-    appInsights.trackEvent('vscode-open', determineHintStatus({}, result));
+    trackEvent('vscode-open', determineHintStatus({}, result));
 };
 
 export const trackClose = (uri: string) => {
@@ -105,7 +105,7 @@ export const trackSave = (uri: string) => {
     prevProblems.set(uri, next);
     nextProblems.delete(uri);
 
-    appInsights.trackEvent('vscode-save', determineHintStatus(prev, next));
+    trackEvent('vscode-save', determineHintStatus(prev, next));
 
     lastSaveTimes.set(uri, now);
 };

--- a/packages/extension-vscode/src/utils/app-insights.ts
+++ b/packages/extension-vscode/src/utils/app-insights.ts
@@ -1,0 +1,95 @@
+import * as https from 'https';
+
+type Measurements = { [key: string]: number };
+type Properties = { [key: string]: string };
+
+type TelemetryItem = {
+    data: {
+        baseData: {
+            measurements: Measurements;
+            name: string;
+            properties: Properties;
+            ver?: number
+        };
+        baseType: string;
+    };
+    iKey: string;
+    name: string;
+    time: string;
+};
+
+const appInsightsEndpoint = 'https://dc.services.visualstudio.com/v2/track';
+const telemetryDelay = 15000;
+
+let defaultProperties: Properties = {};
+let instrumentationKey = '';
+let nameKey = '';
+let sendTimeout: NodeJS.Timeout | null = null;
+let telemetryEnabled: boolean;
+let telemetryQueue: TelemetryItem[] = [];
+
+const sendTelemetry = () => {
+    if (sendTimeout) {
+        clearTimeout(sendTimeout);
+        sendTimeout = null;
+    }
+
+    const request = https.request(appInsightsEndpoint, { method: 'POST' }, (response) => {
+        if (response.statusCode !== 200) {
+            console.error('Failed to send telemetry: ', response.statusCode);
+        }
+    });
+
+    request.on('error', (err) => {
+        console.error('Failed to send telemetry: ', err);
+    });
+
+    request.write(JSON.stringify(telemetryQueue));
+    request.end();
+
+    telemetryQueue = [];
+};
+
+const track = (type: string, data: TelemetryItem['data']['baseData']) => {
+    if (!telemetryEnabled) {
+        return;
+    }
+
+    telemetryQueue.push({
+        data: {
+            baseData: {
+                measurements: data.measurements,
+                name: data.name,
+                properties: { ...defaultProperties, ...data.properties },
+                ver: 2
+            },
+            baseType: `${type}Data`
+        },
+        iKey: instrumentationKey,
+        name: `Microsoft.ApplicationInsights.${nameKey}.${type}`,
+        time: new Date().toISOString()
+    });
+
+    if (!sendTimeout) {
+        sendTimeout = setTimeout(sendTelemetry, telemetryDelay);
+    }
+};
+
+export const initTelemetry = (key: string, defaults: Properties = {}, enabled: boolean) => {
+    defaultProperties = defaults;
+    instrumentationKey = key;
+    nameKey = key.replace(/-/g, '');
+    telemetryEnabled = enabled;
+};
+
+export const isTelemetryConfigured = () => {
+    return telemetryEnabled !== null;
+};
+
+export const trackEvent = (name: string, properties: Properties = {}, measurements: Measurements = {}) => {
+    track('Event', { name, measurements, properties });
+};
+
+export const updateTelemetry = (enabled: boolean) => {
+    telemetryEnabled = enabled;
+};

--- a/packages/extension-vscode/src/utils/notifications.ts
+++ b/packages/extension-vscode/src/utils/notifications.ts
@@ -1,0 +1,5 @@
+// Reveal the output panel for this extension.
+export const showOutput = 'vscode-webhint/show-output';
+
+// Update whether telemetry is enabled.
+export const telemetryEnabledChanged = 'vscode-webhint/telemetry-enabled-changed';

--- a/packages/extension-vscode/src/utils/packages.ts
+++ b/packages/extension-vscode/src/utils/packages.ts
@@ -1,0 +1,57 @@
+import { spawn } from 'child_process';
+import { access } from 'fs';
+import { resolve as pathResolve } from 'path';
+
+export type LoadOptions = {
+    paths?: string[];
+};
+
+export type InstallOptions = {
+    cwd?: string;
+};
+
+export const hasFile = (name: string, cwd = process.cwd()): Promise<boolean> => {
+    return new Promise((resolve) => {
+        access(pathResolve(cwd, name), (err) => {
+            resolve(!err);
+        });
+    });
+};
+
+export const installPackages = (packages: string[], options?: InstallOptions) => {
+    return new Promise(async (resolve, reject) => {
+
+        // Build the installation commands.
+        const cmd = process.platform === 'win32' ? '.cmd' : '';
+        const npm = `npm${cmd} install ${packages.join(' ')} --save-dev --verbose`;
+        const yarn = `yarn${cmd} add ${packages.join(' ')} --dev`;
+
+        // Install via `yarn` if `yarn.lock` is present, `npm` otherwise.
+        const isUsingYarn = await hasFile('yarn.lock', options && options.cwd);
+        const command = isUsingYarn ? yarn : npm;
+        const parts = command.split(' ');
+
+        // Actually start the installation.
+        const child = spawn(parts[0], parts.slice(1), { cwd: options && options.cwd, stdio: 'inherit' });
+
+        child.on('error', (err) => {
+            reject(err);
+        });
+
+        child.on('exit', (code) => {
+            if (code) {
+                reject(code);
+            } else {
+                resolve();
+            }
+        });
+    });
+};
+
+export const loadPackage = <T>(name: string, options?: LoadOptions): T => {
+    const path = require.resolve(name, { paths: options && options.paths });
+
+    console.log(`Found ${name} at ${path}`);
+
+    return require(path);
+};

--- a/packages/extension-vscode/src/utils/problems.ts
+++ b/packages/extension-vscode/src/utils/problems.ts
@@ -1,0 +1,37 @@
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+
+import { Problem, Severity } from 'hint';
+
+// Translate a webhint severity into the VSCode DiagnosticSeverity format.
+const webhintToDiagnosticServerity = (severity: Severity): DiagnosticSeverity => {
+    switch (severity) {
+        case 2:
+            return DiagnosticSeverity.Error;
+        case 1:
+            return DiagnosticSeverity.Warning;
+        default:
+            return DiagnosticSeverity.Hint;
+    }
+};
+
+// Translate a webhint problem into the VSCode diagnostic format.
+export const problemToDiagnostic = (problem: Problem): Diagnostic => {
+
+    let { column: character, line } = problem.location;
+
+    // Move (-1, -1) or similar to (0, 0) so VSCode underlines the start of the document.
+    if (character < 0 || line < 0) {
+        character = 0;
+        line = 0;
+    }
+
+    return {
+        message: `${problem.message}\n(${problem.hintId})`,
+        range: {
+            end: { character, line },
+            start: { character, line }
+        },
+        severity: webhintToDiagnosticServerity(problem.severity),
+        source: 'webhint'
+    };
+};


### PR DESCRIPTION
* Only prompt to install `hint` to a project when `.hintrc` is present
* Fall back to a shared copy of `hint` from extension's global folder
* Use VS Code settings to track telemetry preferences
* Refactor dependencies to reduce package size

- - - - - - - - - -

Fix #1942

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Creating as a draft pending test updates. Feel free to start reviewing core changes.