### PR TITLE
Chore: Remove redundant canvas hack

### DIFF
--- a/packages/parser-html/src/parser.ts
+++ b/packages/parser-html/src/parser.ts
@@ -2,30 +2,6 @@
  * @fileoverview webhint parser needed to analyze HTML files
  */
 
-/**
- * `jsdom` always tries to load `canvas` even though it is not needed for
- * the HTML parser. If there is a mismatch between the user's node version
- * and where the HTML parser is being executed (e.g.: VS Code extension)
- * `canvas` will fail to load and crash the excution. To avoid
- * that we hijack `require`'s cache and set an empty `Module` for `canvas`
- * and `canvas-prebuilt` so `jsdom` doesn't use it and continues executing
- * normally.
- *
- */
-
-try {
-    const canvasPath = require.resolve('canvas');
-    const Module = require('module');
-    const fakeCanvas = new Module('', null);
-
-    /* istanbul ignore next */
-    fakeCanvas.exports = function () { };
-
-    require.cache[canvasPath] = fakeCanvas;
-} catch (e) {
-    // `canvas` is not installed, nothing to do
-}
-
 import { createHTMLDocument } from '@hint/utils/dist/src/dom/create-html-document';
 import { Parser, FetchEnd } from 'hint/dist/src/lib/types';
 import { Engine } from 'hint/dist/src/lib/engine';


### PR DESCRIPTION
This is still done directly in `connector-local` (which needs it).
The HTML parser does not use `jsdom` anymore.

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
