### PR TITLE
Fix: Add getUserConfig to the try/catch block

### DIFF
--- a/packages/extension-vscode/src/utils/analyze.ts
+++ b/packages/extension-vscode/src/utils/analyze.ts
@@ -54,15 +54,15 @@ export class Analyzer {
             return null;
         }
 
-        const userConfig = getUserConfig(hintModule, directory);
-
         try {
+            const userConfig = getUserConfig(hintModule, directory);
+
             return hintModule.createAnalyzer(userConfig);
         } catch (e) {
             // Instantiating webhint failed, log the error to the webhint output panel to aid debugging.
             console.error(e);
 
-            return await promptRetry(this.connection.window, /* istanbul ignore next */ () => {
+            return await promptRetry(this.connection.window, /* istanbul ignore next */() => {
                 this.connection.sendNotification(notifications.showOutput);
 
                 // We retry with the shared version as it is more likely to not be broken 🤞


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

Using and old version of webhint, the vscode extension throw an exception in the method `getUserConfig`, and the extension stop working. Adding that method to the `try/catch` block, if something fails, it will prompt a message to continue using the shared version of webhint.