### PR TITLE
New: Group hint reports with the same message text

### DIFF
--- a/packages/extension-browser/src/_locales/en/messages.json
+++ b/packages/extension-browser/src/_locales/en/messages.json
@@ -83,10 +83,6 @@
         "message": "Help us improve webhint by sending limited usage information (no personal information or URLs will be sent).",
         "description": "Label for telemetry opt-in popup"
     },
-    "hintCountLabel": {
-        "message": "hint $1:",
-        "description": "Label for a test result based on the order in which it is listed, e.g. 'hint 2:'."
-    },
     "inspectElement": {
         "message": "Inspect Element",
         "description": "Label for a button to link to a specific element in the Elements panel."

--- a/packages/extension-browser/src/devtools/views/controls/external-link.css
+++ b/packages/extension-browser/src/devtools/views/controls/external-link.css
@@ -3,14 +3,17 @@
 
     border-bottom: var(--border);
     color: var(--link-color);
+    padding-bottom: 1px;
     text-decoration: none;
 }
 
 .root:focus {
     border-bottom: 2px solid var(--base-color);
     outline: none;
+    padding-bottom: 0;
 }
 
 .root:global(:not(.focus-visible)) {
     border-bottom: var(--border);
+    padding-bottom: 1px;
 }

--- a/packages/extension-browser/src/devtools/views/pages/results/category-summary.tsx
+++ b/packages/extension-browser/src/devtools/views/pages/results/category-summary.tsx
@@ -25,7 +25,7 @@ const CategorySummary = ({ name, hints, passed }: CategoryResults) => {
     return (
         <a className={styles.root} href={`#results-category-${name}`} data-icon={name}>
             {getCategoryName(name)}
-            <span className={`${styles.status} ${statusStyle}`}>{passed}/{hints.length}</span>
+            <span className={`${styles.status} ${statusStyle}`}>{hints.length - passed}</span>
         </a>
     );
 };

--- a/packages/extension-browser/src/devtools/views/pages/results/category.css
+++ b/packages/extension-browser/src/devtools/views/pages/results/category.css
@@ -18,6 +18,10 @@
 }
 
 .results {
-    padding-left: 1rem; /* 16px */
+    display: grid;
+    gap: 0.5625rem; /* 9px */
+    justify-items: start;
     margin-bottom: 1.25rem; /* 20px */
+    margin-top: 0.5625rem; /* 9px */
+    padding-left: 1rem; /* 16px */
 }

--- a/packages/extension-browser/src/devtools/views/pages/results/hint.css
+++ b/packages/extension-browser/src/devtools/views/pages/results/hint.css
@@ -1,9 +1,8 @@
-.root {
-    margin: 0.5625rem 0;
-}
-
 .results {
+    display: grid;
     font-size: var(--font-size-sm);
+    gap: 0.5rem; /* 8px */
+    justify-items: start;
     padding-left: 1rem; /* 16px */
 }
 

--- a/packages/extension-browser/src/devtools/views/pages/results/hint.tsx
+++ b/packages/extension-browser/src/devtools/views/pages/results/hint.tsx
@@ -10,7 +10,7 @@ import ExternalLink from '../../controls/external-link';
 
 import Summary from '../../controls/summary';
 
-import Problem from './problem';
+import MessageGroup from './message-group';
 
 import * as styles from './hint.css';
 
@@ -20,7 +20,45 @@ const hasError = (problems: ProblemData[]) => {
     });
 };
 
+/**
+ * Group problems which have the same message string.
+ */
+const groupProblems = (problems: ProblemData[]) => {
+    const groups = new Map<string, ProblemData[]>();
+
+    for (const problem of problems) {
+        const group = groups.get(problem.message) || [];
+
+        group.push(problem);
+        groups.set(problem.message, group);
+    }
+
+    return groups;
+};
+
+/**
+ * Sort group keys (messages) with higher severity first,
+ * then alphabetically by message text.
+ */
+const getSortedGroupKeys = (groups: Map<string, ProblemData[]>) => {
+    return [...groups.keys()].sort((k1, k2) => {
+        const p1 = groups.get(k1)![0];
+        const p2 = groups.get(k2)![0];
+
+        if (p1.severity > p2.severity) {
+            return -1;
+        }
+
+        if (p1.severity < p2.severity) {
+            return 1;
+        }
+
+        return k1.localeCompare(k2);
+    });
+};
+
 const Hint = ({ name, problems, helpURL }: HintResults) => {
+    const groups = groupProblems(problems);
     let statusStyle = styles.pass;
 
     if (problems.length) {
@@ -28,25 +66,25 @@ const Hint = ({ name, problems, helpURL }: HintResults) => {
     }
 
     return (
-        <details className={styles.root}>
+        <details>
             <Summary>
                 <span>
                     {name}
                 </span>
                 {' '}
                 <span className={`${styles.status} ${statusStyle}`}>
-                    {!problems.length ? getMessage('noIssuesLabel') : getMessage('hintIssuesLabel', problems.length.toString())}
+                    {!problems.length ? getMessage('noIssuesLabel') : getMessage('hintIssuesLabel', groups.size.toString())}
                 </span>
             </Summary>
             <div className={styles.results}>
                 <ExternalLink href={helpURL}>
                     {!problems.length ? getMessage('learnWhyLabel') : getMessage('learnWhyAndHowLabel')}
                 </ExternalLink>
-                {problems.map(
-                    (problem, index) => {
-                        return <Problem key={index} problem={problem} index={index} />;
-                    })
-                }
+                {getSortedGroupKeys(groups).map(
+                    (message) => {
+                        return <MessageGroup key={message} message={message} problems={groups.get(message)!} />;
+                    }
+                )}
             </div>
         </details>
     );

--- a/packages/extension-browser/src/devtools/views/pages/results/message-group.css
+++ b/packages/extension-browser/src/devtools/views/pages/results/message-group.css
@@ -1,0 +1,17 @@
+.root {
+    -webkit-user-select: text;
+    user-select: text;
+    width: 100%;
+}
+
+.header {
+    font-size: var(--font-size);
+}
+
+.problems {
+    display: grid;
+    gap: 1.5rem; /* 24px */
+    margin-bottom: 1rem; /* 16px */
+    margin-top: 0.75rem; /* 12px */
+    padding-left: 1rem; /* 16px */
+}

--- a/packages/extension-browser/src/devtools/views/pages/results/message-group.tsx
+++ b/packages/extension-browser/src/devtools/views/pages/results/message-group.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+import { Problem as ProblemData } from '@hint/utils/dist/src/types/problems';
+
+import Summary from '../../controls/summary';
+
+import Problem from './problem';
+
+import * as styles from './message-group.css';
+
+type Props = {
+    message: string;
+    problems: ProblemData[];
+};
+
+const MessageGroup = ({ message, problems }: Props) => {
+    return (
+        <details className={styles.root} open>
+            <Summary className={styles.header}>
+                {message}
+            </Summary>
+            <div className={styles.problems}>
+                {problems.map(
+                    (problem, index) => {
+                        return <Problem key={index} problem={problem} />;
+                    }
+                )}
+            </div>
+        </details>
+    );
+};
+
+export default MessageGroup;

--- a/packages/extension-browser/src/devtools/views/pages/results/problem.css
+++ b/packages/extension-browser/src/devtools/views/pages/results/problem.css
@@ -1,16 +1,3 @@
-.root {
-    margin: 1.5rem 0; /* 24px */
-    padding-left: 0.5rem; /* 8px */
-    -webkit-user-select: text;
-    user-select: text;
-}
-
-.header {
-    font-size: var(--font-size);
-    margin-bottom: 0.75rem; /* 12px */
-    margin-left: -0.5rem; /* -8px */
-}
-
 .problemLink {
     color: var(--link-alt-color);
     text-decoration: none;
@@ -25,8 +12,4 @@
 
 .problemLink:global(:not(.focus-visible)) {
     border: none;
-}
-
-.number {
-    font-weight: var(--bold);
 }

--- a/packages/extension-browser/src/devtools/views/pages/results/problem.tsx
+++ b/packages/extension-browser/src/devtools/views/pages/results/problem.tsx
@@ -5,8 +5,6 @@ import { Problem as ProblemData } from '@hint/utils/dist/src/types/problems';
 
 import { browser } from '../../../../shared/globals';
 
-import { getMessage } from '../../../utils/i18n';
-
 import InspectButton from '../../controls/inspect-button';
 import SourceCode from '../../controls/source-code';
 
@@ -14,10 +12,9 @@ import * as styles from './problem.css';
 
 type Props = {
     problem: ProblemData;
-    index: number;
 };
 
-const Problem = ({ problem, index }: Props) => {
+const Problem = ({ problem }: Props) => {
     const { line, column, elementId } = problem.location;
     const url = `${problem.resource}${line > -1 ? `:${line + 1}:${column + 1}` : ''}`;
 
@@ -35,14 +32,7 @@ const Problem = ({ problem, index }: Props) => {
     );
 
     return (
-        <div className={styles.root}>
-            <div className={styles.header}>
-                <span className={styles.number}>
-                    {getMessage('hintCountLabel', [(index + 1).toString()])}
-                </span>
-                {' '}
-                {problem.message}
-            </div>
+        <div>
             <a className={styles.problemLink} href={`view-source:${problem.resource}`} target="_blank" onClick={onViewSourceClick}>
                 {url}
             </a>


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Also update layout of related controls to prefer controlling spacing
from parent controls instead of children. This makes child controls
easier to re-use without breaking layout.

- - - - - - - - - -

Fix #2970