### PR TITLE
severityThreshold + respect user's configuration

### DIFF
--- a/packages/extension-vscode/src/utils/problems.ts
+++ b/packages/extension-vscode/src/utils/problems.ts
@@ -5,10 +5,14 @@ import { Problem, Severity } from 'hint';
 // Translate a webhint severity into the VSCode DiagnosticSeverity format.
 const webhintToDiagnosticServerity = (severity: Severity): DiagnosticSeverity => {
     switch (severity) {
-        case 2:
+        case 4:
             return DiagnosticSeverity.Error;
-        case 1:
+        case 3:
             return DiagnosticSeverity.Warning;
+        case 2:
+            return DiagnosticSeverity.Information;
+        case 1:
+            return DiagnosticSeverity.Hint;
         default:
             return DiagnosticSeverity.Hint;
     }

--- a/packages/hint/src/lib/cli/analyze.ts
+++ b/packages/hint/src/lib/cli/analyze.ts
@@ -404,10 +404,16 @@ export default async (actions: CLIOptions): Promise<boolean> => {
         }
     };
 
-    const hasError = (reports: Problem[]): boolean => {
-        return reports.some((result: Problem) => {
-            return result.severity === Severity.error;
-        });
+    const hasIssues = (reports: Problem[]): boolean => {
+        const threshold = userConfig.severityThreshold || Severity.error;
+
+        for (const result of reports) {
+            if (result.severity >= threshold) {
+                return true;
+            }
+        }
+
+        return false;
     };
 
     const print = async (reports: Problem[], target?: string, scanTime?: number, date?: string): Promise<void> => {
@@ -447,7 +453,7 @@ export default async (actions: CLIOptions): Promise<boolean> => {
             const scanEnd = Date.now();
             const start = scanStart.get(end.url) || 0;
 
-            if (hasError(end.problems)) {
+            if (hasIssues(end.problems)) {
                 exitCode = 1;
             }
 

--- a/packages/hint/src/lib/config/config-hints.ts
+++ b/packages/hint/src/lib/config/config-hints.ts
@@ -39,7 +39,7 @@ export const getSeverity = (config: HintConfig | HintConfig[]): Severity | null 
         configuredSeverity = getSeverity(config[0]);
     }
 
-    if (configuredSeverity !== null && configuredSeverity >= 0 && configuredSeverity <= 2) {
+    if (configuredSeverity !== null && configuredSeverity >= 0 && configuredSeverity <= 4) {
         return configuredSeverity;
     }
 

--- a/packages/hint/src/lib/config/config-schema.json
+++ b/packages/hint/src/lib/config/config-schema.json
@@ -3,7 +3,68 @@
     "title": "Configuration",
     "description": "A configuration file for hint",
     "type": "object",
-    "properties": {
+    "definitions": {
+        "errorlevelstring": {
+            "type": "string",
+            "enum": [
+                "off",
+                "hint",
+                "information",
+                "warning",
+                "error"
+            ]
+        },
+        "errorlevelnumber": {
+            "type": "number",
+            "enum": [
+                0,
+                1,
+                2,
+                3,
+                4
+            ]
+        },
+        "hintconfig": {
+            "type": "array",
+            "items": [
+                {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/errorlevelstring"
+                        },
+                        {
+                            "$ref": "#/definitions/errorlevelnumber"
+                        }
+                    ]
+                },
+                {
+                    "type": "object"
+                }
+            ],
+            "maxItems": 2,
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "hintobject": {
+            "type": "object",
+            "patternProperties": {
+                "^.+$": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/errorlevelstring"
+                        },
+                        {
+                            "$ref": "#/definitions/errorlevelnumber"
+                        },
+                        {
+                            "$ref": "#/definitions/hintconfig"
+                        }
+                    ]
+                }
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
         "connector": {
             "description": "The connector to use to gather information",
             "anyOf": [
@@ -133,6 +194,41 @@
         "language": {
             "description": "Localization language",
             "type": "string"
+        },
+        "severityThreshold": {
+            "$ref": "#/definitions/errorlevelstring"
+        }
+    },
+    "properties": {
+        "connector": {
+            "$ref": "#/definitions/connector"
+        },
+        "extends": {
+            "$ref": "#/definitions/extends"
+        },
+        "parsers": {
+            "$ref": "#/definitions/parsers"
+        },
+        "formatters": {
+            "$ref": "#/definitions/formatters"
+        },
+        "hintsTimeout": {
+            "$ref": "#/definitions/hintsTimeout"
+        },
+        "hints": {
+            "$ref": "#/definitions/hints"
+        },
+        "browserslist": {
+            "$ref": "#/definitions/browserslist"
+        },
+        "ignoredUrls": {
+            "$ref": "#/definitions/ignoredUrls"
+        },
+        "language": {
+            "$ref": "#/definitions/language"
+        },
+        "severityThreshold": {
+            "$ref": "#/definitions/severityThreshold"
         }
     },
     "anyOf": [
@@ -148,64 +244,5 @@
             ]
         }
     ],
-    "additionalProperties": false,
-    "definitions": {
-        "errorlevelstring": {
-            "type": "string",
-            "enum": [
-                "off",
-                "warning",
-                "error"
-            ]
-        },
-        "errorlevelnumber": {
-            "type": "number",
-            "enum": [
-                0,
-                1,
-                2
-            ]
-        },
-        "hintconfig": {
-            "type": "array",
-            "items": [
-                {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/errorlevelstring"
-                        },
-                        {
-                            "$ref": "#/definitions/errorlevelnumber"
-                        }
-                    ]
-                },
-                {
-                    "type": "object"
-                }
-            ],
-            "maxItems": 2,
-            "minItems": 1,
-            "uniqueItems": true
-        },
-        "hintobject": {
-            "type": "object",
-            "patternProperties": {
-                "^.+$": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/errorlevelstring"
-                        },
-                        {
-                            "$ref": "#/definitions/errorlevelnumber"
-                        },
-                        {
-                            "$ref": "#/definitions/hintconfig"
-                        }
-                    ]
-                }
-            },
-            "minItems": 1,
-            "uniqueItems": true
-        }
-    }
+    "additionalProperties": false
 }

--- a/packages/hint/src/lib/hint-context.ts
+++ b/packages/hint/src/lib/hint-context.ts
@@ -33,7 +33,7 @@ export type ReportOptions = {
      * If specified with `element`, represents an offset in the element's content (e.g. for inline CSS in HTML).
      */
     location?: ProblemLocation | null;
-    /** The `Severity` to report the issue as (overrides default settings for a hint). */
+    /** The `Severity` to report the issue as. */
     severity?: Severity;
     /** Indicate the language of the codeSnippet. */
     codeLanguage?: CodeLanguage;
@@ -125,7 +125,7 @@ export class HintContext<E extends Events = Events> {
 
     /** Reports a problem with the resource. */
     public report(resource: string, message: string, options: ReportOptions = {}) {
-        const { codeSnippet, element, severity } = options;
+        const { codeSnippet, element, severity = Severity.warning } = options;
         let sourceCode: string | null = null;
         let position = options.location || null;
 
@@ -147,7 +147,7 @@ export class HintContext<E extends Events = Events> {
             location: position || { column: -1, line: -1 },
             message,
             resource,
-            severity: severity || this.severity,
+            severity: this.severity || severity,
             sourceCode: codeSnippet || sourceCode || ''
         });
     }

--- a/packages/hint/tests/lib/config/config-hints.ts
+++ b/packages/hint/tests/lib/config/config-hints.ts
@@ -61,8 +61,10 @@ class HintWithSchema implements IHint {
 test('getSeverity with an string should return the right value', (t) => {
     const data = new Map([
         ['off', 0],
-        ['warning', 1],
-        ['error', 2],
+        ['hint', 1],
+        ['information', 2],
+        ['warning', 3],
+        ['error', 4],
         ['invalid', null],
         ['', null]
     ]);
@@ -79,7 +81,8 @@ test('getSeverity with a number should return the right value', (t) => {
         [0, 0],
         [1, 1],
         [2, 2],
-        [3, null],
+        [3, 3],
+        [4, 4],
         [-1, null]
     ]);
 
@@ -93,13 +96,16 @@ test('getSeverity with a number should return the right value', (t) => {
 test('getSeverity with an array should return the right value', (t) => {
     const data: Map<HintConfig, number | null> = new Map([
         [(['off', {}] as HintConfig), 0],
-        [(['warning', {}] as HintConfig), 1],
-        [(['error', {}] as HintConfig), 2],
+        [(['hint', {}] as HintConfig), 1],
+        [(['information', {}] as HintConfig), 2],
+        [(['warning', {}] as HintConfig), 3],
+        [(['error', {}] as HintConfig), 4],
         [(['invalid' as any, {}] as HintConfig), null],
         [([0, {}] as HintConfig), 0],
         [([1, {}] as HintConfig), 1],
         [([2, {}] as HintConfig), 2],
-        [([3, {}] as HintConfig), null],
+        [([3, {}] as HintConfig), 3],
+        [([4, {}] as HintConfig), 4],
         [([-1, {}] as HintConfig), null]
     ]);
 

--- a/packages/utils/src/types/config.ts
+++ b/packages/utils/src/types/config.ts
@@ -57,4 +57,5 @@ export type UserConfig = {
     ignoredUrls?: IgnoredUrl[];
     language?: string;
     parsers?: string[];
+    severityThreshold?: HintSeverity;
 };

--- a/packages/utils/src/types/problems.ts
+++ b/packages/utils/src/types/problems.ts
@@ -6,8 +6,10 @@ export { ProblemLocation };
 /** The severity configuration of a hint */
 export enum Severity {
     off = 0,
-    warning = 1,
-    error = 2
+    hint = 1,
+    information = 2,
+    warning = 3,
+    error = 4
 }
 
 /** A problem found by a hint  */


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

It turns out that the new proposed format is kind of already supported but not documented.

We can use the shorthand version to declare hints:

```json
{
  "hints": [
    "hint-a",
    "hint-b",
    ["hint-a", { "config": "a" }]
  ]
}
```

On top of that we also have the option to prefix the hint with `-` to disable it (e.g. `-hint-a`), as well as `hint-a:off`. 

The option of `on|off` is still not implemented and right now I'm not sure we should with all the other options we have already supported. I'm thinking we should just remove some of the options (such as `hint-a:warn`, but keep `hint-a:off`) when we are ready for a breaking change.

This PR also: 

* adds the `information` and `hint` severity levels that match the ones in VS Code. 
* adds `severityThreshold` to the schema to let the user decide when the exit code should be different than 0
* makes sure that the user severity configuration per hint is respected. The reason to do this is so we can start adding the new severity to the reports without being a breaking change. If we follow this the only breaking change should be the configuration.

I haven't added any documentation yet because I wanted your feedback about this approach so please let me know :)



<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
