### PR TITLE
Fix check mark not appearing after copy to clipboard in `formatter-html`

### DIFF
--- a/packages/formatter-html/src/assets/js/scan/scanner-common.js
+++ b/packages/formatter-html/src/assets/js/scan/scanner-common.js
@@ -265,7 +265,7 @@
     };
 
     var checkClipboard = function (element) {
-        var parentElement = element.closest('.permalink-copy');
+        var parentElement = element.querySelector('.permalink-copy');
         var permalinkImageElement = parentElement.querySelector('img');
 
         if (!window.ejsPartials) {
@@ -286,7 +286,7 @@
 
         setClipboardText(permalink.trim());
 
-        checkClipboard(permalinkElement);
+        checkClipboard(parent);
     };
 
     copyButtons.forEach(function (copyButton) {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
This bug got introduced because of a small change.
Earlier `<span class="permalink-content">` was inside the copy button, so logic was to find closest parent element with class `.permalink-copy`.
But in [this commit](https://github.com/webhintio/hint/commit/f0438eb0121c96a21c67619477c03b06ec8ac7a8), `<span>` was taken out for a good reason :). But logic start breaking as there is no parent element with class `.permalink-copy`.

Please review the fix.

Fix: #2705
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
