### PR TITLE
Fix: Load shared webhint when prompting to install locally

### DIFF
--- a/packages/extension-vscode/src/utils/analyze.ts
+++ b/packages/extension-vscode/src/utils/analyze.ts
@@ -45,6 +45,7 @@ export class Analyzer {
             return promptAddWebhint(this.connection.window, async () => {
                 this.connection.sendNotification(notifications.showOutput);
                 await install();
+                this.onConfigurationChanged();
             });
         });
 

--- a/packages/extension-vscode/src/utils/prompts.ts
+++ b/packages/extension-vscode/src/utils/prompts.ts
@@ -23,7 +23,7 @@ export const promptRetry = async <T>(window: RemoteWindow, retry: () => Promise<
     // Prompt the user to retry after checking their configuration.
     const retryTitle = 'Retry';
     const answer = await window.showErrorMessage(
-        'Unable to start webhint. Ensure you are using the latest version of the `hint` and `@hint/configuration-development` packages.',
+        'Unable to start webhint. Ensure you are using the latest version of the `hint` package.',
         { title: retryTitle }
     );
 

--- a/packages/extension-vscode/src/utils/webhint-packages.ts
+++ b/packages/extension-vscode/src/utils/webhint-packages.ts
@@ -1,8 +1,9 @@
 import { hasFile, mkdir } from './fs';
 import { installPackages, loadPackage, InstallOptions } from './packages';
 
+/* istanbul ignore next */
 const installWebhint = (options: InstallOptions) => {
-    return installPackages(['hint', '@hint/configuration-development'], options);
+    return installPackages(['hint'], options);
 };
 
 /**

--- a/packages/extension-vscode/src/utils/webhint-packages.ts
+++ b/packages/extension-vscode/src/utils/webhint-packages.ts
@@ -52,7 +52,7 @@ export const loadWebhint = async (directory: string, globalStoragePath: string, 
     try {
         return loadPackage('hint', { paths: [directory] });
     } catch (e) {
-        if (promptToInstall && await hasFile('.hintrc', directory)) {
+        if (await hasFile('.hintrc', directory)) {
             /**
              * Prompt to install, but don't wait in case the user ignores.
              * Load the shared copy for now until the install is done.

--- a/packages/extension-vscode/src/utils/webhint-packages.ts
+++ b/packages/extension-vscode/src/utils/webhint-packages.ts
@@ -47,16 +47,19 @@ const loadSharedWebhint = async (globalStoragePath: string): Promise<typeof impo
  * Load webhint, installing it if needed.
  * Will prompt to install a local copy if `.hintrc` is present.
  */
-export const loadWebhint = async (directory: string, globalStoragePath: string, promptToInstall?: (install: () => Promise<void>) => Promise<void>): Promise<typeof import('hint') | null> => {
+export const loadWebhint = async (directory: string, globalStoragePath: string, promptToInstall: (install: () => Promise<void>) => Promise<void>): Promise<typeof import('hint') | null> => {
     try {
         return loadPackage('hint', { paths: [directory] });
     } catch (e) {
         if (promptToInstall && await hasFile('.hintrc', directory)) {
-            await promptToInstall(async () => {
+            /**
+             * Prompt to install, but don't wait in case the user ignores.
+             * Load the shared copy for now until the install is done.
+             * Caller is expected to reload once install is complete.
+             */
+            promptToInstall(async () => {
                 await installWebhint({ cwd: directory });
             });
-
-            return loadWebhint(directory, globalStoragePath);
         }
 
         return loadSharedWebhint(globalStoragePath);

--- a/packages/extension-vscode/tests/utils/webhint-packages.ts
+++ b/packages/extension-vscode/tests/utils/webhint-packages.ts
@@ -1,0 +1,56 @@
+import test from 'ava';
+import * as proxyquire from 'proxyquire';
+import * as sinon from 'sinon';
+
+const stubContext = () => {
+    const stubs = {
+        './fs': {
+            '@noCallThru': true,
+            hasFile() {
+                return Promise.resolve(true);
+            }
+        },
+        './packages': {
+            '@noCallThru': true,
+            loadPackage(name: string, opts: any) {
+                if (name !== 'hint' || !opts.paths || opts.paths[0] !== 'global') {
+                    throw new Error('Not found');
+                }
+
+                return Promise.resolve('webhint');
+            }
+        } as Partial<typeof import('../../src/utils/packages')>
+    };
+
+    const module = proxyquire('../../src/utils/webhint-packages', stubs) as typeof import('../../src/utils/webhint-packages');
+
+    return { module, stubs };
+};
+
+test('It loads shared webhint when prompting to install a local copy', async (t) => {
+    const sandbox = sinon.createSandbox();
+    const { module, stubs } = stubContext();
+    const loadPackageSpy = sandbox.spy(stubs['./packages'], 'loadPackage');
+
+    let promptCalled = false;
+    let promptComplete = false;
+
+    const hint = await module.loadWebhint('local', 'global', async () => {
+        promptCalled = true;
+
+        await new Promise((resolve) => {
+            setTimeout(resolve, 0);
+        });
+
+        promptComplete = true;
+    });
+
+    t.is(hint as any, 'webhint');
+    t.true(promptCalled);
+    t.false(promptComplete);
+    t.true(loadPackageSpy.calledTwice);
+    t.deepEqual(loadPackageSpy.firstCall.args[0], 'hint');
+    t.deepEqual(loadPackageSpy.firstCall.args[1], { paths: ['local'] });
+    t.deepEqual(loadPackageSpy.secondCall.args[0], 'hint');
+    t.deepEqual(loadPackageSpy.secondCall.args[1], { paths: ['global'] });
+});


### PR DESCRIPTION
Previously a prompt to install to a project would delay
loading any copy of webhint until the user responded,
causing the experience to feel broken once the
notification was automatically hidden.

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Opening as a draft while I finish adding tests.