### PR TITLE
Fix: Hide `configuration-all` from the user

### DIFF
--- a/packages/create-hintrc/src/create-hintrc.ts
+++ b/packages/create-hintrc/src/create-hintrc.ts
@@ -64,11 +64,15 @@ const extendConfig = async (): Promise<InitUserConfig | null> => {
         return null;
     }
 
-    const choices = configPackages.map((pkg) => {
+    const configNames = configPackages.map((pkg) => {
         return {
             name: getConfigurationName(pkg.name),
             value: pkg.name
         };
+    });
+
+    const choices = configNames.filter((config) => {
+        return config.name !== 'all';
     });
 
     const questions: inquirer.Questions = [{

--- a/packages/hint/src/lib/config/config-schema.json
+++ b/packages/hint/src/lib/config/config-schema.json
@@ -98,7 +98,8 @@
             "description": "Base configuration to use.",
             "type": "array",
             "items": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^(?!all$).*$"
             },
             "uniqueItems": true
         },

--- a/packages/hint/tests/lib/config/config-validator.ts
+++ b/packages/hint/tests/lib/config/config-validator.ts
@@ -64,6 +64,7 @@ const invalidHintsConfigArrayFormArrayInverted = {
     hints: [[{}, 'no-html-only-headers:error']]
 };
 
+const invalidExtends = { extends: ['all'] };
 
 test('If config has an invalid schema, it should return false', (t) => {
     const valid = configValidator.validateConfig(invalidConfig as any);
@@ -117,4 +118,10 @@ test('If the configuration uses shorthands, it should validate', (t) => {
     const valid = configValidator.validateConfig(validHintsConfig as any);
 
     t.true(valid);
+});
+
+test('If config extends from "all" is should not validate', (t) => {
+    const invalid = configValidator.validateConfig(invalidExtends as any);
+
+    t.false(invalid);
 });


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- [x] Added/Updated related tests.

## Short description of the change(s)

This configuration is only for internal consumption to get easy access
to all the documentation and should never be used by a user as it can
cause problems when extending from it.

This PR filters it when running `npm init hintrc` and verifies the
`.hintrc` doesn't `extends` from it.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #3097


<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
