### PR TITLE
Chore: Re-enable `no-insecure-cookies` tests on `puppeteer`

### DIFF
--- a/packages/hint-validate-set-cookie-header/tests/tests.ts
+++ b/packages/hint-validate-set-cookie-header/tests/tests.ts
@@ -194,31 +194,21 @@ const oldAndNewBrowsersTest = [
     }
 ];
 
-testHint(hintPath, defaultTests, {
-    https: true,
-    /*
-     * Tests are skipped in `chrome` due to the absence of 'Set-Cookie' header.
-     * Issue: https://bugs.chromium.org/p/chromium/issues/detail?id=692090.
-     * TODO: Update the tests once the issue above is fixed.
-     */
-    ignoredConnectors: ['puppeteer']
-});
+testHint(hintPath, defaultTests, { https: true });
 
 testHint(hintPath, newBrowserOnlyTests, {
     browserslist: [
         '> 1%',
         'last 2 versions'
     ],
-    https: true,
-    ignoredConnectors: ['puppeteer']
+    https: true
 });
 
 testHint(hintPath, olderBrowserOnlyTests, {
     browserslist: [
         'ie 6', 'ie 7'
     ],
-    https: true,
-    ignoredConnectors: ['puppeteer']
+    https: true
 });
 
 testHint(hintPath, oldAndNewBrowsersTest, {
@@ -226,6 +216,5 @@ testHint(hintPath, oldAndNewBrowsersTest, {
         'ie >= 6',
         'last 2 versions'
     ],
-    https: true,
-    ignoredConnectors: ['chrompuppeteerium']
+    https: true
 });


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- [x] Added/Updated related tests.

## Short description of the change(s)

I tried them on WSL which has headless on by default and tests are passing now: 

![image](https://user-images.githubusercontent.com/606594/65266787-9931c180-dac8-11e9-90a8-3f2b24021a88.png)

Fix #439

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
