### PR TITLE
Fix: Track `FirstRun` events in CI differently

### DIFF
--- a/packages/hint/src/bin/hint.ts
+++ b/packages/hint/src/bin/hint.ts
@@ -12,33 +12,22 @@
  * ------------------------------------------------------------------------------
  */
 
-const tracking = (/--tracking[=\s]+([^\s]*)/i).exec(process.argv.join(' '));
+const telemetry = (/--tracking[=\s]+([^\s]*)/i).exec(process.argv.join(' '));
 
-import { configStore, appInsights } from '@hint/utils';
+import { appInsights } from '@hint/utils';
 
-const trackingEnv = process.env.HINT_TRACKING;
-let enableTracking;
+const telemetryEnv = process.env.HINT_TRACKING;
+let enableTelemetry;
 
-if (tracking) {
-    enableTracking = tracking[1] === 'on';
-} else if (trackingEnv) {
-    enableTracking = trackingEnv === 'on';
+if (telemetry) {
+    enableTelemetry = telemetry[1] === 'on';
+} else if (telemetryEnv) {
+    enableTelemetry = telemetryEnv === 'on';
 }
 
-if (typeof enableTracking !== 'undefined') {
-    if (enableTracking) {
-        const alreadyRun: boolean = configStore.get('run');
-        const configured = appInsights.isConfigured();
-
+if (typeof enableTelemetry !== 'undefined') {
+    if (enableTelemetry) {
         appInsights.enable();
-
-        if (!configured) {
-            if (!alreadyRun) {
-                appInsights.trackEvent('FirstRun');
-            } else {
-                appInsights.trackEvent('SecondRun');
-            }
-        }
     } else {
         appInsights.disable();
     }

--- a/packages/hint/tests/lib/cli/analyze.ts
+++ b/packages/hint/tests/lib/cli/analyze.ts
@@ -464,9 +464,9 @@ test('If there is missing or incompatible packages, they should be tracked', asy
     }
 
     t.true(appInsightTrackEventSpy.calledTwice);
-    t.is(appInsightTrackEventSpy.args[0][0], 'missing');
+    t.is(appInsightTrackEventSpy.args[0][0], 'cli-missing');
     t.deepEqual(appInsightTrackEventSpy.args[0][1], ['hint1']);
-    t.is(appInsightTrackEventSpy.args[1][0], 'incompatible');
+    t.is(appInsightTrackEventSpy.args[1][0], 'cli-incompatible');
     t.deepEqual(appInsightTrackEventSpy.args[1][1], ['hint2']);
 });
 
@@ -477,7 +477,7 @@ test('If no sites are defined, it should return false', async (t) => {
     t.false(result);
 });
 
-test('If there is no errors analyzing the url, and it is the second time running a scan, and the user confirm telemetry, telemetry should be enabled', async (t) => {
+test('If there is no errors analyzing the url, webhint was previously run, and the user confirm telemetry, the payload should indicate it', async (t) => {
     const sandbox = t.context.sandbox;
     const fakeAnalyzer = new FakeAnalyzer();
 
@@ -499,9 +499,10 @@ test('If there is no errors analyzing the url, and it is the second time running
     const args = appInsightTrackEventSpy.args;
 
     t.true(appInsightEnableSpy.calledOnce);
-    t.true(appInsightTrackEventSpy.calledThrice);
-    t.is(args[1][0], 'SecondRun');
-    t.is(args[2][0], 'analyze');
+    t.true(appInsightTrackEventSpy.calledTwice);
+    t.is(args[0][0], 'cli-telemetry');
+    t.is(args[1][0], 'cli-analyze');
+    t.true(args[1][1].previouslyRun);
 });
 
 test('Telemetry should trim options from a connector', async (t) => {
@@ -509,6 +510,10 @@ test('Telemetry should trim options from a connector', async (t) => {
     const fakeAnalyzer = new FakeAnalyzer();
 
     sandbox.stub(t.context.analyzer.Analyzer as any, 'create').returns(fakeAnalyzer);
+    sandbox.stub(t.context.appInsight, 'isConfigured').returns(true);
+    sandbox.stub(t.context.appInsight, 'isEnabled').returns(true);
+    sandbox.stub(t.context.configStore, 'get').returns(true);
+
     sandbox.stub(fakeAnalyzer, 'analyze').resolves();
 
     sandbox.stub(t.context.analyzer.Analyzer as any, 'getUserConfig').returns({
@@ -530,10 +535,11 @@ test('Telemetry should trim options from a connector', async (t) => {
 
     await analyze(actions);
 
+    t.true(appInsightTrackEventSpy.calledOnce);
     t.falsy(appInsightTrackEventSpy.args[0][1].connector.options);
 });
 
-test('Telemetry should remove properties from rules', async (t) => {
+test('Telemetry should remove properties from rules and send the "cli-telemetry" when opting-in', async (t) => {
     const sandbox = t.context.sandbox;
     const fakeAnalyzer = new FakeAnalyzer();
 
@@ -562,8 +568,10 @@ test('Telemetry should remove properties from rules', async (t) => {
 
     await analyze(actions);
 
-    const hints = appInsightTrackEventSpy.args[0][1].hints;
 
+    const hints = appInsightTrackEventSpy.args[1][1].hints;
+
+    t.is(appInsightTrackEventSpy.args[0][0], 'cli-telemetry');
     t.is(hints.hint1, 'error');
     t.is(hints.hint2, 'warning');
 });

--- a/packages/utils/src/app-insights.ts
+++ b/packages/utils/src/app-insights.ts
@@ -10,7 +10,7 @@ interface IFlushOptions {
 const debug: debug.IDebugger = d(__filename);
 const configStoreKey: string = 'insight';
 
-let insightsEnabled = configStore.get(configStoreKey);
+let insightsEnabled: boolean | undefined = configStore.get(configStoreKey);
 
 let appInsightsClient: appInsights.TelemetryClient = {
     flush(options: IFlushOptions) {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

Send `CIRun` events when the user gives permission for telemetry instead
of `FirstRun` so it is easier to know when there are new users and how
many times it is used from CI.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #2962


<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
