### PR TITLE
Fix: CSS prefix order does not have full code snippet

### DIFF
--- a/packages/hint-css-prefix-order/src/hint.ts
+++ b/packages/hint-css-prefix-order/src/hint.ts
@@ -8,7 +8,7 @@ import { vendor, Declaration, Rule } from 'postcss';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
 import { IHint } from 'hint/dist/src/lib/types';
 import { debug as d } from '@hint/utils-debug';
-import { getCSSCodeSnippet, getCSSLocationFromNode } from '@hint/utils-css';
+import { getFullCSSCodeSnippet, getCSSLocationFromNode } from '@hint/utils-css';
 import { StyleEvents, StyleParse } from '@hint/parser-css';
 import { Severity } from '@hint/utils-types';
 
@@ -111,7 +111,7 @@ export default class CssPrefixOrderHint implements IHint {
                     const message = formatMessage(invalidPair);
                     const isValue = invalidPair.lastPrefixed.prop === invalidPair.unprefixed.prop;
                     const location = getCSSLocationFromNode(invalidPair.unprefixed, { isValue });
-                    const codeSnippet = getCSSCodeSnippet(invalidPair.unprefixed);
+                    const codeSnippet = getFullCSSCodeSnippet(invalidPair.unprefixed);
                     const severity = Severity.warning;
 
                     context.report(

--- a/packages/utils-css/README.md
+++ b/packages/utils-css/README.md
@@ -15,3 +15,4 @@ npm install hint --save-dev
 
 * `getCSSCodeSnippet`: Generate a Snippet code for a CSS node.
 * `getCSSLocationFromNode`: Returns the location of a CSS node.
+* `getFullCSSCodeSnippet`: Generate a full Snippet code for a CSS node.

--- a/packages/utils-css/src/get-css-code-snippet.ts
+++ b/packages/utils-css/src/get-css-code-snippet.ts
@@ -88,6 +88,57 @@ ${getChildrenCodeSnippet(child.nodes).replace(/^/gm, '    ')}
     return result.trim();
 };
 
+/**
+ * Generate a Snippet code for a CSS node.
+ *
+ * Examples:
+ *
+ * Node type `rule`:
+ *
+ *     .selector {
+ *         prop1: value;
+ *         prop2: value;
+ *     }
+ *
+ * Node type `decl`
+ *
+ *     .selector {
+ *         prop1: value;
+ *         prop2: value;
+ *     }
+ *
+ * Node type `comment`
+ *
+ *      /* comment * / (the space is intentional to not break the comment)
+ *
+ * Node type `atrule`
+ *
+ *     @keyframe name {
+ *         %0 {
+ *             prop1: value;
+ *             prop2: value;
+ *         }
+ *     }
+ *
+ * Node type `rule` inside `atrule`
+ *
+ *     @support (display: grid) {
+ *         .selector {
+ *             prop1: value;
+ *             prop2: value;
+ *         }
+ *     }
+ *
+ * Node type `decl` inside `atrule`
+ *
+ *     @support (display: grid) {
+ *         .selector {
+ *             prop: value;
+ *             prop: value;
+ *         }
+ *     }
+ * @param node - Node to generate the snippet code
+ */
 export const getFullCSSCodeSnippet = (node: ChildNode): string => {
     const children = 'nodes' in node && node.nodes;
     const defaultSuffix = node.type === 'comment' ? '' : ';';

--- a/packages/utils-css/tests/fixtures/report.css
+++ b/packages/utils-css/tests/fixtures/report.css
@@ -9,7 +9,9 @@
 @keyframes keyname {
     0% {
         /* keyframe comment */
+
         width: 0;
+        height: 0;
     }
 }
 
@@ -21,6 +23,7 @@
     @supports (display:flex) {
         .document-head .center .document-actions {
             flex-grow: 9999;
+            flex-direction: column;
         }
     }
 }

--- a/packages/utils-css/tests/get-css-code-snippet.ts
+++ b/packages/utils-css/tests/get-css-code-snippet.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import anyTest, { TestInterface } from 'ava';
 import * as postcss from 'postcss';
 
-import { getCSSCodeSnippet } from '../src/get-css-code-snippet';
+import { getCSSCodeSnippet, getFullCSSCodeSnippet } from '../src/get-css-code-snippet';
 
 const safe = require('postcss-safe-parser');
 
@@ -22,14 +22,14 @@ test.before(async (t) => {
     t.context.ast = parsedCSS.root!;
 });
 
-test(`If node type is 'atrule' with no children, it should print the atrule without braces.`, (t) => {
+test(`getCSSCodeSnippet - If node type is 'atrule' with no children, it should print the atrule without braces.`, (t) => {
     const node = t.context.ast.nodes![0];
     const expected = `@charset "UTF-8";`;
 
     t.is(getCSSCodeSnippet(node), expected);
 });
 
-test(`If node type is 'comment' it should print only the comment.`, (t) => {
+test(`getCSSCodeSnippet - If node type is 'comment' it should print only the comment.`, (t) => {
     const node = t.context.ast.nodes![1];
 
     const expected = '/* comment */';
@@ -37,7 +37,7 @@ test(`If node type is 'comment' it should print only the comment.`, (t) => {
     t.is(getCSSCodeSnippet(node), expected);
 });
 
-test(`If node type is 'rule' it should print only the selector.`, (t) => {
+test(`getCSSCodeSnippet - If node type is 'rule' it should print only the selector.`, (t) => {
     const node = t.context.ast.nodes![2];
 
     const expected = '.selector { }';
@@ -45,7 +45,7 @@ test(`If node type is 'rule' it should print only the selector.`, (t) => {
     t.is(getCSSCodeSnippet(node), expected);
 });
 
-test(`If node type is 'decl' and the first item in the rule, it should print the rule and only the decl.`, (t) => {
+test(`getCSSCodeSnippet - If node type is 'decl' and the first item in the rule, it should print the rule and only the decl.`, (t) => {
     const ruleNode = t.context.ast.nodes![2] as postcss.Rule;
     const node = ruleNode.nodes![0];
     const expected = `.selector {
@@ -55,7 +55,7 @@ test(`If node type is 'decl' and the first item in the rule, it should print the
     t.is(getCSSCodeSnippet(node), expected);
 });
 
-test(`If node type is 'decl' and the second item in the rule, it should print the rule and only the decl.`, (t) => {
+test(`getCSSCodeSnippet - If node type is 'decl' and the second item in the rule, it should print the rule and only the decl.`, (t) => {
     const ruleNode = t.context.ast.nodes![2] as postcss.Rule;
     const node = ruleNode.nodes![1];
     const expected = `.selector {
@@ -65,14 +65,14 @@ test(`If node type is 'decl' and the second item in the rule, it should print th
     t.is(getCSSCodeSnippet(node), expected);
 });
 
-test(`If node type is 'atrule', it should print the atrule.`, (t) => {
+test(`getCSSCodeSnippet - If node type is 'atrule', it should print the atrule.`, (t) => {
     const node = t.context.ast.nodes![3];
     const expected = `@keyframes keyname { }`;
 
     t.is(getCSSCodeSnippet(node), expected);
 });
 
-test(`If node type is 'rule' and it is inside an atrule, it should print the atrule and the rule.`, (t) => {
+test(`getCSSCodeSnippet - If node type is 'rule' and it is inside an atrule, it should print the atrule and the rule.`, (t) => {
     const atRuleNode = t.context.ast.nodes![3] as postcss.AtRule;
     const node = atRuleNode.nodes![0];
     const expected = `@keyframes keyname {
@@ -82,7 +82,7 @@ test(`If node type is 'rule' and it is inside an atrule, it should print the atr
     t.is(getCSSCodeSnippet(node), expected);
 });
 
-test(`If node type is 'comment' and it is inside a rule and an atrule, it should print the atrule, the rule and the comment.`, (t) => {
+test(`getCSSCodeSnippet - If node type is 'comment' and it is inside a rule and an atrule, it should print the atrule, the rule and the comment.`, (t) => {
     const atRuleNode = t.context.ast.nodes![3] as postcss.AtRule;
     const ruleNode = atRuleNode.nodes![0] as postcss.Rule;
     const node = ruleNode.nodes![0];
@@ -95,7 +95,7 @@ test(`If node type is 'comment' and it is inside a rule and an atrule, it should
     t.is(getCSSCodeSnippet(node), expected);
 });
 
-test(`If node type is 'decl' and it is inside a rule and an atrule, it should print the atrule, the rule and the decl.`, (t) => {
+test(`getCSSCodeSnippet - If node type is 'decl' and it is inside a rule and an atrule, it should print the atrule, the rule and the decl.`, (t) => {
     const atRuleNode = t.context.ast.nodes![3] as postcss.AtRule;
     const ruleNode = atRuleNode.nodes![0] as postcss.Rule;
     const node = ruleNode.nodes![1];
@@ -108,7 +108,7 @@ test(`If node type is 'decl' and it is inside a rule and an atrule, it should pr
     t.is(getCSSCodeSnippet(node), expected);
 });
 
-test(`If node type is 'rule' with multple selectors it should print each selector on its own line.`, (t) => {
+test(`getCSSCodeSnippet - If node type is 'rule' with multiple selectors it should print each selector on its own line.`, (t) => {
     const node = t.context.ast.nodes![4];
 
     const expected = '.selector1,\n.selector2 { }';
@@ -116,7 +116,7 @@ test(`If node type is 'rule' with multple selectors it should print each selecto
     t.is(getCSSCodeSnippet(node), expected);
 });
 
-test(`If node type is 'decl' and it is inside a rule, atrule, and another atrule, all should print with correct indentation.`, (t) => {
+test(`getCSSCodeSnippet - If node type is 'decl' and it is inside a rule, atrule, and another atrule, all should print with correct indentation.`, (t) => {
     const atRuleNode = t.context.ast.nodes![5] as postcss.AtRule;
     const nestedAtRuleNode = atRuleNode.nodes![0] as postcss.AtRule;
     const ruleNode = nestedAtRuleNode.nodes![0] as postcss.Rule;
@@ -130,4 +130,154 @@ test(`If node type is 'decl' and it is inside a rule, atrule, and another atrule
 }`;
 
     t.is(getCSSCodeSnippet(node), expected);
+});
+
+test(`getFullCSSCodeSnippet - If node type is 'atrule' with no children, it should print the atrule without braces.`, (t) => {
+    const node = t.context.ast.nodes![0];
+    const expected = `@charset "UTF-8";`;
+
+    t.is(getFullCSSCodeSnippet(node), expected);
+});
+
+test(`getFullCSSCodeSnippet - If node type is 'comment' it should print only the comment.`, (t) => {
+    const node = t.context.ast.nodes![1];
+
+    const expected = '/* comment */';
+
+    t.is(getFullCSSCodeSnippet(node), expected);
+});
+
+test(`getFullCSSCodeSnippet - If node type is 'rule' it should print the selector and its children.`, (t) => {
+    const node = t.context.ast.nodes![2];
+
+    const expected = `.selector {
+    color: #000;
+    font-size: 1rem;
+}`;
+
+    t.is(getFullCSSCodeSnippet(node), expected);
+});
+
+test(`getFullCSSCodeSnippet - If node type is 'decl' and the first item in the rule, it should print the rule and all the decls.`, (t) => {
+    const ruleNode = t.context.ast.nodes![2] as postcss.Rule;
+    const node = ruleNode.nodes![0];
+    const expected = `.selector {
+    color: #000;
+    font-size: 1rem;
+}`;
+
+    t.is(getFullCSSCodeSnippet(node), expected);
+});
+
+test(`getFullCSSCodeSnippet - If node type is 'decl' and the second item in the rule, it should print the rule and all the decls.`, (t) => {
+    const ruleNode = t.context.ast.nodes![2] as postcss.Rule;
+    const node = ruleNode.nodes![1];
+    const expected = `.selector {
+    color: #000;
+    font-size: 1rem;
+}`;
+
+    t.is(getFullCSSCodeSnippet(node), expected);
+});
+
+test(`getFullCSSCodeSnippet - If node type is 'atrule', it should print the atrule and all the children.`, (t) => {
+    const node = t.context.ast.nodes![3];
+    const expected = `@keyframes keyname {
+    0% {
+        /* keyframe comment */
+        width: 0;
+        height: 0;
+    }
+}`;
+
+    t.is(getFullCSSCodeSnippet(node), expected);
+});
+
+test(`getFullCSSCodeSnippet - If node type is 'rule' and it is inside an atrule, it should print the atrule all the children`, (t) => {
+    const atRuleNode = t.context.ast.nodes![3] as postcss.AtRule;
+    const node = atRuleNode.nodes![0];
+    const expected = `@keyframes keyname {
+    0% {
+        /* keyframe comment */
+        width: 0;
+        height: 0;
+    }
+}`;
+
+    t.is(getFullCSSCodeSnippet(node), expected);
+});
+
+
+test(`getFullCSSCodeSnippet - If node type is 'comment' and it is inside a rule and an atrule, it should print the atrule, the rule, the comment and all the decls.`, (t) => {
+    const atRuleNode = t.context.ast.nodes![3] as postcss.AtRule;
+    const ruleNode = atRuleNode.nodes![0] as postcss.Rule;
+    const node = ruleNode.nodes![0];
+    const expected = `@keyframes keyname {
+    0% {
+        /* keyframe comment */
+        width: 0;
+        height: 0;
+    }
+}`;
+
+    t.is(getFullCSSCodeSnippet(node), expected);
+});
+
+test(`getFullCSSCodeSnippet - If node type is 'decl' and it is inside a rule and an atrule, it should print the atrule, the rule, the comment and all the decls.`, (t) => {
+    const atRuleNode = t.context.ast.nodes![3] as postcss.AtRule;
+    const ruleNode = atRuleNode.nodes![0] as postcss.Rule;
+    const node = ruleNode.nodes![1];
+    const expected = `@keyframes keyname {
+    0% {
+        /* keyframe comment */
+        width: 0;
+        height: 0;
+    }
+}`;
+
+    t.is(getFullCSSCodeSnippet(node), expected);
+});
+
+test(`getFullCSSCodeSnippet - If node type is 'rule' with multiple selectors it should print each selector on its own line.`, (t) => {
+    const node = t.context.ast.nodes![4];
+
+    const expected = `.selector1,\n.selector2 {
+    color: #000;
+}`;
+
+    t.is(getFullCSSCodeSnippet(node), expected);
+});
+
+test(`getFullCSSCodeSnippet - If node type is 'decl', the first item and it is inside a rule, atrule, and another atrule, all should print with correct indentation.`, (t) => {
+    const atRuleNode = t.context.ast.nodes![5] as postcss.AtRule;
+    const nestedAtRuleNode = atRuleNode.nodes![0] as postcss.AtRule;
+    const ruleNode = nestedAtRuleNode.nodes![0] as postcss.Rule;
+    const node = ruleNode.nodes![0];
+    const expected = `@media all and (min-width:29.9385em) {
+    @supports (display:flex) {
+        .document-head .center .document-actions {
+            flex-grow: 9999;
+            flex-direction: column;
+        }
+    }
+}`;
+
+    t.is(getFullCSSCodeSnippet(node), expected);
+});
+
+test(`getFullCSSCodeSnippet - If node type is 'decl', the second item and it is inside a rule, atrule, and another atrule, all should print with correct indentation.`, (t) => {
+    const atRuleNode = t.context.ast.nodes![5] as postcss.AtRule;
+    const nestedAtRuleNode = atRuleNode.nodes![0] as postcss.AtRule;
+    const ruleNode = nestedAtRuleNode.nodes![0] as postcss.Rule;
+    const node = ruleNode.nodes![1];
+    const expected = `@media all and (min-width:29.9385em) {
+    @supports (display:flex) {
+        .document-head .center .document-actions {
+            flex-grow: 9999;
+            flex-direction: column;
+        }
+    }
+}`;
+
+    t.is(getFullCSSCodeSnippet(node), expected);
 });


### PR DESCRIPTION
Fix #3347

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
![image](https://user-images.githubusercontent.com/1581288/69283056-83ac4700-0ba0-11ea-9875-726f7dacbfe3.png)

