### PR TITLE
Build: Enable releasing from `servicing` branch

### DIFF
--- a/release/tasks/validate-environment.ts
+++ b/release/tasks/validate-environment.ts
@@ -8,6 +8,8 @@ import { debug, execa } from '../lib/utils';
 import { ListrTaskWrapper } from 'listr';
 import { getCurrentBranchRemoteInfo } from '../lib/git-helpers';
 
+const validRemoteBranches = ['master', 'servicing'];
+
 const runningInRoot = () => {
     const errorMessage = 'Not running from root of project';
     const pkg = require(path.join(process.cwd(), 'package.json'));
@@ -69,7 +71,7 @@ const authenticatedOnVsce = async () => {
     }
 };
 
-const masterRemote = async () => {
+const validRemote = async () => {
     const { remoteBranch, remoteURL } = await getCurrentBranchRemoteInfo();
 
     /*
@@ -89,8 +91,8 @@ const masterRemote = async () => {
         throw new Error(message);
     }
 
-    if (remoteBranch !== 'master') {
-        const message = `Current branch "${remoteBranch}" does not point to master`;
+    if (!validRemoteBranches.includes(remoteBranch)) {
+        const message = `Current branch "${remoteBranch}" does not point to any of the valid branches (${validRemoteBranches.join(', ')})`;
 
         debug(message);
 
@@ -118,7 +120,7 @@ export const validateEnvironment = async (ctx: Context, task: ListrTaskWrapper) 
 
     // We don't care about the branch when running on `--dryRun` mode
     if (!ctx.argv.dryRun) {
-        checks.push(masterRemote);
+        checks.push(validRemote);
     } else {
         debug('skipping branch check');
     }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

Fix #3172 

Changed to validate temporary against my fork and tested with `servicing` and `bla` branches:

![image](https://user-images.githubusercontent.com/606594/67418644-07fab280-f580-11e9-8904-135c0fa34bbc.png)


<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
