### PR TITLE
Fix: Use chrome beta for builds

### DIFF
--- a/azure-pipelines/full.yml
+++ b/azure-pipelines/full.yml
@@ -1,10 +1,10 @@
 steps:
   - script: |
       sudo apt-get update
-      sudo apt-get install -y google-chrome-stable
+      sudo apt-get install -y google-chrome-beta
     condition: eq(variables['Agent.OS'], 'Linux')
     displayName: 'Update Chrome on Linux'
-  - script: brew update && brew cask install google-chrome
+  - script: brew update && brew cask uninstall google-chrome && brew cask install google-chrome-beta
     condition: eq(variables['Agent.OS'], 'Darwin')
     displayName: 'Update Chrome on macOS'
   - task: NodeTool@0

--- a/azure-pipelines/standard.yml
+++ b/azure-pipelines/standard.yml
@@ -1,10 +1,10 @@
 steps:
   - script: |
       sudo apt-get update
-      sudo apt-get install -y google-chrome-stable
+      sudo apt-get install -y google-chrome-beta
     condition: eq(variables['Agent.OS'], 'Linux')
     displayName: 'Update Chrome on Linux'
-  - script: brew update && brew cask install google-chrome
+  - script: brew update && brew cask uninstall google-chrome && brew cask install google-chrome-beta
     condition: eq(variables['Agent.OS'], 'Darwin')
     displayName: 'Update Chrome on macOS'
   - task: NodeTool@0


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

Linux and macOS are failing a lot in CI. Looks like the problem is the current version of the browser with puppeteer. Using the beta version of the browser looks like fix the issue.