### PR TITLE
Chore: Remove iterating over elements and use direct selector

### DIFF
--- a/packages/hint-highest-available-document-mode/src/hint.ts
+++ b/packages/hint-highest-available-document-mode/src/hint.ts
@@ -34,20 +34,6 @@ export default class HighestAvailableDocumentModeHint implements IHint {
         let requireMetaElement: boolean = false;
         let suggestRemoval: boolean = false;
 
-        /*
-         * This function exists because not all connector (e.g.: jsdom)
-         * support matching attribute values case-insensitively.
-         *
-         * https://www.w3.org/TR/selectors4/#attribute-case
-         */
-
-        const getXUACompatibleMetaElements = (elements: HTMLElement[]): HTMLElement[] => {
-            return elements.filter((element: HTMLElement) => {
-                return (element.getAttribute('http-equiv') !== null &&
-                    normalizeString(element.getAttribute('http-equiv')) === 'x-ua-compatible');
-            });
-        };
-
         const checkHeader = (resource: string, responseHeaders: HttpHeaders) => {
             const originalHeaderValue = responseHeaders['x-ua-compatible'];
             const headerValue = normalizeString(originalHeaderValue);
@@ -98,7 +84,7 @@ export default class HighestAvailableDocumentModeHint implements IHint {
         const checkMetaElement = (resource: string) => {
 
             const pageDOM: HTMLDocument = context.pageDOM as HTMLDocument;
-            const XUACompatibleMetaElements: HTMLElement[] = getXUACompatibleMetaElements(pageDOM.querySelectorAll('meta'));
+            const XUACompatibleMetaElements: HTMLElement[] = pageDOM.querySelectorAll('meta[http-equiv=x-ua-compatible i]');
 
             /*
              * By default, if the user did not request the meta
@@ -175,7 +161,7 @@ export default class HighestAvailableDocumentModeHint implements IHint {
 
             // * it's specified in the `<body>`.
 
-            const bodyMetaElements: HTMLElement[] = getXUACompatibleMetaElements(pageDOM.querySelectorAll('body meta'));
+            const bodyMetaElements: HTMLElement[] = pageDOM.querySelectorAll('body meta[http-equiv=x-ua-compatible i]');
 
             if ((bodyMetaElements.length > 0) && bodyMetaElements[0].isSame(XUACompatibleMetaElement)) {
                 const message = getMessage('metaElementNotBody', context.language);


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
In `hint-highest-available-document-mode`, `getXUACompatibleMetaElements` function is defined to filter out elements from given `elements` that have attribute `http-equiv` with value `x-ua-compatible`.

It can be replaced by using direct selectors. Selectors with attributes and values are now supported by `querySelectorAll`.

So we can use `meta[http-equiv=x-ua-compatible i]` selector to get `XUACompatibleMetaElements`.

`i` in the selector is to ignore case.

Resolves: #2033
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
