### PR TITLE
Chore: Ensure severity gets validated in tests with position data

### DIFF
--- a/packages/utils-tests-helpers/src/hint-runner.ts
+++ b/packages/utils-tests-helpers/src/hint-runner.ts
@@ -177,6 +177,10 @@ const validateResults = (t: ExecutionContext<HintRunnerContext>, sources: Map<st
                 return false;
             }
 
+            if (typeof report.severity !== 'undefined' && severity !== report.severity) {
+                return false;
+            }
+
             if (report.position && location) {
                 let position: ProblemLocation | undefined;
 
@@ -191,10 +195,6 @@ const validateResults = (t: ExecutionContext<HintRunnerContext>, sources: Map<st
                     (!('range' in report.position) || (
                         position.endLine === location.endLine &&
                         position.endColumn === location.endColumn));
-            }
-
-            if (typeof report.severity !== 'undefined' && severity !== report.severity) {
-                return false;
             }
 
             return true;


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Likely superseded by #3297, but wanted to call this out separately in case we want to either (1) merge this fix first or (2) ensure this fix is covered by that PR.

Basically the way the checks were structured in `validateResults` allowed `severity` to be ignored if a `position` property was also part of the expected report as the block for `position` would return whether or not there was a match. Moving the `severity` check earlier fixes that issue.