### PR TITLE
Fix: Use VS Code language ID to reduce file type telemetry noise

### DIFF
--- a/packages/extension-vscode/src/server.ts
+++ b/packages/extension-vscode/src/server.ts
@@ -55,7 +55,7 @@ documents.onDidClose(({ document }) => {
 
 // Report deltas in cached results when a document is saved.
 documents.onDidSave(({ document }) => {
-    trackSave(document.uri);
+    trackSave(document.uri, document.languageId);
 });
 
 // Listen on the text document manager and connection.

--- a/packages/extension-vscode/tests/utils/analytics.ts
+++ b/packages/extension-vscode/tests/utils/analytics.ts
@@ -43,7 +43,7 @@ test('It tracks the first result for each document when opened', (t) => {
     const trackEventSpy = sandbox.spy(stubs['./app-insights'], 'trackEvent');
 
     // First result should be tracked.
-    module.trackResult('test.html', {
+    module.trackResult('test.html', 'html', {
         hints: [
             { meta: { id: 'foo' } } as IHintConstructor
         ],
@@ -56,7 +56,7 @@ test('It tracks the first result for each document when opened', (t) => {
     });
 
     // Second result should not be tracked (will be cached for 'onSave').
-    module.trackResult('test.html', {
+    module.trackResult('test.html', 'html', {
         hints: [
             { meta: { id: 'foo' } } as IHintConstructor
         ],
@@ -64,7 +64,7 @@ test('It tracks the first result for each document when opened', (t) => {
     });
 
     // First result for another document should be tracked.
-    module.trackResult('test.css', {
+    module.trackResult('test.css', 'css', {
         hints: [
             { meta: { id: 'bar' } } as IHintConstructor
         ],
@@ -74,13 +74,13 @@ test('It tracks the first result for each document when opened', (t) => {
     t.true(trackEventSpy.calledTwice);
     t.is(trackEventSpy.firstCall.args[0], 'vscode-open');
     t.deepEqual(trackEventSpy.firstCall.args[1], {
-        fileExtension: '.html',
-        'hint-foo': 'failed'
+        'hint-foo': 'failed',
+        languageId: 'html'
     });
     t.is(trackEventSpy.secondCall.args[0], 'vscode-open');
     t.deepEqual(trackEventSpy.secondCall.args[1], {
-        fileExtension: '.css',
-        'hint-bar': 'passed'
+        'hint-bar': 'passed',
+        languageId: 'css'
     });
 
     sandbox.restore();
@@ -92,7 +92,7 @@ test('It tracks the delta between the first and last results on save', (t) => {
     const trackEventSpy = sandbox.spy(stubs['./app-insights'], 'trackEvent');
 
     // First result should be tracked.
-    module.trackResult('test.html', {
+    module.trackResult('test.html', 'html', {
         hints: [
             { meta: { id: 'bar' } } as IHintConstructor,
             { meta: { id: 'baz' } } as IHintConstructor,
@@ -108,7 +108,7 @@ test('It tracks the delta between the first and last results on save', (t) => {
     });
 
     // Second result should not be tracked (will be cached for 'onSave').
-    module.trackResult('test.html', {
+    module.trackResult('test.html', 'html', {
         hints: [
             { meta: { id: 'bar' } } as IHintConstructor,
             { meta: { id: 'baz' } } as IHintConstructor,
@@ -121,7 +121,7 @@ test('It tracks the delta between the first and last results on save', (t) => {
     });
 
     // First result for another document should be tracked.
-    module.trackResult('test.html', {
+    module.trackResult('test.html', 'html', {
         hints: [
             { meta: { id: 'bar' } } as IHintConstructor,
             { meta: { id: 'baz' } } as IHintConstructor,
@@ -132,25 +132,25 @@ test('It tracks the delta between the first and last results on save', (t) => {
         ]
     });
 
-    module.trackSave('test.html');
+    module.trackSave('test.html', 'html');
 
     // Verify multiple saves only submit once with no new results.
-    module.trackSave('test.html');
+    module.trackSave('test.html', 'html');
 
     t.true(trackEventSpy.calledTwice);
     t.is(trackEventSpy.firstCall.args[0], 'vscode-open');
     t.deepEqual(trackEventSpy.firstCall.args[1], {
-        fileExtension: '.html',
         'hint-bar': 'failed',
         'hint-baz': 'passed',
-        'hint-foo': 'failed'
+        'hint-foo': 'failed',
+        languageId: 'html'
     });
     t.is(trackEventSpy.secondCall.args[0], 'vscode-save');
     t.deepEqual(trackEventSpy.secondCall.args[1], {
-        fileExtension: '.html',
         'hint-bar': 'fixed',
         'hint-baz': 'passed',
-        'hint-foo': 'fixing'
+        'hint-foo': 'fixing',
+        languageId: 'html'
     });
 
     sandbox.restore();
@@ -162,7 +162,7 @@ test('It tracks results again for a document when re-opened', (t) => {
     const trackEventSpy = sandbox.spy(stubs['./app-insights'], 'trackEvent');
 
     // First result should be tracked.
-    module.trackResult('test.html', {
+    module.trackResult('test.html', 'html', {
         hints: [
             { meta: { id: 'foo' } } as IHintConstructor
         ],
@@ -178,7 +178,7 @@ test('It tracks results again for a document when re-opened', (t) => {
     module.trackClose('test.html');
 
     // Second result should be tracked because document was re-opened.
-    module.trackResult('test.html', {
+    module.trackResult('test.html', 'html', {
         hints: [
             { meta: { id: 'foo' } } as IHintConstructor
         ],
@@ -188,12 +188,12 @@ test('It tracks results again for a document when re-opened', (t) => {
     t.true(trackEventSpy.calledTwice);
     t.is(trackEventSpy.firstCall.args[0], 'vscode-open');
     t.deepEqual(trackEventSpy.firstCall.args[1], {
-        fileExtension: '.html',
-        'hint-foo': 'failed'
+        'hint-foo': 'failed',
+        languageId: 'html'
     });
     t.is(trackEventSpy.secondCall.args[0], 'vscode-open');
     t.deepEqual(trackEventSpy.secondCall.args[1], {
-        fileExtension: '.html',
-        'hint-foo': 'passed'
+        'hint-foo': 'passed',
+        languageId: 'html'
     });
 });


### PR DESCRIPTION
Early telemetry shows a large number of different file extensions can be
mapped to one of the language types webhint registers for. Switching to
use the language ID from VS Code should help simplify this metric.

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
