### PR TITLE
Fix: Align manual manifest fetch behavior with connectors

### DIFF
--- a/packages/hint-manifest-exists/src/_locales/en/messages.json
+++ b/packages/hint-manifest-exists/src/_locales/en/messages.json
@@ -11,6 +11,14 @@
         "description": "Report message when the manifest has an empty href attribute",
         "message": "'manifest' link element should have non-empty 'href' attribute."
     },
+    "manifestNotFetched": {
+        "description": "Report message when the manifest file cannot be loaded due to network failure.",
+        "message": "'manifest' could not be fetched. Request failed."
+    },
+    "manifestNotFetchedStatus": {
+        "description": "Report message when the manifest file cannot be loaded due to server failure.",
+        "message": "'manifest' could not be fetched. Status code: $1"
+    },
     "manifestNotSpecified": {
         "description": "Report message when the manifest link element is not specified",
         "message": "'manifest' link element was not specified."

--- a/packages/hint-manifest-exists/src/hint.ts
+++ b/packages/hint-manifest-exists/src/hint.ts
@@ -11,6 +11,7 @@
 
 import {
     ElementFound,
+    FetchEnd,
     FetchError,
     HintContext,
     IHint,
@@ -70,13 +71,20 @@ export default class ManifestExistsHint implements IHint {
             }
         };
 
-        const handleFetchErrors = (fetchErrorEvent: FetchError) => {
-            const { resource, element, error } = fetchErrorEvent;
+        const handleFetchEnd = ({ element, resource, response }: FetchEnd) => {
+            if (response.statusCode >= 400) {
+                context.report(resource, getMessage('manifestNotFetchedStatus', context.language, `${response.statusCode}`), { element });
+            }
+        };
 
-            context.report(resource, error.message, { element });
+        const handleFetchErrors = (fetchErrorEvent: FetchError) => {
+            const { resource, element } = fetchErrorEvent;
+
+            context.report(resource, getMessage('manifestNotFetched', context.language), { element });
         };
 
         context.on('element::link', checkIfManifest);
+        context.on('fetch::end::manifest', handleFetchEnd);
         context.on('fetch::error::manifest', handleFetchErrors);
         context.on('scan::end', checkIfManifestWasSpecified);
     }

--- a/packages/hint-manifest-exists/tests/tests.ts
+++ b/packages/hint-manifest-exists/tests/tests.ts
@@ -62,7 +62,7 @@ const tests: HintTest[] = [
     },
     {
         name: `Manifest is specified and request for file fails`,
-        reports: [{ message: `'site.webmanifest' could not be fetched (request failed).` }],
+        reports: [{ message: `'manifest' could not be fetched. Request failed.` }],
         serverConfig: {
             '/': htmlWithManifestSpecified,
             '/site.webmanifest': null
@@ -70,7 +70,7 @@ const tests: HintTest[] = [
     },
     {
         name: `Manifest is specified and request for file fails with status code 404`,
-        reports: [{ message: `'site.webmanifest' could not be fetched (status code: 404).` }],
+        reports: [{ message: `'manifest' could not be fetched. Status code: 404` }],
         serverConfig: {
             '/': htmlWithManifestSpecified,
             '/site.webmanifest': { status: 404 }
@@ -78,7 +78,7 @@ const tests: HintTest[] = [
     },
     {
         name: `Manifest is specified and request for file fails with status code 500`,
-        reports: [{ message: `'site.webmanifest' could not be fetched (status code: 500).` }],
+        reports: [{ message: `'manifest' could not be fetched. Status code: 500` }],
         serverConfig: {
             '/': htmlWithManifestSpecified,
             '/site.webmanifest': { status: 500 }

--- a/packages/parser-manifest/tests/tests.ts
+++ b/packages/parser-manifest/tests/tests.ts
@@ -44,13 +44,13 @@ const getEngine = (): Engine<ManifestEvents> => {
 };
 
 const fetchEndEventName = 'fetch::end::manifest';
-const fetchErrorEventName: string = 'fetch::error::manifest';
-const fetchStartEventName: string = 'fetch::start::manifest';
+const fetchErrorEventName = 'fetch::error::manifest';
+const fetchStartEventName = 'fetch::start::manifest';
 
-const parseStartEventName: string = 'parse::start::manifest';
-const parseEndEventName: string = 'parse::end::manifest';
-const parseErrorSchemaEventName: string = 'parse::error::manifest::schema';
-const parseJSONErrorEventName: string = 'parse::error::manifest::json';
+const parseStartEventName = 'parse::start::manifest';
+const parseEndEventName = 'parse::end::manifest';
+const parseErrorSchemaEventName = 'parse::error::manifest::schema';
+const parseJSONErrorEventName = 'parse::error::manifest::json';
 
 const scanEndEventName = 'scan::end';
 const scanEndEventValue = { resource: 'https://example.com' };
@@ -176,7 +176,7 @@ test(`'${fetchErrorEventName}' event is emitted when the manifest cannot be fetc
     sandbox.restore();
 });
 
-test(`'${fetchErrorEventName}' event is emitted when the response for the web app manifest has a status code differenr the 200`, async (t) => {
+test(`'${fetchEndEventName}' event is emitted when the response for the web app manifest has a failure status code`, async (t) => {
     const elementEventValue = getElementLinkEventValue();
     const manifestContent = '500 Internal Server Error';
     const sandbox = sinon.createSandbox();
@@ -196,8 +196,7 @@ test(`'${fetchErrorEventName}' event is emitted when the response for the web ap
     t.is(engineEmitAsyncSpy.callCount, 4);
     t.is(engineEmitAsyncSpy.args[0][0], elementLinkEventName);
     t.is(engineEmitAsyncSpy.args[1][0], fetchStartEventName);
-    t.is(engineEmitAsyncSpy.args[2][0], fetchErrorEventName);
-    t.not(typeof (engineEmitAsyncSpy.args[2][1] as any).error, 'undefined');
+    t.is(engineEmitAsyncSpy.args[2][0], fetchEndEventName);
     t.is(engineEmitAsyncSpy.args[3][0], scanEndEventName);
 
     sandbox.restore();


### PR DESCRIPTION
Update manual fetches from `parser-manifest` to emit
`fetch::end::manifest` in response to failure status codes instead of
`fetch::error::manifest` to align with connector behavior.

- - - - - - - - - -

Fix #2882

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
