### PR TITLE
Build: Ensure connectors are built before running tests (v2)

### DIFF
--- a/packages/utils-tests-helpers/package.json
+++ b/packages/utils-tests-helpers/package.json
@@ -38,6 +38,9 @@
   "main": "./dist/src/index.js",
   "name": "@hint/utils-tests-helpers",
   "peerDependencies": {
+    "@hint/connector-jsdom": "4.1.0",
+    "@hint/connector-local": "3.2.0",
+    "@hint/connector-puppeteer": "^2.4.0",
     "hint": "^5.0.0"
   },
   "repository": {

--- a/scripts/lint-dependencies.js
+++ b/scripts/lint-dependencies.js
@@ -20,7 +20,9 @@ const typeDependencies = new Set([
 const ignoredDependencies = new Set([
     '@hint/configuration-development',
     '@hint/configuration-web-recommended',
+    '@hint/connector-jsdom',
     '@hint/connector-local',
+    '@hint/connector-puppeteer',
     '@hint/utils-tests-helpers',
     '@types/chrome',
     '@types/node',

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -68,6 +68,9 @@ const buildDependencies = async (dependencies) => {
     for (const dependency of dependencies) {
         if (!ALREADY_BUILD_DEPENDENCIES.has(dependency)) {
             ALREADY_BUILD_DEPENDENCIES.add(dependency);
+
+            console.log(`Building ${dependency}`);
+
             await exec(`cd ${dependency} && yarn build`);
         }
     }
@@ -178,8 +181,7 @@ const getLocalDependencies = (packagePath, packageJSONFileContent) => {
     [
         'dependencies',
         'devDependencies',
-        'optionalDependencies',
-        'peerDependencies'
+        'optionalDependencies'
     ].forEach((dependencyType) => {
 
         /*
@@ -571,6 +573,8 @@ const runTests = async (projectData) => {
         if (!ALREADY_BUILD_DEPENDENCIES.has(packagePath)) {
             await buildDependencies(packageData.dependencies);
         }
+
+        console.log(`Testing ${packagePath}`);
 
         await execWithRetry(`cd ${packagePath} && yarn ${packageData.testScript}`);
     }


### PR DESCRIPTION
Built on top of #3332 rebasing with master and not following `peerDependencies`