### PR TITLE
Fix: Return an Error instead of an string when rejecting

### DIFF
--- a/packages/extension-vscode/src/utils/process.ts
+++ b/packages/extension-vscode/src/utils/process.ts
@@ -17,7 +17,7 @@ export const run = (command: string, options?: SpawnOptions) => {
 
         child.on('exit', (code) => {
             if (code) {
-                reject(code);
+                reject(new Error('NoExitCodeZero'));
             } else {
                 resolve();
             }

--- a/packages/hint-html-checker/src/hint.ts
+++ b/packages/hint-html-checker/src/hint.ts
@@ -136,7 +136,7 @@ export default class HtmlCheckerHint implements IHint {
             debug(`Error getting HTML checker result for ${resource}.`, error);
             context.report(
                 resource,
-                getMessage('couldNotGetResult', context.language, [resource, error.toString()]),
+                getMessage('couldNotGetResult', context.language, [resource, error.message]),
                 { severity: Severity.warning });
         };
 

--- a/packages/hint-html-checker/tests/tests.ts
+++ b/packages/hint-html-checker/tests/tests.ts
@@ -91,7 +91,7 @@ const htmlCheckerMock = (response: any) => {
             return Promise.resolve(JSON.stringify(responseMessages));
         }
 
-        return Promise.reject(validatorError); // Error with the validator
+        return Promise.reject(new Error(validatorError)); // Error with the validator
     };
 
     (utilsNetwork as any).requestAsync = requestAsync;

--- a/packages/hint-image-optimization-cloudinary/tests/tests.ts
+++ b/packages/hint-image-optimization-cloudinary/tests/tests.ts
@@ -49,7 +49,7 @@ const mockCloudinary = (responses?: Partial<cloudinaryResult> | Partial<cloudina
             uploader: {
                 upload: () => {
                     if (!responses) {
-                        return Promise.reject('Invalid image');
+                        return Promise.reject(new Error('Invalid image'));
                     }
 
                     const response = Array.isArray(responses) ? responses.shift() : responses;

--- a/packages/hint-no-broken-links/src/hint.ts
+++ b/packages/hint-no-broken-links/src/hint.ts
@@ -100,8 +100,8 @@ export default class NoBrokenLinksHint implements IHint {
         const handleRejection = (error: any, url: string, element: HTMLElement) => {
             debug(`Error accessing ${url}. ${JSON.stringify(error)}`);
 
-            if (typeof error === 'string' && error.toLowerCase().includes('loop')) {
-                return context.report(url, error, { element, severity: Severity.error });
+            if (error.message && error.message.toLowerCase().includes('loop')) {
+                return context.report(url, error.message, { element, severity: Severity.error });
             }
 
             return context.report(

--- a/packages/hint-strict-transport-security/tests/_common.ts
+++ b/packages/hint-strict-transport-security/tests/_common.ts
@@ -80,7 +80,7 @@ export const requestJSONAsyncMock = (responseObject: any) => {
         }
 
         if (!response) {
-            return Promise.reject('Error with the verification service.');
+            return Promise.reject(new Error('Error with the verification service.'));
         }
 
         return Promise.resolve(response);

--- a/packages/utils-connector-tools/src/requester.ts
+++ b/packages/utils-connector-tools/src/requester.ts
@@ -266,7 +266,7 @@ export class Requester {
                         const newUri = url.resolve(uriString, response.headers.location as string);
 
                         if (requestedUrls.has(newUri)) {
-                            return reject(`'${uriString}' could not be fetched using ${this._options.method || 'GET'} method (redirect loop detected).`);
+                            return reject(new Error(`'${uriString}' could not be fetched using ${this._options.method || 'GET'} method (redirect loop detected).`));
                         }
 
                         this._redirects.add(newUri, uriString);
@@ -274,7 +274,7 @@ export class Requester {
                         const currentRedirectNumber = this._redirects.calculate(newUri).length;
 
                         if (currentRedirectNumber > this._maxRedirects) {
-                            return reject(`The number of redirects(${currentRedirectNumber}) exceeds the limit(${this._maxRedirects}).`);
+                            return reject(new Error(`The number of redirects(${currentRedirectNumber}) exceeds the limit(${this._maxRedirects}).`));
                         }
 
                         try {

--- a/packages/utils-connector-tools/tests/requester.ts
+++ b/packages/utils-connector-tools/tests/requester.ts
@@ -224,7 +224,7 @@ test(`Throws an error if number of hops exceeds the redirect limit`, async (t) =
     try {
         await maxRedirectsRequester.get(`http://localhost:${server.port}/hop301`);
     } catch (e) {
-        t.is(e, 'The number of redirects(5) exceeds the limit(4).');
+        t.is(e.message, 'The number of redirects(5) exceeds the limit(4).');
     }
 
     await server.stop();
@@ -258,7 +258,7 @@ test(`Requester returns and exception if a loop is detected`, async (t) => {
     try {
         await requester.get(`http://localhost:${server.port}/hop301`) as NetworkData; // eslint-disable-line no-unused-expressions
     } catch (e) {
-        t.is(e, `'http://localhost:${server.port}/hop301' could not be fetched using GET method (redirect loop detected).`);
+        t.is(e.message, `'http://localhost:${server.port}/hop301' could not be fetched using GET method (redirect loop detected).`);
     }
 
     await server.stop();
@@ -274,7 +274,7 @@ test(`Requester returns and exception if a loop is detected after few redirects`
     try {
         await requester.get(`http://localhost:${server.port}/hop301`) as NetworkData; // eslint-disable-line no-unused-expressions
     } catch (e) {
-        t.is(e, `'http://localhost:${server.port}/hop303' could not be fetched using GET method (redirect loop detected).`);
+        t.is(e.message, `'http://localhost:${server.port}/hop303' could not be fetched using GET method (redirect loop detected).`);
     }
 
     await server.stop();

--- a/packages/utils/src/npm.ts
+++ b/packages/utils/src/npm.ts
@@ -23,7 +23,7 @@ const install = (command: string) => {
 
         npmInstall.on('exit', (code) => {
             if (code !== 0) {
-                return reject();
+                return reject(new Error('NoExitCodeZero'));
             }
 
             return resolve(true);

--- a/packages/utils/tests/async-wrapper.ts
+++ b/packages/utils/tests/async-wrapper.ts
@@ -5,7 +5,7 @@ import { asyncTry } from '../src';
 test(`asyncTry returns null if the function wrapped is rejected`, async (t) => {
     const fn = () => {
         return new Promise((resolve, reject) => {
-            reject('error');
+            reject(new Error('error'));
         });
     };
 


### PR DESCRIPTION
Fix #1745

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
