### PR TITLE
Fix: Normalize hints when extending

### DIFF
--- a/packages/hint/src/lib/config.ts
+++ b/packages/hint/src/lib/config.ts
@@ -99,6 +99,8 @@ const composeConfig = (userConfig: UserConfig, parentConfig = '') => {
             throw new Error(`Configuration package "${config}" is not valid`);
         }
 
+        loadedConfiguration.hints = normalizeHints(loadedConfiguration.hints);
+
         return composeConfig(loadedConfiguration, config);
     });
 

--- a/packages/hint/tests/lib/fixtures/valid/array-hints.json
+++ b/packages/hint/tests/lib/fixtures/valid/array-hints.json
@@ -1,0 +1,19 @@
+{
+    "connector": {
+        "name": "chrome",
+        "options": {
+            "waitFor": 1000
+        }
+    },
+    "formatters": [
+        "json"
+    ],
+    "parsers": [
+        "typescript"
+    ],
+    "hints": [
+        "axe",
+        "disallowed-headers",
+        "https-only"
+    ]
+}


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
