### PR TITLE
Enable `hint-scoped-svg-styles` in default configuration

### DIFF
--- a/packages/configuration-development/index.json
+++ b/packages/configuration-development/index.json
@@ -21,6 +21,7 @@
         "meta-viewport": "error",
         "no-bom": "error",
         "no-protocol-relative-urls": "error",
+        "scoped-svg-styles": "error",
         "sri": "error",
         "typescript-config/consistent-casing": "error",
         "typescript-config/import-helpers": "error",

--- a/packages/configuration-development/package.json
+++ b/packages/configuration-development/package.json
@@ -15,6 +15,7 @@
     "@hint/hint-meta-viewport": "^4.1.3",
     "@hint/hint-no-bom": "^4.1.3",
     "@hint/hint-no-protocol-relative-urls": "^2.3.3",
+    "@hint/hint-scoped-svg-styles": "^1.0.0",
     "@hint/hint-sri": "^3.2.3",
     "@hint/hint-typescript-config": "^2.3.4",
     "@hint/hint-webpack-config": "^2.3.4",

--- a/packages/configuration-web-recommended/index.json
+++ b/packages/configuration-web-recommended/index.json
@@ -28,6 +28,7 @@
         "no-http-redirects": "error",
         "no-protocol-relative-urls": "error",
         "no-vulnerable-javascript-libraries": "error",
+        "scoped-svg-styles": "error",
         "sri": "error",
         "ssllabs": "error",
         "strict-transport-security": "error",

--- a/packages/configuration-web-recommended/package.json
+++ b/packages/configuration-web-recommended/package.json
@@ -26,6 +26,7 @@
     "@hint/hint-no-http-redirects": "^2.3.3",
     "@hint/hint-no-protocol-relative-urls": "^2.3.3",
     "@hint/hint-no-vulnerable-javascript-libraries": "^2.9.4",
+    "@hint/hint-scoped-svg-styles": "^1.0.0",
     "@hint/hint-sri": "^3.2.3",
     "@hint/hint-ssllabs": "^2.3.3",
     "@hint/hint-strict-transport-security": "^2.3.3",

--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -30,6 +30,7 @@
     "@hint/hint-no-http-redirects": "^2.3.3",
     "@hint/hint-no-protocol-relative-urls": "^2.3.3",
     "@hint/hint-no-vulnerable-javascript-libraries": "^2.9.4",
+    "@hint/hint-scoped-svg-styles": "^1.0.0",
     "@hint/hint-sri": "^3.2.3",
     "@hint/hint-stylesheet-limits": "^3.2.3",
     "@hint/hint-validate-set-cookie-header": "^2.3.3",

--- a/packages/extension-browser/tsconfig.json
+++ b/packages/extension-browser/tsconfig.json
@@ -36,6 +36,7 @@
         { "path": "../hint-no-http-redirects" },
         { "path": "../hint-no-protocol-relative-urls" },
         { "path": "../hint-no-vulnerable-javascript-libraries" },
+        { "path": "../hint-scoped-svg-styles" },
         { "path": "../hint-sri" },
         { "path": "../hint-stylesheet-limits" },
         { "path": "../hint-validate-set-cookie-header" },

--- a/packages/hint-scoped-svg-styles/package.json
+++ b/packages/hint-scoped-svg-styles/package.json
@@ -51,7 +51,6 @@
     "@hint/parser-css": "^3.0.7",
     "hint": "^5.1.2"
   },
-  "private": true,
   "repository": "webhintio/hint",
   "scripts": {
     "build": "npm run i18n && npm-run-all build:*",


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
Enabling `hint-scoped-svg-styles` and `private: true` removed from the hint.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
