### PR TITLE
Fix: Disallow simple names as filesystem paths

### DIFF
--- a/packages/utils/src/packages/load-resource.ts
+++ b/packages/utils/src/packages/load-resource.ts
@@ -174,6 +174,16 @@ const generateConfigPathsToResources = (configurations: string[], name: string, 
 };
 
 /**
+ * Accepts:
+ * * Relative paths (./foo)
+ * * Unix-style absolute paths (/foo)
+ * * Windows-style absolute paths (c:/foo)
+ */
+const isFilesystemPath = (filename: string) => {
+    return filename[0] === '.' || filename[0] === '/' || filename[1] === ':';
+};
+
+/**
  * Looks for a hint resource with the given `name` and tries to load it.
  * If no valid resource is found, it throws an `Error`.
  *
@@ -187,7 +197,7 @@ const generateConfigPathsToResources = (configurations: string[], name: string, 
  */
 export const loadResource = (name: string, type: ResourceType, configurations: string[] = [], verifyVersion = false) => {
     debug(`Searching ${name}…`);
-    const isSource = fs.existsSync(name); // eslint-disable-line no-sync
+    const isSource = isFilesystemPath(name) && fs.existsSync(name); // eslint-disable-line no-sync
     const isPackage = isFullPackageName(name, type);
     const nameParts = name.split('/');
 


### PR DESCRIPTION
Previously names like 'css' could match local folders.
Now relative paths must be written like `./css`.

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
