### PR TITLE
Fix: Template broken url

### DIFF
--- a/packages/create-hint/src/templates/meta.ts.hbs
+++ b/packages/create-hint/src/templates/meta.ts.hbs
@@ -34,7 +34,7 @@ const meta: HintMetadata = {
         /*
          * If you want to allow the user to configure your hint
          * you should use a valid JSON schema. More info in:
-         * https://webhint.io/docs/contributor-guide/hints/#themetaproperty
+         * https://webhint.io/docs/contributor-guide/#hints/#themetaproperty
          */
     ],
     scope: HintScope.{{hint.scope}}

--- a/packages/create-hint/src/templates/meta.ts.hbs
+++ b/packages/create-hint/src/templates/meta.ts.hbs
@@ -35,7 +35,7 @@ const meta: HintMetadata = {
          * If you want to allow the user to configure your hint
          * you should use a valid JSON schema. More info in:
          * https://webhint.io/docs/contributor-guide/how-to/hint/#the-meta-property
-         *
+         */
     ],
     scope: HintScope.{{hint.scope}}
 };

--- a/packages/create-hint/src/templates/meta.ts.hbs
+++ b/packages/create-hint/src/templates/meta.ts.hbs
@@ -34,8 +34,8 @@ const meta: HintMetadata = {
         /*
          * If you want to allow the user to configure your hint
          * you should use a valid JSON schema. More info in:
-         * https://webhint.io/docs/contributor-guide/#hints/#themetaproperty
-         */
+         * https://webhint.io/docs/contributor-guide/how-to/hint/#the-meta-property
+         *
     ],
     scope: HintScope.{{hint.scope}}
 };

--- a/packages/create-hint/src/templates/partial-event-code.hbs
+++ b/packages/create-hint/src/templates/partial-event-code.hbs
@@ -8,7 +8,7 @@ debug(`Validating hint {{hint.name}}`);
  * context.report(resource, 'Add error message here.');
  *
  * More information on how to develop a hint is available in:
- * https://webhint.io/docs/contributor-guide/#hints/
+ * https://webhint.io/docs/contributor-guide/how-to/hint/
  */
 
 if (Math.ceil(Math.random()) === 0) {

--- a/packages/create-hint/src/templates/partial-event-code.hbs
+++ b/packages/create-hint/src/templates/partial-event-code.hbs
@@ -8,7 +8,7 @@ debug(`Validating hint {{hint.name}}`);
  * context.report(resource, 'Add error message here.');
  *
  * More information on how to develop a hint is available in:
- * https://webhint.io/docs/contributor-guide/hints/
+ * https://webhint.io/docs/contributor-guide/#hints/
  */
 
 if (Math.ceil(Math.random()) === 0) {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

The `create-hint` template has some old/broken urls in the comments. I updated the urls to point to the pages that I think they should:
- about schema: https://webhint.io/docs/contributor-guide/how-to/hint/#the-meta-property
- how to hint: https://webhint.io/docs/contributor-guide/how-to/hint/

Feel free to update the links if I got the pages wrong. Thanks!

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
