### PR TITLE
Chore: Shadow styles as CSS variables in extension

### DIFF
--- a/packages/extension-browser/src/devtools/views/app.base.css
+++ b/packages/extension-browser/src/devtools/views/app.base.css
@@ -104,8 +104,8 @@
 .root[data-theme='dark']::-webkit-scrollbar-thumb {
     border-radius: 0.125rem;
     background-color: var(--button-bg);
-    box-shadow: inset 0 0 1px var(--shadow-color);
+    box-shadow: var(--scrollbar-shadow);
 }
 .root[data-theme='dark']::-webkit-scrollbar-track {
-    box-shadow: inset 0 0 1px var(--shadow-color);
+    box-shadow: var(--scrollbar-shadow);
 }

--- a/packages/extension-browser/src/devtools/views/app.fluent.css
+++ b/packages/extension-browser/src/devtools/views/app.fluent.css
@@ -25,6 +25,9 @@
     --status-bg-warn: #f2c811;
 
     --shadow-color: #00000080;
+    --scrollbar-shadow: inset 0 0 1px var(--shadow-color);
+    --code-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.18), 0px 1.6px 3.6px rgba(0, 0, 0, 0.22);
+    --analyze-shadow: 0 4.8px 14.4px rgba(0, 0, 0, 0.18), 0 25.6px 57.6px rgba(0, 0, 0, 0.22);
 
     --text-bg: var(--base-bg);
 

--- a/packages/extension-browser/src/devtools/views/app.photon.css
+++ b/packages/extension-browser/src/devtools/views/app.photon.css
@@ -25,6 +25,9 @@
     --status-bg-warn: #f2c811;
 
     --shadow-color: #00000080;
+    --scrollbar-shadow: inset 0 0 1px var(--shadow-color);
+    --code-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.18), 0px 1.6px 3.6px rgba(0, 0, 0, 0.22);
+    --analyze-shadow: 0 4.8px 14.4px rgba(0, 0, 0, 0.18), 0 25.6px 57.6px rgba(0, 0, 0, 0.22);
 
     /* Category icons */
     --icon-accessibility-url: url(../../images/icon-accessibility.svg);

--- a/packages/extension-browser/src/devtools/views/controls/source-code.css
+++ b/packages/extension-browser/src/devtools/views/controls/source-code.css
@@ -2,7 +2,7 @@
     display: block;
     background-color: var(--code-bg) !important;
     border-radius: var(--rounding);
-    box-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.18), 0px 1.6px 3.6px rgba(0, 0, 0, 0.22);
+    box-shadow: var(--code-shadow);
     box-sizing: border-box;
     color: var(--code-default-color);
     font-size: 12px; /* rem units are incorrect here at runtime?!? */

--- a/packages/extension-browser/src/devtools/views/pages/analyze.css
+++ b/packages/extension-browser/src/devtools/views/pages/analyze.css
@@ -13,7 +13,7 @@
 .status {
     background-color: var(--base-bg);
     border-radius: calc(2 * var(--rounding));
-    box-shadow: 0 4.8px 14.4px rgba(0, 0, 0, 0.18), 0 25.6px 57.6px rgba(0, 0, 0, 0.22);
+    box-shadow: var(--analyze-shadow);
     box-sizing: border-box;
     display: grid;
     gap: 1rem; /* 16px */


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
Shadow styles used in the extension are defined as CSS variables in `app.fluent.css` and `app.photon.css`
