### PR TITLE
Fix: Edge error locations when using `extends`

### DIFF
--- a/packages/hint-typescript-config/src/target.ts
+++ b/packages/hint-typescript-config/src/target.ts
@@ -10,6 +10,7 @@ import { TypeScriptConfigEvents, TypeScriptConfigParse } from '@hint/parser-type
 
 import meta from './meta/target';
 import { getMessage } from './i18n.import';
+import { findLocation } from './helpers/config-checker';
 
 /*
  * ------------------------------------------------------------------------------
@@ -227,16 +228,19 @@ export default class TypeScriptConfigTarget implements IHint {
         };
 
         const validate = (evt: TypeScriptConfigParse) => {
-            const { config, getLocation, resource } = evt;
+            const { config, getLocation, mergedConfig, originalConfig, resource } = evt;
             const { targetedBrowsers } = context;
+
             const target = normalizeScriptTarget(config.compilerOptions.target as any);
             const minimumBrowsers = toMiniumBrowser(targetedBrowsers);
+            const messageName = 'target';
+            const propertyPath = 'compilerOptions.target';
 
             const maxESVersion = getMaxVersion(minimumBrowsers);
 
             if (maxESVersion !== target) {
-                const message = getMessage('target', context.language, [maxESVersion, target]);
-                const location = getLocation('compilerOptions.target', { at: 'value' });
+                const location = findLocation(propertyPath, mergedConfig, originalConfig, getLocation);
+                const message = getMessage(messageName, context.language, [maxESVersion, target]);
 
                 context.report(resource, message, { location });
             }

--- a/packages/hint-typescript-config/tests/consistent-casing.ts
+++ b/packages/hint-typescript-config/tests/consistent-casing.ts
@@ -14,12 +14,19 @@ const tests: HintLocalTest[] = [
     {
         name: 'Configuration with "compilerOptions.forceConsistentCasingInFileNames = false" should fail',
         path: path.join(__dirname, 'fixtures', 'consistent-casing', 'consistent-casing-false'),
-        reports: [{ message: 'The compiler option "forceConsistentCasingInFileNames" should be enabled to reduce issues when working with different OSes.' }]
+        reports: [
+            {
+                message: 'The compiler option "forceConsistentCasingInFileNames" should be enabled to reduce issues when working with different OSes.',
+                position: { match: 'false' }
+            }]
     },
     {
         name: 'Configuration without "compilerOptions.forceConsistentCasingInFileNames" should fail',
         path: path.join(__dirname, 'fixtures', 'consistent-casing', 'no-consistent-casing'),
-        reports: [{ message: 'The compiler option "forceConsistentCasingInFileNames" should be enabled to reduce issues when working with different OSes.' }]
+        reports: [{
+            message: 'The compiler option "forceConsistentCasingInFileNames" should be enabled to reduce issues when working with different OSes.',
+            position: { match: 'compilerOptions' }
+        }]
     }
 ];
 

--- a/packages/hint-typescript-config/tests/fixtures/strict/strict-false/tsconfig.json
+++ b/packages/hint-typescript-config/tests/fixtures/strict/strict-false/tsconfig.json
@@ -12,7 +12,7 @@
         ],
         "module": "commonjs",
         "newLine": "lf",
-        "removeComments": false,
+        "removeComments": true,
         "target": "esnext",
         "strict": false
     },

--- a/packages/hint-typescript-config/tests/fixtures/target/extends-overrides/tsconfig.json
+++ b/packages/hint-typescript-config/tests/fixtures/target/extends-overrides/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "target": "es3"
+    },
+    "extends": "../es2016/tsconfig.json"
+}

--- a/packages/hint-typescript-config/tests/fixtures/target/extends/tsconfig.json
+++ b/packages/hint-typescript-config/tests/fixtures/target/extends/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../es2016/tsconfig.json"
+}

--- a/packages/hint-typescript-config/tests/fixtures/target/no-target-extends-target/tsconfig.json
+++ b/packages/hint-typescript-config/tests/fixtures/target/no-target-extends-target/tsconfig.json
@@ -3,22 +3,14 @@
         "alwaysStrict": true,
         "declaration": true,
         "inlineSourceMap": true,
-        "lib": [
-            "dom",
-            "dom.iterable",
-            "es2017",
-            "esnext",
-            "esnext.asynciterable"
-        ],
         "module": "commonjs",
         "newLine": "lf",
-        "removeComments": true,
-        "target": "esnext",
-        "importHelpers": false
+        "removeComments": false
     },
     "exclude": [
         "dist",
         "node_modules",
         "packages"
-    ]
+    ],
+    "extends": "../es3/tsconfig.json"
 }

--- a/packages/hint-typescript-config/tests/fixtures/target/no-target-extends/tsconfig.json
+++ b/packages/hint-typescript-config/tests/fixtures/target/no-target-extends/tsconfig.json
@@ -3,22 +3,14 @@
         "alwaysStrict": true,
         "declaration": true,
         "inlineSourceMap": true,
-        "lib": [
-            "dom",
-            "dom.iterable",
-            "es2017",
-            "esnext",
-            "esnext.asynciterable"
-        ],
         "module": "commonjs",
         "newLine": "lf",
-        "removeComments": true,
-        "target": "esnext",
-        "importHelpers": false
+        "removeComments": false
     },
     "exclude": [
         "dist",
         "node_modules",
         "packages"
-    ]
+    ],
+    "extends": "../no-target/tsconfig.json"
 }

--- a/packages/hint-typescript-config/tests/import-helpers.ts
+++ b/packages/hint-typescript-config/tests/import-helpers.ts
@@ -66,7 +66,12 @@ const tests: HintLocalTest[] = [
         },
         name: 'Configuration with "compilerOptions.importHelpers = false" should fail',
         path: path.join(__dirname, 'fixtures', 'import-helpers', 'import-false'),
-        reports: [{ message: 'The compiler option "importHelpers" should be enabled to reduce the output size.' }]
+        reports: [
+            {
+                message: 'The compiler option "importHelpers" should be enabled to reduce the output size.',
+                position: { match: 'false' }
+            }
+        ]
     },
     {
         after: (t: ExecutionContext<ImportHelpersContext>) => {
@@ -83,7 +88,12 @@ const tests: HintLocalTest[] = [
         },
         name: 'Configuration with no explicit "compilerOptions.importHelpers" should fail',
         path: path.join(__dirname, 'fixtures', 'import-helpers', 'no-import'),
-        reports: [{ message: 'The compiler option "importHelpers" should be enabled to reduce the output size.' }]
+        reports: [
+            {
+                message: 'The compiler option "importHelpers" should be enabled to reduce the output size.',
+                position: { match: 'compilerOptions' }
+            }
+        ]
     },
     {
         after: (t: ExecutionContext<ImportHelpersContext>) => {
@@ -101,7 +111,10 @@ const tests: HintLocalTest[] = [
         name: 'Configuration with no explicit "compilerOptions.importHelpers" and no "tslib" installed should fail',
         path: path.join(__dirname, 'fixtures', 'import-helpers', 'no-import'),
         reports: [
-            { message: 'The compiler option "importHelpers" should be enabled to reduce the output size.' },
+            {
+                message: 'The compiler option "importHelpers" should be enabled to reduce the output size.',
+                position: { match: 'compilerOptions' }
+            },
             { message: `Couldn't find package "tslib".` }
         ]
     }

--- a/packages/hint-typescript-config/tests/is-valid.ts
+++ b/packages/hint-typescript-config/tests/is-valid.ts
@@ -18,15 +18,22 @@ const tests: HintLocalTest[] = [
     {
         name: 'Invalid JSON should fail',
         path: path.join(__dirname, 'fixtures', 'invalidjson'),
-        reports: [{ message: `Unexpected token i in JSON at position 0` }]
+        reports: [
+            {
+                message: `Unexpected token i in JSON at position 0`,
+                position: { column: -1, line: -1 }
+            }
+        ]
     },
     {
         name: 'Invalid schema should fail',
         path: path.join(__dirname, 'fixtures', 'invalidschemaenum'),
-        reports: [{
-            message: `'compilerOptions.lib[3]' should be equal to one of the allowed values 'es5, es6, es2015, es7, es2016, es2017, es2018, es2019, es2020, esnext, dom, dom.iterable, webworker, webworker.importscripts, scripthost, es2015.core, es2015.collection, es2015.generator, es2015.iterable, es2015.promise, es2015.proxy, es2015.reflect, es2015.symbol, es2015.symbol.wellknown, es2016.array.include, es2017.object, es2017.intl, es2017.sharedmemory, es2017.string, es2017.typedarrays, es2018.asynciterable, es2018.intl, es2018.promise, es2018.regexp, es2019.array, es2019.object, es2019.string, es2019.symbol, es2020.string, es2020.symbol.wellknown, esnext.asynciterable, esnext.array, esnext.bigint, esnext.intl, esnext.symbol'. Value found 'invalidlib'`,
-            position: { match: '"invalidlib"' }
-        }]
+        reports: [
+            {
+                message: `'compilerOptions.lib[3]' should be equal to one of the allowed values 'es5, es6, es2015, es7, es2016, es2017, es2018, es2019, es2020, esnext, dom, dom.iterable, webworker, webworker.importscripts, scripthost, es2015.core, es2015.collection, es2015.generator, es2015.iterable, es2015.promise, es2015.proxy, es2015.reflect, es2015.symbol, es2015.symbol.wellknown, es2016.array.include, es2017.object, es2017.intl, es2017.sharedmemory, es2017.string, es2017.typedarrays, es2018.asynciterable, es2018.intl, es2018.promise, es2018.regexp, es2019.array, es2019.object, es2019.string, es2019.symbol, es2020.string, es2020.symbol.wellknown, esnext.asynciterable, esnext.array, esnext.bigint, esnext.intl, esnext.symbol'. Value found 'invalidlib'`,
+                position: { match: '"invalidlib"' }
+            }
+        ]
     },
     {
         name: 'If schema has an invalid pattern, it should fail',

--- a/packages/hint-typescript-config/tests/strict.ts
+++ b/packages/hint-typescript-config/tests/strict.ts
@@ -14,13 +14,23 @@ const tests: HintLocalTest[] = [
     {
         name: 'Configuration with "compilerOptions.strict = false" should fail',
         path: path.join(__dirname, 'fixtures', 'strict', 'strict-false'),
-        reports: [{message: 'The compiler option "strict" should be enabled to reduce type errors.'}]
+        reports: [
+            {
+                message: 'The compiler option "strict" should be enabled to reduce type errors.',
+                position: { match: 'false' }
+            }
+        ]
     },
     {
         name: 'Configuration with no explicit "compilerOptions.strict" should fail',
         path: path.join(__dirname, 'fixtures', 'strict', 'no-strict'),
-        reports: [{message: 'The compiler option "strict" should be enabled to reduce type errors.'}]
+        reports: [
+            {
+                message: 'The compiler option "strict" should be enabled to reduce type errors.',
+                position: { match: 'compilerOptions' }
+            }
+        ]
     }
 ];
 
-testLocalHint(hintPath, tests, {parsers: ['typescript-config']});
+testLocalHint(hintPath, tests, { parsers: ['typescript-config'] });

--- a/packages/hint-typescript-config/tests/target.ts
+++ b/packages/hint-typescript-config/tests/target.ts
@@ -11,7 +11,18 @@ type TestWithBrowserInfo = HintLocalTest & {
 };
 
 /** The paths to the target configurations for each tested version */
-const paths = ['es3', 'es5', 'es2015', 'es2016', 'esnext', 'no-target'].reduce((final, version) => {
+const paths = [
+    'es3',
+    'es5',
+    'es2015',
+    'es2016',
+    'esnext',
+    'extends',
+    'extends-overrides',
+    'no-target',
+    'no-target-extends',
+    'no-target-extends-target'
+].reduce((final, version) => {
 
     final[version] = path.join(__dirname, 'fixtures', 'target', version);
 
@@ -29,7 +40,12 @@ const tests: TestWithBrowserInfo[] = [
         browserslist: ['Edge 15', 'Chrome 63'],
         name: 'Configuration with "compilerOptions.target = es3" and modern browsers should fail',
         path: paths.es3,
-        reports: [{ message: `Based on your browser configuration your "compilerOptions.target" should be "ES2016". Current one is "ES3"` }]
+        reports: [
+            {
+                message: `Based on your browser configuration your "compilerOptions.target" should be "ES2016". Current one is "ES3"`,
+                position: { match: '"es3"' }
+            }
+        ]
     },
     {
         browserslist: ['IE 9', 'Edge 15', 'Chrome 63'],
@@ -45,13 +61,23 @@ const tests: TestWithBrowserInfo[] = [
         browserslist: ['IE 8', 'Edge 15', 'Chrome 63'],
         name: 'Configuration with "compilerOptions.target = es2016" and old browsers should fail',
         path: paths.es2016,
-        reports: [{ message: `Based on your browser configuration your "compilerOptions.target" should be "ES3". Current one is "ES2016"` }]
+        reports: [
+            {
+                message: `Based on your browser configuration your "compilerOptions.target" should be "ES3". Current one is "ES2016"`,
+                position: { match: '"es2016"' }
+            }
+        ]
     },
     {
         browserslist: ['Edge 15', 'Chrome 63'],
         name: 'Configuration with "compilerOptions.target = esnext" and not very old browsers should fail',
         path: paths.esnext,
-        reports: [{ message: `Based on your browser configuration your "compilerOptions.target" should be "ES2016". Current one is "ESNext"` }]
+        reports: [
+            {
+                message: `Based on your browser configuration your "compilerOptions.target" should be "ES2016". Current one is "ESNext"`,
+                position: { match: '"esnext"' }
+            }
+        ]
     },
     {
         browserslist: ['IE 8', 'Edge 15', 'Chrome 63'],
@@ -62,7 +88,63 @@ const tests: TestWithBrowserInfo[] = [
         browserslist: ['Edge 15', 'Chrome 63'],
         name: `Configuration with no "compilerOptions.target" and modern browsers shouldn't pass`,
         path: paths['no-target'],
-        reports: [{ message: `Based on your browser configuration your "compilerOptions.target" should be "ES2016". Current one is "ES3"` }]
+        reports: [
+            {
+                message: `Based on your browser configuration your "compilerOptions.target" should be "ES2016". Current one is "ES3"`,
+                position: { match: 'compilerOptions' }
+            }]
+    },
+    {
+        browserslist: ['IE 8', 'Edge 15', 'Chrome 63'],
+        name: 'Configuration with no "compilerOptions.target" in extended file and old browsers should pass',
+        path: paths['no-target-extends']
+    },
+    {
+        browserslist: ['Edge 15', 'Chrome 63'],
+        name: `Configuration with no "compilerOptions.target" in extended file and modern browsers shouldn't pass`,
+        path: paths['no-target-extends'],
+        reports: [
+            {
+                message: `Based on your browser configuration your "compilerOptions.target" should be "ES2016". Current one is "ES3"`,
+                position: { match: 'compilerOptions' }
+            }]
+    },
+    {
+        browserslist: ['Edge 15', 'Chrome 63'],
+        name: `Configuration with "compilerOptions.target" in extended file and modern browsers shouldn't pass`,
+        path: paths['no-target-extends-target'],
+        reports: [
+            {
+                message: `Based on your browser configuration your "compilerOptions.target" should be "ES2016". Current one is "ES3"`,
+                position: { match: '"../es3/tsconfig.json"' }
+            }]
+    },
+    {
+        browserslist: ['Edge 15', 'Chrome 63'],
+        name: `Configuration with extends pointing to ES2016 and modern browsers should pass`,
+        path: paths.extends
+    },
+    {
+        browserslist: ['Edge 15', 'Chrome 63'],
+        name: `Configuration with extends pointing to ES2016 and target es3 should fail`,
+        path: paths['extends-overrides'],
+        reports: [
+            {
+                message: `Based on your browser configuration your "compilerOptions.target" should be "ES2016". Current one is "ES3"`,
+                position: { match: '"es3"' }
+            }
+        ]
+    },
+    {
+        browserslist: ['IE 8', 'Edge 15', 'Chrome 63'],
+        name: `Configuration with extends pointing to ES2016 and old browsers should fail`,
+        path: paths.extends,
+        reports: [
+            {
+                message: `Based on your browser configuration your "compilerOptions.target" should be "ES3". Current one is "ES2016"`,
+                position: { match: '"../es2016/tsconfig.json"' }
+            }
+        ]
     }
 ];
 

--- a/packages/parser-typescript-config/README.md
+++ b/packages/parser-typescript-config/README.md
@@ -44,7 +44,12 @@ This `parser` emits the following events:
   which contains the following information:
 
   * `resource`: the parsed resource.
-  * `config`: an object with a valid configuration (`TypeScriptConfig`).
+  * `getLocation`: helper to find the location of a path within the original
+    JSON source.
+  * `config`: the final configuration after adding default values
+    (`TypeScriptConfig`).
+  * `mergedConfig`: the merged configuration after inlining `extends`.
+  * `originalConfig`: the original configuration before resolving `extends`.
 
 * `parse::error::typescript-config::json`, of type `TypeScriptConfigInvalidJSON`
   which contains the following information:

--- a/packages/parser-typescript-config/src/parser.ts
+++ b/packages/parser-typescript-config/src/parser.ts
@@ -148,7 +148,7 @@ export default class TypeScriptConfigParser extends Parser<TypeScriptConfigEvent
                 await this.updateSchema();
             }
 
-            result = parseJSON(fetchEnd.response.body.content, 'extends');
+            result = parseJSON(fetchEnd.response.body.content);
 
             const originalConfig = cloneDeep(result.data);
 

--- a/packages/parser-typescript-config/src/parser.ts
+++ b/packages/parser-typescript-config/src/parser.ts
@@ -179,6 +179,7 @@ export default class TypeScriptConfigParser extends Parser<TypeScriptConfigEvent
             await this.engine.emitAsync(`parse::end::typescript-config`, {
                 config: validationResult.data,
                 getLocation: result.getLocation,
+                mergedConfig: config,
                 originalConfig,
                 resource
             });

--- a/packages/parser-typescript-config/src/types.ts
+++ b/packages/parser-typescript-config/src/types.ts
@@ -27,10 +27,12 @@ export type TypeScriptConfigParseStart = Event;
 
 /** The object emitted by the `typescript-config` parser */
 export type TypeScriptConfigParse = Event & {
-    /** The TypeScript config parsed */
+    /** The final TypeScript config after adding default values */
     config: TypeScriptConfig;
     /** Find the location of a path within the original JSON source */
     getLocation: IJSONLocationFunction;
+    /** The combined TypeScript config after inlining `extends` */
+    mergedConfig: TypeScriptConfig;
     /** The original TypeScript config */
     originalConfig: TypeScriptConfig;
 };


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

Improvements in a couple of edge cases:

- `target` was pointing to `{` because it did not do the right search
- when a configuration `extends` but none of the files had a required
  property, `extends` got underlined because it was set as the
  `alternatePath`. With the improvements in the node search this is no
  longer needed.


<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
