### PR TITLE
New: Add support for JSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,10 @@
   },
   "workspaces": {
     "nohoist": [
+      "**/acorn",
+      "**/acorn-jsx",
+      "**/acorn-jsx-walk",
+      "**/acorn-walk",
       "**/vscode",
       "**/vscode-languageclient",
       "**/vscode-languageserver"

--- a/packages/configuration-development/index.json
+++ b/packages/configuration-development/index.json
@@ -43,6 +43,8 @@
         "babel-config",
         "css",
         "html",
+        "javascript",
+        "jsx",
         "less",
         "sass",
         "typescript-config",

--- a/packages/configuration-development/package.json
+++ b/packages/configuration-development/package.json
@@ -23,6 +23,8 @@
     "@hint/parser-babel-config": "^2.1.13",
     "@hint/parser-css": "^3.0.13",
     "@hint/parser-html": "^3.0.10",
+    "@hint/parser-javascript": "^3.0.13",
+    "@hint/parser-jsx": "^1.0.0",
     "@hint/parser-less": "^1.0.5",
     "@hint/parser-sass": "^1.0.5",
     "@hint/parser-typescript-config": "^2.3.10",

--- a/packages/extension-browser/src/shims/acorn-jsx-walk.ts
+++ b/packages/extension-browser/src/shims/acorn-jsx-walk.ts
@@ -1,0 +1,1 @@
+export const extend = () => {};

--- a/packages/extension-browser/src/shims/acorn-jsx.ts
+++ b/packages/extension-browser/src/shims/acorn-jsx.ts
@@ -1,0 +1,1 @@
+export = null;

--- a/packages/extension-browser/webpack.config.js
+++ b/packages/extension-browser/webpack.config.js
@@ -85,6 +85,8 @@ module.exports = (env) => {
                 './i18n/get-message$': path.resolve(__dirname, 'dist/src/shims/get-message.js'),
                 '@hint/utils/dist/src/i18n/get-message$': path.resolve(__dirname, 'dist/src/shims/get-message.js'),
                 '@hint/utils/dist/src/network/request-async$': path.resolve(__dirname, 'dist/src/shims/request-async.js'),
+                'acorn-jsx$': path.resolve(__dirname, 'dist/src/shims/acorn-jsx.js'),
+                'acorn-jsx-walk$': path.resolve(__dirname, 'dist/src/shims/acorn-jsx-walk.js'),
                 'axe-core': require.resolve('axe-core/axe.min.js'),
                 url$: path.resolve(__dirname, 'dist/src/shims/url.js')
             }

--- a/packages/extension-vscode/package.json
+++ b/packages/extension-vscode/package.json
@@ -3,6 +3,7 @@
     "onLanguage:css",
     "onLanguage:html",
     "onLanguage:javascript",
+    "onLanguage:javascriptreact",
     "onLanguage:json",
     "onLanguage:jsonc",
     "onLanguage:less",

--- a/packages/parser-javascript/package.json
+++ b/packages/parser-javascript/package.json
@@ -8,13 +8,15 @@
   },
   "dependencies": {
     "@hint/utils": "^6.0.0",
+    "@types/estree-jsx": "^0.0.0",
     "acorn": "^7.1.0",
+    "acorn-jsx": "^5.0.2",
+    "acorn-jsx-walk": "^2.0.0",
     "acorn-walk": "^7.0.0"
   },
   "description": "webhint parser needed to analyze JavaScript files",
   "devDependencies": {
     "@types/acorn": "^4.0.5",
-    "@types/estree": "^0.0.39",
     "@types/node": "^12.7.5",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.0.13",

--- a/packages/parser-javascript/src/parser.ts
+++ b/packages/parser-javascript/src/parser.ts
@@ -1,229 +1,71 @@
-import { Options, parse, tokenizer } from 'acorn';
-import * as acornWalk from 'acorn-walk';
-import * as ESTree from 'estree';
+import { Options, Parser } from 'acorn';
+import { Node } from 'estree-jsx';
 
+import { debug as d } from '@hint/utils/dist/src/debug';
 import { HTMLElement } from '@hint/utils/dist/src/dom';
-import * as logger from '@hint/utils/dist/src/logging';
 import { determineMediaTypeForScript } from '@hint/utils/dist/src/content-type';
 import { ElementFound, FetchEnd, Parser as WebhintParser } from 'hint/dist/src/lib/types';
 import { Engine } from 'hint/dist/src/lib/engine';
 
-import { ScriptEvents, Walk, NodeVisitor } from './types';
+import { ScriptEvents } from './types';
+import { combineWalk } from './walk';
 
 export * from './types';
 
-type Key = {
-    node: ESTree.Node;
-    base?: NodeVisitor;
-    state?: any;
-};
-
-/**
- * A WalkArray is a pair of Key and a Map with
- * all the callbacks (for methods full and fullAncestor)
- * or all the NodeVisitor (for methods simple and ancestor) for that Key.
- *
- * The key is the same if the root node, the base and the state
- * you call walk.(simple|ancestor|full|fullAncestor) is the same.
- *
- * In case of method used is `full` or `fullAncestor`, the map will
- * have an only key `callbacks`.
- */
-type WalkArray = Array<[Key, Map<keyof NodeVisitor | 'callbacks', Function[]>]>;
+const debug = d(__filename);
+const jsx = require('acorn-jsx');
+const jsParser = Parser.extend();
+const jsxParser = jsx ? Parser.extend(jsx()) : Parser.extend();
 
 export default class JavascriptParser extends WebhintParser<ScriptEvents> {
     public constructor(engine: Engine<ScriptEvents>) {
         super(engine, 'javascript');
 
         engine.on('fetch::end::script', this.parseJavascript.bind(this));
+        engine.on('fetch::end::unknown', this.onFetchUnknown.bind(this));
         engine.on('element::script', this.parseJavascriptTag.bind(this));
     }
 
-    private getCurrentVisitorsOrCallback(walkArray: WalkArray, node: ESTree.Node, base?: NodeVisitor, state?: any) {
-        const item = walkArray.find(([key]) => {
-            return key.node === node && key.base === base && key.state === state;
-        });
-
-        return item ? item[1] : null;
-    }
-
-    private async emitScript(sourceCode: string, resource: string, element: HTMLElement | null) {
+    private async emitScript(parser: typeof Parser, sourceCode: string, resource: string, element: HTMLElement | null) {
         try {
             await this.engine.emitAsync(`parse::start::javascript`, { resource });
 
-            const options: Options = { locations: true };
-            const ast = parse(sourceCode, options) as ESTree.Node;
-            const tokens = [...tokenizer(sourceCode, options)];
-            const defaultCallbacksProperty = 'callbacks';
+            const options: Options = { locations: true, ranges: true };
+            const ast = parser.parse(sourceCode, options) as Node;
+            const tokens = [...parser.tokenizer(sourceCode, options)];
 
-            // Store a WalkArray for each method supported.
-            const walkArrays: { [key in keyof Walk]: WalkArray } = {
-                ancestor: [],
-                full: [],
-                fullAncestor: [],
-                simple: []
-            };
-
-            /**
-             * Create a method that will create a WalkArray for a walk method (simple, full, etc.).
-             */
-            const getWalkAccumulator = <K extends keyof Walk>(methodName: K): Walk[K] => {
-                if (!walkArrays[methodName]) {
-                    walkArrays[methodName] = [];
-                }
-
-                /**
-                 * Every time a hint calls to walk.(simple|ancestor|full|fullAncestor), it is going to
-                 * execute this method, storing in a WalkArray object all the NodeVistors or Callbacks
-                 * the hints are defining for the walk method.
-                 *
-                 * This will allow later generate our custom NodeVisitor(s) or callback to call the
-                 * real `acorn-walk` method, so we just need to walk once for each Key (node + base + state)
-                 * and method.
-                 *
-                 * E.g:
-                 * For the script1.js
-                 *
-                 * hint 1: call to walk.simple(ast, {
-                 *     CallExpression(node) { // this is a NodeVisitor
-                 *         // any code here
-                 *     }
-                 * });
-                 *
-                 * hint 2: call to walk.simple(ast, {
-                 *     CallExpression(node) { // This is a NodeVisitor
-                 *         // any other code here
-                 *     }
-                 * });
-                 *
-                 * hint 3: call to walk.simple(ast, {
-                 *     Literal(node) { // This is a NodeVisitor
-                 *         // any code for Literal.
-                 *     }
-                 * });
-                 *
-                 * hint 4: call to walk.full(ast, (node) => {
-                 *   // Callback code here.
-                 * });
-                 *
-                 * These hints will create two WalkArray, one for the method `simple` and another one
-                 * for the method `full`.
-                 *
-                 * The WalkArray object for `simple` will have a map with 2 entries, the key of the first entry
-                 * will be `CallExpression` and the content for that entry will be an array with 2 NodeVisitors,
-                 * one from `hint 1`, and another from the `hint 2`. The key for the second entry will be `Literal`
-                 * and the content for that entry will be an array with 1 NodeVisitor the one from `hint 3`
-                 *
-                 * The WalkArray object for `full` will hava a map with 1 entry, the key of that entry will
-                 * be `callbacks`, and the content for that entry will be an array with 1 function. That function
-                 * is the function defined in `hint 4`
-                 */
-                return (node: ESTree.Node, visitorsOrCallback: NodeVisitor | Function, base?: NodeVisitor, state?: any) => {
-                    let currentVisitors = this.getCurrentVisitorsOrCallback(walkArrays[methodName], node, base, state);
-
-                    if (!currentVisitors) {
-                        currentVisitors = new Map();
-                        walkArrays[methodName].push([{ base, node, state }, currentVisitors]);
-                    }
-
-                    if (typeof visitorsOrCallback === 'function') {
-                        // `full` and `fullAncestor` only track an array of callbacks.
-                        const name = defaultCallbacksProperty;
-                        const visitorCallbacks = currentVisitors.get(name) || [];
-
-                        visitorCallbacks.push(visitorsOrCallback);
-                        currentVisitors.set(name, visitorCallbacks);
-
-                        return;
-                    }
-
-                    for (const [name, callback] of Object.entries(visitorsOrCallback)) {
-                        // `ancestor` and `simple` track an array of NodeVisitors.
-                        const mapName = name as keyof NodeVisitor;
-                        const visitorCallbacks = currentVisitors.get(mapName) || [];
-
-                        visitorCallbacks.push(callback!);
-                        currentVisitors.set(mapName, visitorCallbacks);
-                    }
-                };
-            };
-
-            const walk: Walk = {
-                ancestor: getWalkAccumulator('ancestor'),
-                full: getWalkAccumulator('full'),
-                fullAncestor: getWalkAccumulator('fullAncestor'),
-                simple: getWalkAccumulator('simple')
-            };
-
-            await this.engine.emitAsync(`parse::end::javascript`, {
-                ast,
-                element,
-                resource,
-                sourceCode,
-                tokens,
-                walk
-            });
-
-            /**
-             * After all the hints have registered their NodeVisitor or callback,
-             * it is time to generate a single NodeVisitor for each different
-             * NodeVisitor registered by the hints and execute the real walk.
-             *
-             * Continuing with the previous example, this code will execute:
-             *
-             * acornWalk.simple(ast, {
-             *     CallExpresion(node) {
-             *         // code from CallExpression in hint 1
-             *         // code from CallExpression in hint 2
-             *     },
-             *     Literal(node) {
-             *         // code from Literal in hint 3
-             *     }
-             * });
-             *
-             * acornWalk.full(ast, (node) => {
-             *     // code from callback in hint 4
-             * });
-             */
-            Object.entries(walkArrays).forEach(([methodName, walkArray]) => {
-                walkArray.forEach(([{ node, state, base }, visitors]) => {
-                    let allVisitors: NodeVisitor | Function = {};
-
-                    if (visitors.has(defaultCallbacksProperty)) {
-                        // `full` and `fullAncestor` only track an array of callbacks.
-                        const callbacks = visitors.get(defaultCallbacksProperty)!;
-
-                        /* istanbul ignore next */
-                        allVisitors = (callbackNode: ESTree.Node, callbackState: any, typeOrAncestors: string | ESTree.Node[]) => {
-                            callbacks.forEach((callback: Function) => {
-                                callback(callbackNode, callbackState, typeOrAncestors);
-                            });
-                        };
-                    } else {
-                        // `ancestor` and `simple` track an array of NodeVisitors which need merged.
-                        for (const [name, callbacks] of visitors) {
-                            /* istanbul ignore next */
-                            (allVisitors as any)[name] = (callbackNode: ESTree.Expression, ancestors?: ESTree.Node[]) => {
-                                callbacks.forEach((callback: Function) => {
-                                    callback(callbackNode, ancestors);
-                                });
-                            };
-                        }
-                    }
-
-                    acornWalk[methodName](node, allVisitors, base, state);
+            await combineWalk(async (walk) => {
+                await this.engine.emitAsync(`parse::end::javascript`, {
+                    ast,
+                    element,
+                    resource,
+                    sourceCode,
+                    tokens,
+                    walk
                 });
             });
+
         } catch (err) {
-            logger.error(`Error parsing JS code: ${sourceCode}`);
+            debug(`Error parsing JS code (${err}): ${sourceCode}`);
         }
+    }
+
+    private async onFetchUnknown(fetchEnd: FetchEnd) {
+        if (fetchEnd.response.mediaType !== 'text/jsx') {
+            return;
+        }
+
+        const code = fetchEnd.response.body.content;
+        const resource = fetchEnd.resource;
+
+        await this.emitScript(jsxParser, code, resource, null);
     }
 
     private async parseJavascript(fetchEnd: FetchEnd) {
         const code = fetchEnd.response.body.content;
         const resource = fetchEnd.resource;
 
-        await this.emitScript(code, resource, null);
+        await this.emitScript(jsParser, code, resource, null);
     }
 
     private hasSrcAttribute(element: HTMLElement) {
@@ -250,6 +92,6 @@ export default class JavascriptParser extends WebhintParser<ScriptEvents> {
             return;
         }
 
-        await this.emitScript(element.innerHTML, resource, element);
+        await this.emitScript(jsParser, element.innerHTML, resource, element);
     }
 }

--- a/packages/parser-javascript/src/types.ts
+++ b/packages/parser-javascript/src/types.ts
@@ -1,8 +1,10 @@
 import { Token } from 'acorn';
-import { Node } from 'estree';
+import { Node } from 'estree-jsx';
 
 import { HTMLElement } from '@hint/utils/dist/src/dom/html';
 import { Event, Events } from 'hint/dist/src/lib/types/events';
+
+export * from 'estree-jsx';
 
 /** All possible values for the Node `type` property. */
 type NodeTypes = Node['type'];
@@ -36,8 +38,10 @@ type NodeTypeForValue<N, T> = N extends { type: T } ? N : never;
  */
 export type NodeVisitor = { [T in NodeTypes]?: (node: NodeTypeForValue<Node, T>, ancestors?: Node[]) => void };
 
+export type WalkCompleteListener = () => Promise<void> | void;
+
 // TODO: Define types for all `acorn-walk` helpers and use them instead.
-export type Walk = {
+export type WalkMethods = {
     /**
      * Does a 'simple' walk over a tree. `node` should be the AST node to walk,
      * and `visitors` an object with properties whose names correspond to node
@@ -56,6 +60,17 @@ export type Walk = {
     full(node: Node, callback: (node: Node, state: any, type: string) => void, base?: NodeVisitor, state?: any): void;
     fullAncestor(node: Node, callback: (node: Node, state: any, ancestors: Node[]) => void, base?: NodeVisitor, state?: any): void;
 };
+
+export type WalkEvents = {
+    /**
+     * Register a callback to execute once the walks have actually been performed.
+     * Necessary because walks are performed slightly delayed so they can be
+     * batched across multiple listeners for performance.
+     */
+    onComplete: (listener: WalkCompleteListener) => void;
+};
+
+export type Walk = WalkMethods & WalkEvents;
 
 /** The object emitted by the `javascript` parser */
 export type ScriptParse = Event & {

--- a/packages/parser-javascript/src/walk.ts
+++ b/packages/parser-javascript/src/walk.ts
@@ -1,0 +1,218 @@
+import * as acornWalk from 'acorn-walk';
+import { Node } from 'estree-jsx';
+import { NodeVisitor, Walk, WalkMethods, WalkCompleteListener } from './types';
+
+const { extend } = require('acorn-jsx-walk');
+
+extend(acornWalk.base); // Add `walk` support for JSXElement, etc.
+
+type Key = {
+    node: Node;
+    base?: NodeVisitor;
+    state?: any;
+};
+
+const getCurrentVisitorsOrCallback = (walkArray: WalkArray, node: Node, base?: NodeVisitor, state?: any) => {
+    const item = walkArray.find(([key]) => {
+        return key.node === node && key.base === base && key.state === state;
+    });
+
+    return item ? item[1] : null;
+};
+
+/**
+ * A WalkArray is a pair of Key and a Map with
+ * all the callbacks (for methods full and fullAncestor)
+ * or all the NodeVisitor (for methods simple and ancestor) for that Key.
+ *
+ * The key is the same if the root node, the base and the state
+ * you call walk.(simple|ancestor|full|fullAncestor) is the same.
+ *
+ * In case of method used is `full` or `fullAncestor`, the map will
+ * have an only key `callbacks`.
+ */
+type WalkArray = Array<[Key, Map<keyof NodeVisitor | 'callbacks', Function[]>]>;
+type WalkArrays = { [key in keyof WalkMethods]: WalkArray };
+
+const defaultCallbacksProperty = 'callbacks';
+
+
+/**
+ * After all the hints have registered their NodeVisitor or callback,
+ * it is time to generate a single NodeVisitor for each different
+ * NodeVisitor registered by the hints and execute the real walk.
+ *
+ * Continuing with the previous example, this code will execute:
+ *
+ * acornWalk.simple(ast, {
+ *     CallExpresion(node) {
+ *         // code from CallExpression in hint 1
+ *         // code from CallExpression in hint 2
+ *     },
+ *     Literal(node) {
+ *         // code from Literal in hint 3
+ *     }
+ * });
+ *
+ * acornWalk.full(ast, (node) => {
+ *     // code from callback in hint 4
+ * });
+ */
+const performWalk = (walkArrays: WalkArrays) => {
+    Object.entries(walkArrays).forEach(([methodName, walkArray]) => {
+        walkArray.forEach(([{ node, state, base }, visitors]) => {
+            let allVisitors: NodeVisitor | Function = {};
+
+            if (visitors.has(defaultCallbacksProperty)) {
+                // `full` and `fullAncestor` only track an array of callbacks.
+                const callbacks = visitors.get(defaultCallbacksProperty)!;
+
+                /* istanbul ignore next */
+                allVisitors = (callbackNode: Node, callbackState: any, typeOrAncestors: string | Node[]) => {
+                    callbacks.forEach((callback: Function) => {
+                        callback(callbackNode, callbackState, typeOrAncestors);
+                    });
+                };
+            } else {
+                // `ancestor` and `simple` track an array of NodeVisitors which need merged.
+                for (const [name, callbacks] of visitors) {
+                    /* istanbul ignore next */
+                    (allVisitors as any)[name] = (callbackNode: Node, ancestors?: Node[]) => {
+                        callbacks.forEach((callback: Function) => {
+                            callback(callbackNode, ancestors);
+                        });
+                    };
+                }
+            }
+
+            acornWalk[methodName](node, allVisitors, base, state);
+        });
+    });
+};
+
+const prepareWalk = () => {
+    // Store a WalkArray for each method supported.
+    const walkArrays: WalkArrays = {
+        ancestor: [],
+        full: [],
+        fullAncestor: [],
+        simple: []
+    };
+
+    /**
+     * Create a method that will create a WalkArray for a walk method (simple, full, etc.).
+     */
+    const getWalkAccumulator = <K extends keyof WalkMethods>(methodName: K): WalkMethods[K] => {
+        if (!walkArrays[methodName]) {
+            walkArrays[methodName] = [];
+        }
+
+        /**
+         * Every time a hint calls to walk.(simple|ancestor|full|fullAncestor), it is going to
+         * execute this method, storing in a WalkArray object all the NodeVistors or Callbacks
+         * the hints are defining for the walk method.
+         *
+         * This will allow later generate our custom NodeVisitor(s) or callback to call the
+         * real `acorn-walk` method, so we just need to walk once for each Key (node + base + state)
+         * and method.
+         *
+         * E.g:
+         * For the script1.js
+         *
+         * hint 1: call to walk.simple(ast, {
+         *     CallExpression(node) { // this is a NodeVisitor
+         *         // any code here
+         *     }
+         * });
+         *
+         * hint 2: call to walk.simple(ast, {
+         *     CallExpression(node) { // This is a NodeVisitor
+         *         // any other code here
+         *     }
+         * });
+         *
+         * hint 3: call to walk.simple(ast, {
+         *     Literal(node) { // This is a NodeVisitor
+         *         // any code for Literal.
+         *     }
+         * });
+         *
+         * hint 4: call to walk.full(ast, (node) => {
+         *   // Callback code here.
+         * });
+         *
+         * These hints will create two WalkArray, one for the method `simple` and another one
+         * for the method `full`.
+         *
+         * The WalkArray object for `simple` will have a map with 2 entries, the key of the first entry
+         * will be `CallExpression` and the content for that entry will be an array with 2 NodeVisitors,
+         * one from `hint 1`, and another from the `hint 2`. The key for the second entry will be `Literal`
+         * and the content for that entry will be an array with 1 NodeVisitor the one from `hint 3`
+         *
+         * The WalkArray object for `full` will hava a map with 1 entry, the key of that entry will
+         * be `callbacks`, and the content for that entry will be an array with 1 function. That function
+         * is the function defined in `hint 4`
+         */
+        return (node: Node, visitorsOrCallback: NodeVisitor | Function, base?: NodeVisitor, state?: any) => {
+            let currentVisitors = getCurrentVisitorsOrCallback(walkArrays[methodName], node, base, state);
+
+            if (!currentVisitors) {
+                currentVisitors = new Map();
+                walkArrays[methodName].push([{ base, node, state }, currentVisitors]);
+            }
+
+            if (typeof visitorsOrCallback === 'function') {
+                // `full` and `fullAncestor` only track an array of callbacks.
+                const name = defaultCallbacksProperty;
+                const visitorCallbacks = currentVisitors.get(name) || [];
+
+                visitorCallbacks.push(visitorsOrCallback);
+                currentVisitors.set(name, visitorCallbacks);
+            } else {
+                // `ancestor` and `simple` track an array of NodeVisitors.
+                for (const [name, callback] of Object.entries(visitorsOrCallback)) {
+                    const mapName = name as keyof NodeVisitor;
+                    const visitorCallbacks = currentVisitors.get(mapName) || [];
+
+                    visitorCallbacks.push(callback!);
+                    currentVisitors.set(mapName, visitorCallbacks);
+                }
+            }
+        };
+    };
+
+    const listeners: WalkCompleteListener[] = [];
+    const onComplete = (listener: WalkCompleteListener) => {
+        listeners.push(listener);
+    };
+
+    const walk: Walk = {
+        ancestor: getWalkAccumulator('ancestor'),
+        full: getWalkAccumulator('full'),
+        fullAncestor: getWalkAccumulator('fullAncestor'),
+        onComplete,
+        simple: getWalkAccumulator('simple')
+    };
+
+    return { listeners, walk, walkArrays };
+};
+
+/**
+ * Batch multiple AST `walk.*` calls during a registration period, then execute
+ * them in a single pass of the AST.
+ *
+ * This improves performance by avoiding multiple redundant walks, but requires
+ * registering an `onComplete` callback for consumers which need to
+ * post-process accumulated state after the walk is finished.
+ */
+export const combineWalk = async (register: (walk: Walk) => Promise<void>) => {
+    const { listeners, walk, walkArrays } = prepareWalk();
+
+    await register(walk);
+
+    performWalk(walkArrays);
+
+    await Promise.all(listeners.map((listener) => {
+        return listener();
+    }));
+};

--- a/packages/parser-jsx/.npmrc
+++ b/packages/parser-jsx/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/parser-jsx/LICENSE.txt
+++ b/packages/parser-jsx/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright JS Foundation and other contributors, https://js.foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/parser-jsx/README.md
+++ b/packages/parser-jsx/README.md
@@ -1,0 +1,48 @@
+# JSX (`@hint/parser-jsx`)
+
+The `jsx` parser allows hints to analyze HTML elements from `JSX` files.
+It operates on ASTs received via `parse::end::javascript` events and
+emits the same events as `@hint/parser-html`. This ensures existing hints
+targeting `HTML` files will work without modification.
+
+This package is installed automatically by webhint:
+
+```bash
+npm install hint --save-dev
+```
+
+To use it, activate it via the [`.hintrc`][hintrc] configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "hints": {
+        ...
+    },
+    "parsers": ["javascript", "jsx"],
+    ...
+}
+```
+
+**Note**: The recommended way of running webhint is as a `devDependency` of
+your project.
+
+## Events emitted
+
+This `parser` emits the event `parse::end::html` of type `HTMLParse`
+which has the following information:
+
+* `document`: an `HTMLDocument` object containing the
+  parsed document.
+* `html`: a string containing the generated HTML source code.
+* `resource`: the parsed resource.
+
+And the event `parse::start::html` of type `Event` which has the
+following information:
+
+* `resource`: the resource that is going to be parsed
+
+<!-- Link labels: -->
+
+[hintrc]: https://webhint.io/docs/user-guide/configuring-webhint/summary/

--- a/packages/parser-jsx/package.json
+++ b/packages/parser-jsx/package.json
@@ -1,0 +1,78 @@
+{
+  "ava": {
+    "failFast": false,
+    "files": [
+      "dist/tests/**/*.js"
+    ],
+    "timeout": "1m"
+  },
+  "dependencies": {
+    "@hint/utils": "^6.0.0",
+    "parse5": "^5.1.0",
+    "parse5-htmlparser2-tree-adapter": "^5.1.0"
+  },
+  "description": "webhint parser needed to analyze HTML elements in JSX",
+  "devDependencies": {
+    "@hint/parser-html": "^3.0.10",
+    "@hint/parser-javascript": "^3.0.13",
+    "@types/node": "^12.7.5",
+    "@typescript-eslint/eslint-plugin": "^1.13.0",
+    "@typescript-eslint/parser": "^1.12.0",
+    "ava": "^1.4.1",
+    "cpx": "^1.5.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-markdown": "^1.0.0",
+    "eventemitter2": "^5.0.1",
+    "npm-run-all": "^4.1.5",
+    "nyc": "^14.1.0",
+    "rimraf": "^3.0.0",
+    "typescript": "^3.6.4"
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "files": [
+    "dist/src"
+  ],
+  "homepage": "https://webhint.io/",
+  "keywords": [
+    "jsx",
+    "react",
+    "webhint",
+    "webhint-parser"
+  ],
+  "license": "Apache-2.0",
+  "main": "dist/src/parser.js",
+  "name": "@hint/parser-jsx",
+  "nyc": {
+    "extends": "../../.nycrc"
+  },
+  "peerDependencies": {
+    "@hint/parser-javascript": "^3.0.12",
+    "hint": "^5.0.0"
+  },
+  "repository": {
+    "directory": "packages/parser-jsx",
+    "type": "git",
+    "url": "https://github.com/webhintio/hint.git"
+  },
+  "scripts": {
+    "build": "npm-run-all build:*",
+    "build-release": "npm run clean && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
+    "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
+    "build:ts": "tsc -b",
+    "clean": "rimraf dist",
+    "lint": "npm-run-all lint:*",
+    "lint:js": "eslint . --cache --ext js --ext md --ext ts --ignore-path ../../.eslintignore --report-unused-disable-directives",
+    "lint:dependencies": "node ../../scripts/lint-dependencies.js",
+    "lint:md": "node ../../scripts/lint-markdown.js",
+    "test": "npm run lint && npm run build && npm run test-only",
+    "test-only": "nyc ava",
+    "test-release": "npm run lint && npm run build-release && ava",
+    "watch": "npm run build && npm-run-all --parallel -c watch:*",
+    "watch:assets": "npm run build:assets -- -w --no-initial",
+    "watch:test": "ava --watch",
+    "watch:ts": "npm run build:ts -- --watch"
+  },
+  "version": "1.0.0"
+}

--- a/packages/parser-jsx/src/parser.ts
+++ b/packages/parser-jsx/src/parser.ts
@@ -1,0 +1,275 @@
+/**
+ * @fileoverview webhint parser needed to analyze HTML contained within JSX files.
+ */
+import * as parse5 from 'parse5';
+import * as htmlparser2Adapter from 'parse5-htmlparser2-tree-adapter';
+import { debug as d } from '@hint/utils/dist/src/debug';
+import { HTMLDocument } from '@hint/utils/dist/src/dom/html';
+import { restoreReferences } from '@hint/utils/dist/src/dom/snapshot';
+import { DocumentData, ElementData, TextData } from '@hint/utils/dist/src/types/snapshot';
+import { Parser } from 'hint/dist/src/lib/types';
+import { Engine } from 'hint/dist/src/lib/engine';
+import { HTMLEvents } from '@hint/parser-html';
+import { JSXAttribute, JSXElement, JSXExpressionContainer, JSXText, Node, ScriptEvents } from '@hint/parser-javascript';
+
+type ChildMap = Map<JSXElement, Array<ElementData | TextData>>;
+type RootMap = Map<Node, ElementData>;
+
+const debug: debug.IDebugger = d(__filename);
+
+/**
+ * Check if the provided `Node` is a native HTML element in JSX.
+ */
+const isNativeElement = (node: Node) => {
+    if (node.type !== 'JSXElement') {
+        return false;
+    }
+
+    /* istanbul ignore if */
+    if (node.openingElement.name.type !== 'JSXIdentifier') {
+        return false; // Ignore JSXMemberExpression and JSXNamespacedName.
+    }
+
+    const { name } = node.openingElement.name;
+
+    return name[0] === name[0].toLowerCase(); // Ignore custom components.
+};
+
+/**
+ * Check if the provided `Node` is a `JSXAttribute` or native HTML element.
+ */
+const isAttributeOrNativeElement = (node: Node) => {
+    if (node.type === 'JSXAttribute') {
+        return true;
+    }
+
+    return isNativeElement(node);
+};
+
+/**
+ * Translate JS AST locations to HTML AST locations.
+ */
+const mapLocation = (node: Node, { startColumnOffset = 0 } = {}): parse5.Location => {
+    // TODO: Remove `columnOffset` once `Problem` supports a range.
+    return {
+        endCol: node.loc && (node.loc.end.column) || -1,
+        endLine: node.loc && node.loc.end.line || -1,
+        endOffset: node.range && node.range[1] || -1,
+        startCol: node.loc && (node.loc.start.column + startColumnOffset) || -1,
+        startLine: node.loc && node.loc.start.line || -1,
+        startOffset: node.range && node.range[0] || -1
+    };
+};
+
+/**
+ * Translate collections of `JSXAttribute`s to their HTML AST equivalent.
+ */
+const mapAttributes = (node: JSXElement) => {
+    const attribs: { [name: string]: string } = {};
+    const locations: parse5.AttributesLocation = {};
+
+    for (const attribute of node.openingElement.attributes) {
+        if (attribute.type !== 'JSXAttribute') {
+            continue; // TODO: Do something useful with JSXSpreadAttribute instances.
+        }
+        /* istanbul ignore if */
+        if (attribute.name.type !== 'JSXIdentifier') {
+            continue;
+        }
+        /* istanbul ignore if */
+        if (attribute.value && attribute.value.type !== 'Literal' && attribute.value.type !== 'JSXExpressionContainer') {
+            continue;
+        }
+
+        const { name } = attribute.name;
+
+        if (!attribute.value) {
+            attribs[name] = '';
+        } else if (attribute.value.type === 'JSXExpressionContainer') {
+            attribs[name] = `{expression}`;
+        } else {
+            attribs[name] = `${attribute.value.value}`;
+        }
+
+        locations[name] = mapLocation(attribute);
+    }
+
+    return {
+        attribs,
+        attrs: locations,
+        'x-attribsNamespace': {},
+        'x-attribsPrefix': {}
+    };
+};
+
+/**
+ * Translate `JSXElement` instances (JS AST) to `ElementData` (HTML AST).
+ */
+const mapElement = (node: JSXElement, childMap: ChildMap): ElementData => {
+    /* istanbul ignore if */
+    if (node.openingElement.name.type !== 'JSXIdentifier') {
+        throw new Error('Can only map elements with known names');
+    }
+
+    const { name } = node.openingElement.name;
+    const { attrs, ...attribs } = mapAttributes(node);
+    const children = childMap.get(node) || [];
+
+    return {
+        ...attribs,
+        children,
+        name,
+        next: null,
+        parent: null,
+        prev: null,
+        sourceCodeLocation: {
+            attrs,
+            endTag: node.closingElement ? mapLocation(node.closingElement) : undefined as any, // TODO: Fix types to allow undefined (matches parse5 behavior)
+            startTag: {
+                attrs,
+                ...mapLocation(node.openingElement, { startColumnOffset: 1 })
+            },
+            ...mapLocation(node, { startColumnOffset: 1 })
+        },
+        type: 'tag'
+    };
+};
+
+/**
+ * Translate JSX expressions `{foo}` to text placeholders.
+ */
+const mapExpression = (node: JSXExpressionContainer): TextData => {
+    return {
+        data: '{expression}',
+        next: null,
+        parent: null,
+        prev: null,
+        sourceCodeLocation: mapLocation(node),
+        type: 'text'
+    };
+};
+
+/**
+ * Translate `JSXText` instances (JS AST) to `TextData` (HTML AST).
+ */
+const mapText = (node: JSXText): TextData => {
+    return {
+        data: node.value,
+        next: null,
+        parent: null,
+        prev: null,
+        sourceCodeLocation: mapLocation(node),
+        type: 'text'
+    };
+};
+
+/**
+ * Find the nearest parent which is a native HTML element.
+ */
+const getParentElement = (ancestors: Node[]) => {
+    return ancestors
+        .slice(0, -1) // Omit target node
+        .reverse()
+        .filter(isNativeElement)[0] as JSXElement | undefined;
+};
+
+/**
+ * Find the nearest parent which is a native HTML element or an attribute.
+ */
+const getParentAttributeOrElement = (ancestors: Node[]) => {
+    return ancestors
+        .slice(0, -1) // Omit target node
+        .reverse()
+        .filter(isAttributeOrNativeElement)[0] as JSXAttribute | JSXElement | undefined;
+};
+
+/**
+ * Queue a child to be added to the `ElementData` for the provided `JSXElement`.
+ */
+const addChild = (data: ElementData | TextData, parent: JSXElement, children: ChildMap) => {
+    const list = children.get(parent) || [];
+
+    list.push(data);
+    children.set(parent, list);
+};
+
+/**
+ * Generate an HTML document representing a fragment containing the
+ * provided roots derived from the specified resource.
+ */
+const createHTMLFragment = (roots: RootMap, resource: string) => {
+    const dom = parse5.parse(
+        `<!doctype html><html data-webhint-fragment></html>`,
+        { treeAdapter: htmlparser2Adapter }
+    ) as DocumentData;
+
+    const body = (dom.children[1] as ElementData).children[1] as ElementData;
+
+    roots.forEach((root) => {
+        body.children.push(root);
+    });
+
+    restoreReferences(dom);
+
+    return new HTMLDocument(dom, resource);
+};
+
+export default class JSXParser extends Parser<HTMLEvents> {
+
+    public constructor(engine: Engine<HTMLEvents & ScriptEvents>) {
+        super(engine, 'jsx');
+
+        engine.on('parse::end::javascript', ({ ast, resource, walk }) => {
+            const roots: RootMap = new Map();
+            const childMap: ChildMap = new Map();
+
+            walk.ancestor(ast, {
+                JSXElement(node, /* istanbul ignore next */ ancestors = []) {
+                    if (!isNativeElement(node)) {
+                        return;
+                    }
+
+                    const data = mapElement(node, childMap);
+                    const parent = getParentElement(ancestors);
+
+                    if (parent) {
+                        addChild(data, parent, childMap);
+                    } else {
+                        roots.set(node, data);
+                    }
+                },
+                JSXExpressionContainer(node, /* istanbul ignore next */ ancestors = []) {
+                    const data = mapExpression(node);
+                    const parent = getParentAttributeOrElement(ancestors);
+
+                    if (parent && parent.type !== 'JSXAttribute') {
+                        addChild(data, parent, childMap);
+                    }
+                },
+                JSXText(node, /* istanbul ignore next */ ancestors = []) {
+                    const data = mapText(node);
+                    const parent = getParentElement(ancestors);
+
+                    if (parent) {
+                        addChild(data, parent, childMap);
+                    }
+                }
+            });
+
+            walk.onComplete(async () => {
+                if (!roots.size) {
+                    return; // No JSX content found.
+                }
+
+                await this.engine.emitAsync(`parse::start::html`, { resource });
+
+                const document = createHTMLFragment(roots, resource);
+                const html = `<!doctype html>\n${document.documentElement.outerHTML}`;
+
+                debug('Generated HTML from JSX:', html);
+
+                await this.engine.emitAsync('parse::end::html', { document, html, resource });
+            });
+        });
+    }
+}

--- a/packages/parser-jsx/tests/tests.ts
+++ b/packages/parser-jsx/tests/tests.ts
@@ -1,0 +1,157 @@
+import test from 'ava';
+import { EventEmitter2 } from 'eventemitter2';
+import { Engine, FetchEnd } from 'hint';
+import { HTMLEvents, HTMLParse } from '@hint/parser-html';
+import JavaScriptParser, { ScriptEvents } from '@hint/parser-javascript';
+
+import JSXParser from '../src/parser';
+
+const emitFetchEndJSX = async (engine: Engine<ScriptEvents & HTMLEvents>, content: string) => {
+    let event = {} as HTMLParse;
+
+    engine.on('parse::end::html', (e) => {
+        event = e;
+    });
+
+    await engine.emitAsync('fetch::end::unknown', {
+        resource: 'https://webhint.io/test.jsx',
+        response: {
+            body: { content },
+            mediaType: 'text/jsx'
+        }
+    } as FetchEnd);
+
+    return event;
+};
+
+const mockEngine = () => {
+    return new EventEmitter2({
+        delimiter: '::',
+        wildcard: true
+    }) as Engine<ScriptEvents & HTMLEvents>;
+};
+
+const mockContext = () => {
+    const engine = mockEngine();
+    const jsParser = new JavaScriptParser(engine);
+    const jsxParser = new JSXParser(engine);
+
+    return { engine, jsParser, jsxParser };
+};
+
+const parseJSX = (content: string) => {
+    const { engine } = mockContext();
+
+    return emitFetchEndJSX(engine, content);
+};
+
+test('It translates basic JSX to HTML', async (t) => {
+    let receivedStart = false;
+    const { engine } = mockContext();
+
+    engine.on('parse::start::html', (e) => {
+        receivedStart = true;
+    });
+
+    const { html } = await emitFetchEndJSX(engine, `const jsx = <div>Test</div>;`);
+
+    t.true(receivedStart);
+    t.is(html, `<!doctype html>\n<html data-webhint-fragment=""><head></head><body><div>Test</div></body></html>`);
+});
+
+test('It does not emit HTML events if no JSX is present', async (t) => {
+    let received = false;
+    const { engine } = mockContext();
+
+    engine.on('parse::start::html', () => {
+        received = true;
+    });
+
+    engine.on('parse::end::html', () => {
+        received = true;
+    });
+
+    await emitFetchEndJSX(engine, `const x = 4;`);
+
+    t.false(received);
+});
+
+test('It marks the resulting HTML as a fragment', async (t) => {
+    const { document } = await parseJSX(`const jsx = <div>Test</div>;`);
+
+    t.true(document.isFragment);
+});
+
+test('It omits non-HTML components (but keeps children)', async (t) => {
+    const { document } = await parseJSX(`const jsx = <div><button>1</button><Button>2</Button></div>;`);
+    const body = document.querySelectorAll('body')[0];
+
+    t.is(body.innerHTML, `<div><button>1</button>2</div>`);
+});
+
+test('It serializes attributes', async (t) => {
+    const { document } = await parseJSX(`const jsx = <button type="button">Test</button>;`);
+    const button = document.querySelectorAll('button')[0];
+
+    t.is(button.outerHTML, '<button type="button">Test</button>');
+});
+
+test('It ignores spread attributes', async (t) => {
+    const { document } = await parseJSX(`const jsx = <button type="button" {...foo}>Test</button>;`);
+    const button = document.querySelectorAll('button')[0];
+
+    t.is(button.outerHTML, '<button type="button">Test</button>');
+});
+
+test('It handles boolean attributes', async (t) => {
+    const { document } = await parseJSX(`const jsx = <div hidden>Test</div>;`);
+    const div = document.querySelectorAll('div')[0];
+
+    t.is(div.outerHTML, '<div hidden="">Test</div>');
+});
+
+test('It omits JSX fragments but keeps their children', async (t) => {
+    const { document } = await parseJSX(`const jsx = <><div>1</div><div>2</div></>;`);
+    const body = document.querySelectorAll('body')[0];
+
+    t.is(body.innerHTML, '<div>1</div><div>2</div>');
+});
+
+test('It treats separate JSX islands as siblings', async (t) => {
+    const { document } = await parseJSX(`
+        const jsx1 = () => {
+            return <div>1</div>;
+        };
+        const c = a + b;
+        const jsx2 = <div>2</div>;
+    `);
+    const body = document.querySelectorAll('body')[0];
+
+    t.is(body.innerHTML, `<div>1</div><div>2</div>`);
+});
+
+test('It marks which attributes resulted from template expressions', async (t) => {
+    const { document } = await parseJSX(`const jsx = <button type="button" id={myId}>Test</button>;`);
+    const button = document.querySelectorAll('button')[0];
+
+    t.is(button.getAttribute('type'), 'button');
+    t.is(button.getAttribute('id'), '{expression}');
+    t.false(button.isAttributeAnExpression('type'));
+    t.true(button.isAttributeAnExpression('id'));
+});
+
+test('It replaces expressions with text placeholders', async (t) => {
+    const { document } = await parseJSX(`const jsx = <div>{myText}</div>;`);
+    const div = document.querySelectorAll('div')[0];
+
+    t.is(div.innerHTML, '{expression}');
+});
+
+test('It translates source locations correctly', async (t) => {
+    const { document } = await parseJSX(`const a = 4;\nconst jsx = <div>{myText}</div>;`);
+    const div = document.querySelectorAll('div')[0];
+    const { column, line } = div.getLocation();
+
+    t.is(column, 13);
+    t.is(line, 1);
+});

--- a/packages/parser-jsx/tsconfig.json
+++ b/packages/parser-jsx/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "dist",
+        "strict": true
+    },
+    "exclude": [
+        "dist",
+        "node_modules"
+    ],
+    "extends": "../../tsconfig.json",
+    "include": [
+        "src/**/*.ts",
+        "tests/**/*.ts"
+    ],
+    "references": [
+        { "path": "../hint" },
+        { "path": "../parser-html" },
+        { "path": "../parser-javascript" },
+        { "path": "../utils" }
+    ]
+}

--- a/scripts/lint-dependencies.js
+++ b/scripts/lint-dependencies.js
@@ -11,7 +11,7 @@ const builtIn = require('builtin-modules');
 
 const typeDependencies = new Set([
     'har-format',
-    'estree',
+    'estree-jsx',
     'request',
     'tough-cookie',
     'vscode'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -98,6 +98,7 @@
         { "path": "packages/parser-css" },
         { "path": "packages/parser-html" },
         { "path": "packages/parser-javascript" },
+        { "path": "packages/parser-jsx" },
         { "path": "packages/parser-less" },
         { "path": "packages/parser-manifest" },
         { "path": "packages/parser-package-json" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -631,7 +631,14 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
-"@types/estree@*", "@types/estree@^0.0.39":
+"@types/estree-jsx@^0.0.0":
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/@types/estree-jsx/-/estree-jsx-0.0.0.tgz#41447d0019a12dd43986cd23ca1b10f9a350a178"
+  integrity sha512-qbF1vq7M/ACuNkA3fbLJY0o+O+Yy4TPICtu6bUfX1IBdSOxBDms9zAdbhSfYuHTmWLakWg5zOJ64JrJae1ksdg==
+  dependencies:
+    "@types/estree" "*"
+
+"@types/estree@*":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
@@ -1231,6 +1238,11 @@ acorn-globals@^4.3.2:
   dependencies:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
+
+acorn-jsx-walk@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz#a5ed648264e68282d7c2aead80216bfdf232573a"
+  integrity sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==
 
 acorn-jsx@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Fix #2889 

* Allows JS hints such as `hint-create-element-svg` to run against `*.jsx` files.
* Also allows HTML hints such as `hint-button-type` to run against `JSX` content.
* Introduces the concept of fragment documents and expressions to represent template content.
* Strips JSX libraries when bundling `extension-browser`