### PR TITLE
Fix: Information position in minimum hint severity section

### DIFF
--- a/packages/extension-browser/src/devtools/views/pages/config/sections/severities.tsx
+++ b/packages/extension-browser/src/devtools/views/pages/config/sections/severities.tsx
@@ -69,17 +69,6 @@ const SeveritySection = ({ className, query, onChange }: Props) => {
             </ConfigLabel>
             <ConfigLabel>
                 <Radio
-                    aria-labelledby={`${groupLabelId} ${informationLabelId}`}
-                    checked={query === Severity.information.toString()}
-                    name="severity"
-                    onChange={onInformationSelected}
-                />
-                <LabelText id={informationLabelId}>
-                    {getMessage('informationLabel')}
-                </LabelText>
-            </ConfigLabel>
-            <ConfigLabel>
-                <Radio
                     aria-labelledby={`${groupLabelId} ${hintLabelId}`}
                     checked={query === Severity.hint.toString()}
                     name="severity"
@@ -87,6 +76,17 @@ const SeveritySection = ({ className, query, onChange }: Props) => {
                 />
                 <LabelText id={hintLabelId}>
                     {getMessage('hintLabel')}
+                </LabelText>
+            </ConfigLabel>
+            <ConfigLabel>
+                <Radio
+                    aria-labelledby={`${groupLabelId} ${informationLabelId}`}
+                    checked={query === Severity.information.toString()}
+                    name="severity"
+                    onChange={onInformationSelected}
+                />
+                <LabelText id={informationLabelId}>
+                    {getMessage('informationLabel')}
                 </LabelText>
             </ConfigLabel>
         </ConfigSection>


### PR DESCRIPTION
Fix #3375

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

![image](https://user-images.githubusercontent.com/1581288/69286943-6039ca00-0ba9-11ea-8a8a-da2b7824851d.png)

For selfhosting:

Chromium:
[webhint-1.2.1.zip](https://github.com/webhintio/hint/files/3872001/webhint-1.2.1.zip)

Firefox:
[webhint-1.2.1.zip](https://github.com/webhintio/hint/files/3872002/webhint-1.2.1.zip)

