### PR TITLE
Fix/no broken links

### DIFF
--- a/packages/hint-no-broken-links/tests/tests.ts
+++ b/packages/hint-no-broken-links/tests/tests.ts
@@ -58,6 +58,10 @@ const bodyWithBrokenImageSrcSets = `<div>
 <img alt="test" src="/1.jpg" srcset="2.jpg 640w,3.jpg 750w , 4.jpg 1080w">
 </div>`;
 
+const bodyWithDataUriSrcSets = `<div>
+<img alt="test" src="/1.jpg" srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=,2.jpg 640w,data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII= 1024w">
+</div>`;
+
 const bodyWithBrokenVideo = `<div>
 <video controls src="/1.mp4" poster="/2.png">
 </div>`;
@@ -189,6 +193,14 @@ const tests: HintTest[] = [
             '/2.jpg': '',
             '/3.jpg': { status: 404 },
             '/4.jpg': { status: 404 }
+        }
+    },
+    {
+        name: `This test should pass as data uris in srcset should be ignored`,
+        serverConfig: {
+            '/': { content: generateHTMLPage('', bodyWithDataUriSrcSets) },
+            '/1.jpg': '',
+            '/2.jpg': ''
         }
     },
     {

--- a/packages/utils-connector-tools/src/requester.ts
+++ b/packages/utils-connector-tools/src/requester.ts
@@ -64,7 +64,7 @@ const defaults = {
     },
     jar: true,
     time: true,
-    timeout: 10000
+    timeout: 30000
 };
 
 export class Requester {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- [x] Added/Updated related tests.

## Short description of the change(s)

Fix #3002

Fix an issue where the urls of a `srcset` weren't parsed correctly if it had data URIs and increases the timeout of `Requester` to avoid `ESOCKETTIMEDOUT` errors.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
