### PR TITLE
Fix: Stub calls to Application Insights for tests

### DIFF
--- a/packages/create-hintrc/tests/create-hintrc.ts
+++ b/packages/create-hintrc/tests/create-hintrc.ts
@@ -82,6 +82,10 @@ const loadScript = (context: CreateHintRCContext): () => Promise<boolean> => {
     const initHintrc = proxyquire('../src/create-hintrc', {
         './browserslist': context.stubBrowserslistObject,
         '@hint/utils': {
+            appInsights: {
+                sendPendingData() { },
+                trackEvent() { }
+            },
             fs: utils.fs,
             logger: context.logger,
             npm: context.npm

--- a/packages/create-parser/tests/new-parser.ts
+++ b/packages/create-parser/tests/new-parser.ts
@@ -76,6 +76,10 @@ const loadScript = (context: NewParserContext) => {
     const script = proxyquire('../src/new-parser', {
         '../src/handlebars-utils': context.handlebarsUtils,
         '@hint/utils': {
+            appInsights: {
+                sendPendingData() { },
+                trackEvent() { }
+            },
             fs: {
                 readFileAsync: context.readFileAsync,
                 writeFileAsync: context.writeFileAsync


### PR DESCRIPTION
Fix #2879

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
