### PR TITLE
New: Improve error messages when running tests

### DIFF
--- a/packages/hint-apple-touch-icons/tests/tests.ts
+++ b/packages/hint-apple-touch-icons/tests/tests.ts
@@ -205,10 +205,12 @@ const tests: HintTest[] = [
             },
             {
                 message: elementAlreadySpecifiedErrorMessage,
+                position: { column: 17, line: 4 },
                 severity: Severity.warning
             },
             {
                 message: elementAlreadySpecifiedErrorMessage,
+                position: { column: 17, line: 6 },
                 severity: Severity.warning
             }
         ],


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- ~~Added/Updated related tests.~~

## Short description of the change(s)

When validating a report `hint-runner` checked all the properties at the
same time. This made difficult to debug what property was not matching,
and what was the expected value.

Now `hint-runner` provides more information for each of the properties
that validates, and comparing to the closest matched report.

Old behavior:

![image](https://user-images.githubusercontent.com/606594/68349778-25b53500-00b3-11ea-89c5-a34a2e9b986e.png)

New behavior:

![image](https://user-images.githubusercontent.com/606594/68349755-133afb80-00b3-11ea-84f8-fb2f4a20686d.png)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
