### PR TITLE
Fix: Normalize duplicate headers

### DIFF
--- a/packages/utils-connector-tools/src/normalize-headers.ts
+++ b/packages/utils-connector-tools/src/normalize-headers.ts
@@ -4,7 +4,19 @@ import { HttpHeaders } from '@hint/utils-types';
 export const normalizeHeaders = (headers?: HttpHeaders | null) => {
     if (headers) {
         return Object.keys(headers).reduce((result, key) => {
-            result[key.toLowerCase().trim()] = headers[key];
+            /**
+             * CDP combines duplicated headers and instead of separate
+             * the values with `,` it uses `\n`:
+             *  - https://github.com/puppeteer/puppeteer/issues/5244
+             *
+             * Additionally, some architectures can send duplicate headers
+             * with the same value (https://github.com/webhintio/hint/issues/750#issuecomment-562874029).
+             *
+             * We remove the duplicate values for easier processing.
+             */
+            const values = new Set(headers[key]?.split('\n'));
+
+            result[key.toLowerCase().trim()] = Array.from(values).join(', ');
 
             return result;
         }, {} as HttpHeaders);

--- a/packages/utils-connector-tools/tests/normalize-headers.ts
+++ b/packages/utils-connector-tools/tests/normalize-headers.ts
@@ -14,11 +14,11 @@ test(`'normalizeHeaders' returns '{}' for '{}'`, (t) => {
     t.deepEqual(normalizeHeaders({}), {});
 });
 
-test(`'normalizeHeaders' returns object with lowercase headers field names`, (t) => {
+test(`'normalizeHeaders' returns object with lowercase headers field names and removing duplicates`, (t) => {
     const headers = {
         'Content-Type': 'text/html; charset=utf-8',
         Vary: 'Accept-Encoding',
-        'X-Content-Type-Options': 'nosniff',
+        'X-Content-Type-Options': 'nosniff\nnosniff',
         'X-Frame-Options': 'DENY',
         'X-XSS-Protection': '1; mode=block'
     };


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- ~~Added/Updated related documentation.~~
- [x] Added/Updated related tests.

## Short description of the change(s)

CDP combines duplicated headers with `\n` while `request` follows
[HTTP
RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).

This changes the behavior to be `,` separated and remove duplicated
values.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #750


<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
