### PR TITLE
Fix: Improve minified JavaScript reports

### DIFF
--- a/packages/hint-minified-js/src/hint.ts
+++ b/packages/hint-minified-js/src/hint.ts
@@ -43,12 +43,19 @@ export default class MinifiedJsHint implements IHint {
         };
 
         const validateContentMinified = (scriptData: ScriptParse) => {
+            const { element, resource, sourceCode } = scriptData;
             const improvementIndex = getImprovementIndex(scriptData);
 
-            debug(`Calculated improvementIndex for ${scriptData.resource}: ${improvementIndex}`);
+            if (sourceCode.length < 1024) {
+                debug(`Ignoring minification for script under 1KB: ${resource}`);
+
+                return;
+            }
+
+            debug(`Calculated improvementIndex for ${resource}: ${improvementIndex}`);
 
             if (improvementIndex > threshold) {
-                context.report(scriptData.resource, getMessage('shouldBeMinified', context.language));
+                context.report(resource, getMessage('shouldBeMinified', context.language), { element });
             }
         };
 

--- a/packages/hint-minified-js/tests/tests.ts
+++ b/packages/hint-minified-js/tests/tests.ts
@@ -10,7 +10,7 @@ const generateScriptTag = (script: string) => {
     return `<script>${script}</script>`;
 };
 
-const unminifiedJS = `
+const unminifiedJSBelow1024 = `
 // This method does something
 var highlightCodeBlocks = function () {
     var codeBlocks = document.querySelectorAll('code');
@@ -36,6 +36,8 @@ var updateExpandAllButton = function (element, closeAll) {
 };
 `;
 
+const unminifiedJS = unminifiedJSBelow1024 + unminifiedJSBelow1024;
+
 const minifiedJS = `!function(){"use strict";Element.prototype.matches||(Element.prototype.matches=Element.prototype.msMatchesSelector||Element.prototype.webkitMatchesSelector),Element.prototype.closest||(Element.prototype.closest=function(e){var t=this;if(!document.documentElement.contains(this))return null;do{if(t.matches(e))return t;t=t.parentElement}while(null!==t);return null});var e,s=function(e,t){var n;("undefined"!=typeof closecloseAll?t:(n=e.closest(".rule-result"),Array.prototype.slice.apply(n.querySelectorAll(".rule-result--details")).some(function(e){return"true"===e.getAttribute("aria-expanded")})))?(e.innerHTML="- close all",e.classList.remove("closed"),e.classList.add("expanded")):(e.innerHTML="+ expand all",e.classList.remove("expanded"),e.classList.add("closed"))},r=function(e,t){var n=e.closest(".rule-result--details"),l=void 0!==t?t:"true"===n.getAttribute("aria-expanded"),o=e.getAttribute("data-rule"),r=n.closest(".rule-result").querySelector(".button-expand-all");l?(n.setAttribute("aria-expanded","false"),e.innerHTML="open details",e.setAttribute("title","show "+o+"'s result details")):(n.setAttribute("aria-expanded","true"),e.innerHTML="close details",e.setAttribute("title","close "+o+"'s result details")),s(r)},t=function(e){var t=e.target;-1!==t.className.indexOf("button--details")&&r(t),-1!==t.className.indexOf("button-expand-all")&&function(e){for(var t=e.closest(".rule-result"),n=Array.prototype.slice.apply(t.querySelectorAll(".button--details")),l=e.classList.contains("expanded"),o=0;o<n.length;o++)r(n[o],!!l);s(e,!l)}(t)},n=document.querySelector(".permalink-copy");n&&n.addEventListener("click",function(){!function(e){var t="hidden-clipboard",n=document.getElementById(t);if(!n){var l=document.createElement("textarea");l.id=t,l.style.position="fixed",l.style.top=0,l.style.left=0,l.style.width="1px",l.style.height="1px",l.style.padding=0,l.style.border="none",l.style.outline="none",l.style.boxShadow="none",l.style.background="transparent",document.querySelector("body").appendChild(l),n=document.getElementById(t)}n.value=e,n.select(),document.execCommand("copy")}(document.querySelector(".scan-overview__body__permalink").textContent.trim())}),window.addEventListener("popstate",function(){var e,t;e="/scanner/",(t=window.location.href).length-e.length===t.indexOf(e)&&(window.location.href=window.location.href)},!1),(e=document.getElementById("results-container"))&&e.addEventListener("click",t,!1),function(){for(var e=document.querySelectorAll("code"),t=0;t<e.length;t++)hljs.highlightBlock(e[t])}()}();`;
 const tests: HintTest[] = [
     {
@@ -46,6 +48,10 @@ const tests: HintTest[] = [
         name: 'Unminified content should fail',
         reports: [{ message: expectedMessageFromHint }],
         serverConfig: generateHTMLPage(generateScriptTag(unminifiedJS))
+    },
+    {
+        name: 'Unminified content below 1KB should pass',
+        serverConfig: generateHTMLPage(generateScriptTag(unminifiedJSBelow1024))
     }
 ];
 const testsWithHighThreshold: HintTest[] = [


### PR DESCRIPTION
Include reference to `<script>` element in reports for inline scripts.
Also ignore scripts below 1KB (which are prone to false-positives).

- - - - - - - - - -

Fix #2898
Ref #2645

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
