### PR TITLE
Fix: Copy version to manifest bundled with webpack

### DIFF
--- a/packages/extension-browser/scripts/copy-version.js
+++ b/packages/extension-browser/scripts/copy-version.js
@@ -14,17 +14,21 @@ const writeFile = util.promisify(fs.writeFile);
  */
 const updateFile = async (file, version) => {
     const content = require(file);
+    const filename = path.join(__dirname, file);
 
     content.version = version;
-    await writeFile(path.join(__dirname, file), `${JSON.stringify(content, null, 2)}\n`, 'utf-8');
+    await writeFile(filename, `${JSON.stringify(content, null, 2)}\n`, 'utf-8');
+    console.log(`Set version to ${version} in ${filename}`);
 };
 
 const start = async () => {
     const pkgPath = '../package.json';
-    const manifestPath = '../dist/bundle/manifest.json';
+    const manifestPaths = ['../dist/bundle/manifest.json', '../dist/src/manifest.json'];
     const { version } = require(pkgPath);
 
-    await updateFile(manifestPath, version);
+    for (const manifestPath of manifestPaths) {
+        await updateFile(manifestPath, version);
+    }
 };
 
 start();


### PR DESCRIPTION
Now shows the version number in the UI instead of placeholder text.
This regressed when I integrated the extension into our release script.

Was showing
`Powered by webhint v(set by scripts/copy-version.js)`

Instead of 
`Powered by webhint v0.0.7`

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
