### PR TITLE
Fix: Avoid duplicate reports in nested blocks

### DIFF
--- a/packages/hint-css-prefix-order/package.json
+++ b/packages/hint-css-prefix-order/package.json
@@ -13,6 +13,7 @@
   "description": "Ensure vendor-prefixed versions of a CSS property are listed before the unprefixed version.",
   "devDependencies": {
     "@hint/parser-css": "^3.0.12",
+    "@hint/parser-sass": "^1.0.4",
     "@hint/utils-tests-helpers": "^5.0.10",
     "@types/debug": "^4.1.5",
     "@types/node": "^12.7.5",

--- a/packages/hint-css-prefix-order/src/hint.ts
+++ b/packages/hint-css-prefix-order/src/hint.ts
@@ -67,7 +67,11 @@ const validatePair = (pair: Partial<DeclarationPair>): boolean => {
 const validateRule = (rule: Rule): DeclarationPair[] => {
     const map = new Map<string, Partial<DeclarationPair>>();
 
-    rule.walkDecls((decl) => {
+    rule.each((decl) => {
+        if (!('prop' in decl)) {
+            return;
+        }
+
         const name = decl.prop;
         const baseName = vendor.unprefixed(name);
 

--- a/packages/hint-css-prefix-order/tests/fixtures/prefixes-nested-blocks.scss
+++ b/packages/hint-css-prefix-order/tests/fixtures/prefixes-nested-blocks.scss
@@ -1,0 +1,6 @@
+.parent {
+    .example {
+        appearance: none; /* Report */
+        -webkit-appearance: none;
+    }
+}

--- a/packages/hint-css-prefix-order/tests/tests.ts
+++ b/packages/hint-css-prefix-order/tests/tests.ts
@@ -10,6 +10,18 @@ const generateConfig = (fileName: string) => {
         return readFile(`${__dirname}/fixtures/${fileName}`);
     }
 
+    if (fileName.endsWith('.scss')) {
+        const styles = readFile(`${__dirname}/fixtures/${fileName}`);
+
+        return {
+            '/': generateHTMLPage(`<link rel="stylesheet" href="styles/${fileName}">`),
+            [`/styles/${fileName}`]: {
+                content: styles,
+                headers: { 'Content-Type': 'text/x-scss' }
+            }
+        };
+    }
+
     const styles = readFile(`${__dirname}/fixtures/${fileName}.css`);
 
     return {
@@ -147,7 +159,15 @@ const tests: HintTest[] = [
     {
         name: `Unprefixed property without any prefixed properties pass`,
         serverConfig: generateConfig('unprefixed-only')
+    },
+    {
+        name: 'Prefixed properties in nested blocks only report once',
+        reports: [{
+            message: `'appearance' should be listed after '-webkit-appearance'.`,
+            position: { match: 'appearance: none' }
+        }],
+        serverConfig: generateConfig('prefixes-nested-blocks.scss')
     }
 ];
 
-testHint(hintPath, tests, { parsers: ['css'] });
+testHint(hintPath, tests, { parsers: ['css', 'sass'] });


### PR DESCRIPTION
Fix #3037

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
