### PR TITLE
Fix: Ignore all `link[rel]` values as they are PE

### DIFF
--- a/packages/hint-compat-api/docs/html.md
+++ b/packages/hint-compat-api/docs/html.md
@@ -87,8 +87,7 @@ default value is:
 [
     "crossorigin",
     "integrity",
-    "link[rel=manifest]",
-    "link[rel=preload]",
+    "link[rel]",
     "main",
     "spellcheck"
 ]

--- a/packages/hint-compat-api/src/html.ts
+++ b/packages/hint-compat-api/src/html.ts
@@ -75,8 +75,7 @@ export default class HTMLCompatHint implements IHint {
         const ignore = resolveIgnore([
             'crossorigin',
             'integrity',
-            'link[rel=manifest]',
-            'link[rel=preload]',
+            'link[rel]',
             'main',
             'spellcheck'
         ], context.hintOptions);


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- ~~Added/Updated related tests.~~

## Short description of the change(s)

Fix #2935


<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
