### PR TITLE
Build: Update lint-dependencies to support multilines imports

### DIFF
--- a/scripts/lint-dependencies.js
+++ b/scripts/lint-dependencies.js
@@ -47,7 +47,7 @@ const ignoredDependencies = new Set([
 ]);
 
 const regexps = [
-    /import\s+.*?\s+'([a-z0-9_\-@/.]+)';/gi, // `import * as something from 'something';`
+    /import[\s\w\d{},*]*?'([a-z0-9_\-@/.]+)';/gi, // `import * as something from 'something';`
     /import\('([a-z0-9_\-@/.]+)'\)/gi, // `import('something');`
     /require(?:\.resolve)?\('([a-z0-9_\-@/.]+)'\)/gi, // `const something = require('something');` || `const something = require.resolve('something');`
     /(?:loader|use):\s+'([a-z0-9_\-@/.]+)'/gi, // webpack config: `loader: 'ts-loader'` `use: 'raw-loader'`


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
This PR add supports to `lint-dependencies.js` for:
```
import {
    a,
    b
} from 'package';
```