### PR TITLE
Fix: Clear cache and service worker data on reload

### DIFF
--- a/packages/extension-browser/src/content-script/connector.ts
+++ b/packages/extension-browser/src/content-script/connector.ts
@@ -4,7 +4,7 @@ import { Engine } from 'hint';
 import { getElementByUrl, HTMLDocument, HTMLElement, traverse } from '@hint/utils/dist/src/dom';
 import { createHelpers, restoreReferences } from '@hint/utils/dist/src/dom/snapshot';
 import { DocumentData } from '@hint/utils/dist/src/types/snapshot';
-import { getContentTypeData, getType } from '@hint/utils/dist/src/content-type';
+
 import {
     ConnectorOptionsConfig,
     IConnector,
@@ -15,6 +15,7 @@ import {
 import { browser, document, eval, location, MutationObserver, window } from '../shared/globals';
 import { Events } from '../shared/types';
 import { Fetcher } from './fetcher';
+import { setFetchType } from './set-fetch-type';
 
 export default class WebExtensionConnector implements IConnector {
     private _document: HTMLDocument | undefined;
@@ -124,15 +125,6 @@ export default class WebExtensionConnector implements IConnector {
         }
     }
 
-    private setFetchType(event: FetchEnd): string {
-        const { charset, mediaType } = getContentTypeData(null, event.response.url, event.response.headers, null as any);
-
-        event.response.charset = charset || '';
-        event.response.mediaType = mediaType || '';
-
-        return getType(mediaType || '');
-    }
-
     private async notifyFetch(event: FetchEnd) {
         /*
          * Delay dispatching FetchEnd until we have the DOM snapshot to populate `element`.
@@ -145,7 +137,7 @@ export default class WebExtensionConnector implements IConnector {
         }
 
         this.setFetchElement(event);
-        const type = this.setFetchType(event);
+        const type = setFetchType(event);
 
         await this._engine.emitAsync(`fetch::end::${type}` as 'fetch::end::*', event);
     }

--- a/packages/extension-browser/src/content-script/fetcher.ts
+++ b/packages/extension-browser/src/content-script/fetcher.ts
@@ -1,8 +1,10 @@
 import { FetchEnd, NetworkData } from 'hint/dist/src/lib/types';
-import { fetch } from '../shared/globals';
-import { Events } from '../shared/types';
 import { HttpHeaders } from '@hint/utils/dist/src/types/http-header';
 import { getContentTypeData } from '@hint/utils/dist/src/content-type';
+
+import { fetch } from '../shared/globals';
+import { Events } from '../shared/types';
+import { setFetchType } from './set-fetch-type';
 
 type ResolveNetworkData = (data: NetworkData) => void;
 
@@ -107,6 +109,8 @@ export class Fetcher {
      */
     private resolveFetch(event: FetchEnd) {
         const resolve = this._fetches.get(event.resource);
+
+        setFetchType(event);
 
         if (resolve) {
             resolve(event);

--- a/packages/extension-browser/src/content-script/set-fetch-type.ts
+++ b/packages/extension-browser/src/content-script/set-fetch-type.ts
@@ -1,0 +1,11 @@
+import { getContentTypeData, getType } from '@hint/utils/dist/src/content-type';
+import { FetchEnd } from 'hint/dist/src/lib/types';
+
+export const setFetchType = (event: FetchEnd): string => {
+    const { charset, mediaType } = getContentTypeData(null, event.response.url, event.response.headers, null as any);
+
+    event.response.charset = charset || '';
+    event.response.mediaType = mediaType || '';
+
+    return getType(mediaType || '');
+};

--- a/packages/extension-browser/tests/content-script/fetcher.ts
+++ b/packages/extension-browser/tests/content-script/fetcher.ts
@@ -8,7 +8,7 @@ test('Fetcher can match requests to responses', async (t) => {
     const missFetchStart = { resource: 'http://example.com/index.htm' } as FetchStart;
     const matchFetchStart = { resource } as FetchStart;
     const missFetchEnd = { request: {}, resource: 'http://example.com/index.htm', response: {} } as FetchEnd;
-    const matchFetchEnd = { request: {}, resource, response: { body: { content: 'test content' }} } as FetchEnd;
+    const matchFetchEnd = { request: {}, resource, response: { body: { content: 'test content' }, url: resource} } as FetchEnd;
     const fetchStub = sinon.stub().resolves({});
     const { Fetcher } = proxyquire(
         '../../src/content-script/fetcher', {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

Explicitly delete the cache and any service worker data before reloading. 

Fix #2928

Bundles for testing:

[chromium 2019-09-09](https://github.com/webhintio/hint/files/3592792/webhint-0.0.7.zip)
[firefox 2019-09-09](https://github.com/webhintio/hint/files/3592794/webhint-0.0.7.zip)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

