### PR TITLE
Fix: Stability issues with VS Code extension

### DIFF
--- a/packages/extension-vscode/src/utils/analytics.ts
+++ b/packages/extension-vscode/src/utils/analytics.ts
@@ -103,6 +103,7 @@ export const trackSave = (uri: string, languageId: string) => {
     }
 
     // Throttle tracking saves to reduce redundant reports when autosave is on.
+    /* istanbul ignore if */
     if (lastSave && now - lastSave < twoMinutes) {
         return;
     }

--- a/packages/extension-vscode/src/utils/prompts.ts
+++ b/packages/extension-vscode/src/utils/prompts.ts
@@ -1,24 +1,5 @@
 import { RemoteWindow } from 'vscode-languageserver';
 
-export const promptAddWebhint = async (window: RemoteWindow, install: () => Promise<void>) => {
-    const addWebhint = 'Add webhint';
-    const cancel = 'Cancel';
-    const answer = await window.showInformationMessage(
-        'A local `.hintrc` was found. Add webhint to this project?',
-        { title: addWebhint },
-        { title: cancel }
-    );
-
-    if (answer && answer.title === addWebhint) {
-        try {
-            await install();
-            window.showInformationMessage('Finished installing webhint!');
-        } catch (err) {
-            window.showErrorMessage(`Unable to install webhint:\n${err}`);
-        }
-    }
-};
-
 export const promptRetry = async <T>(window: RemoteWindow, retry: () => Promise<T | null>): Promise<T | null> => {
     // Prompt the user to retry after checking their configuration.
     const retryTitle = 'Retry';

--- a/packages/extension-vscode/tests/utils/problems.ts
+++ b/packages/extension-vscode/tests/utils/problems.ts
@@ -62,7 +62,7 @@ test('It translates missing endColumn and endLine properties correctly', (t) => 
         hintId: 'test-id-1',
         location,
         message: 'Test Message 1',
-        severity: Severity.warning
+        severity: Severity.hint
     } as Problem;
 
     const diagnostic = problemToDiagnostic(problem);
@@ -70,7 +70,7 @@ test('It translates missing endColumn and endLine properties correctly', (t) => 
     t.is(diagnostic.source, 'webhint');
     t.true(diagnostic.message.indexOf(problem.message || '') !== -1);
     t.true(diagnostic.message.indexOf(problem.hintId || '') !== -1);
-    t.is(diagnostic.severity, DiagnosticSeverity.Warning);
+    t.is(diagnostic.severity, DiagnosticSeverity.Hint);
     t.is(diagnostic.range.start.line, location.line);
     t.is(diagnostic.range.start.character, location.column);
     t.is(diagnostic.range.end.character, location.column);

--- a/packages/extension-vscode/tests/utils/prompts.ts
+++ b/packages/extension-vscode/tests/utils/prompts.ts
@@ -2,77 +2,7 @@ import test from 'ava';
 import * as sinon from 'sinon';
 import { RemoteWindow } from 'vscode-languageserver';
 
-import { promptAddWebhint, promptRetry } from '../../src/utils/prompts';
-
-test('It prompts the user to install webhint', async (t) => {
-    const install = sinon.stub().resolves();
-    const showInformationMessage = sinon
-        .stub<Parameters<RemoteWindow['showInformationMessage']>>()
-        .resolves();
-
-    await promptAddWebhint(
-        { showInformationMessage } as Partial<RemoteWindow> as RemoteWindow,
-        install
-    );
-
-    t.is(install.callCount, 0);
-    t.is(showInformationMessage.callCount, 1);
-    t.is(showInformationMessage.firstCall.args.length, 3);
-    t.is(showInformationMessage.firstCall.args[0], 'A local `.hintrc` was found. Add webhint to this project?');
-    t.deepEqual(showInformationMessage.firstCall.args[1], { title: 'Add webhint'});
-    t.deepEqual(showInformationMessage.firstCall.args[2], { title: 'Cancel'});
-});
-
-test('It does not install if the user selects "Cancel"', async (t) => {
-    const install = sinon.stub().resolves();
-    const showInformationMessage = sinon
-        .stub<Parameters<RemoteWindow['showInformationMessage']>>()
-        .resolves({ title: 'Cancel '});
-
-    await promptAddWebhint(
-        { showInformationMessage } as Partial<RemoteWindow> as RemoteWindow,
-        install
-    );
-
-    t.is(install.callCount, 0);
-});
-
-test('It does install if the user selects "Add webhint"', async (t) => {
-    const install = sinon.stub().resolves();
-    const showInformationMessage = sinon
-        .stub<Parameters<RemoteWindow['showInformationMessage']>>()
-        .resolves({ title: 'Add webhint' });
-
-    await promptAddWebhint(
-        { showInformationMessage } as Partial<RemoteWindow> as RemoteWindow,
-        install
-    );
-
-    t.is(install.callCount, 1);
-    t.is(showInformationMessage.callCount, 2);
-    t.is(showInformationMessage.secondCall.args.length, 1);
-    t.is(showInformationMessage.secondCall.args[0], 'Finished installing webhint!');
-});
-
-test('It notifies the user if installation fails', async (t) => {
-    const install = sinon.stub().throws();
-    const showErrorMessage = sinon
-        .stub<Parameters<RemoteWindow['showErrorMessage']>>()
-        .resolves();
-    const showInformationMessage = sinon
-        .stub<Parameters<RemoteWindow['showInformationMessage']>>()
-        .resolves({ title: 'Add webhint' });
-
-    await promptAddWebhint(
-        { showErrorMessage, showInformationMessage } as Partial<RemoteWindow> as RemoteWindow,
-        install
-    );
-
-    t.is(install.callCount, 1);
-    t.is(showErrorMessage.callCount, 1);
-    t.is(showErrorMessage.firstCall.args.length, 1);
-    t.regex(showErrorMessage.firstCall.args[0], /^Unable to install webhint/);
-});
+import { promptRetry } from '../../src/utils/prompts';
 
 test('It prompts the user to retry if initializing webhint fails', async (t) => {
     const retry = sinon.stub().resolves(null);

--- a/packages/extension-vscode/tests/utils/webhint-packages.ts
+++ b/packages/extension-vscode/tests/utils/webhint-packages.ts
@@ -64,22 +64,9 @@ test('It loads shared webhint when prompting to install a local copy', async (t)
     const { module, stubs } = stubContext();
     const loadPackageSpy = sandbox.spy(stubs['./packages'], 'loadPackage');
 
-    let promptCalled = false;
-    let promptComplete = false;
-
-    const hint = await module.loadWebhint('local', 'global', async () => {
-        promptCalled = true;
-
-        await new Promise((resolve) => {
-            setTimeout(resolve, 0);
-        });
-
-        promptComplete = true;
-    });
+    const hint = await module.loadWebhint('local', 'global');
 
     t.is(hint as any, 'webhint');
-    t.true(promptCalled);
-    t.false(promptComplete);
     t.true(loadPackageSpy.calledTwice);
     t.deepEqual(loadPackageSpy.firstCall.args[0], 'hint');
     t.deepEqual(loadPackageSpy.firstCall.args[1], { paths: ['local'] });


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

The VS Code extension could end up breaking `node_modules` in the
workspace or the global shared folder. This was caused because we were
installing `hint@latest` in the workspace and because that process
took too long and the user might closed the editor before it was
ended.
To avoid that we now let the user manage their own `hint` installation
in the workspace, no more prompting about installation. If no version
can be loaded from the workspace, the shared one (`hint@latest`) will
be used.
Also, the shared version is updated after 2 minutes instead of
immediately and only if the shared version has been successfully
loaded.
If the user already has a workspace version there is no point in
updating the shared one as it will not be used.


<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
