### PR TITLE
Fix: Allow //-urls on dns-prefetch

### DIFF
--- a/packages/hint-no-protocol-relative-urls/src/hint.ts
+++ b/packages/hint-no-protocol-relative-urls/src/hint.ts
@@ -46,8 +46,9 @@ export default class NoProtocolRelativeUrlsHint implements IHint {
              */
 
             const url: string = (element.getAttribute('src') || element.getAttribute('href') || '').trim();
+            const rel = element.getAttribute('rel') || '';
 
-            if (url.startsWith('//')) {
+            if (url.startsWith('//') && rel !== 'dns-prefetch') {
                 debug('Protocol relative URL found');
 
                 const message = getMessage('noProtocolRelativeUrl', context.language, url);

--- a/packages/hint-no-protocol-relative-urls/tests/_generate-tests.ts
+++ b/packages/hint-no-protocol-relative-urls/tests/_generate-tests.ts
@@ -31,6 +31,10 @@ const getTests = (severity: Severity) => {
             serverConfig: generateHTMLPage('<link rel="manifest" href="//site.webmanifest">')
         },
         {
+            name: `'link' for 'dns-prefetch' with initial // passes the hint`,
+            serverConfig: generateHTMLPage('<link rel="dns-prefetch" href="//host_name_to_prefetch.com">')
+        },
+        {
             name: `'script' with no initial slashes passes the hint`,
             serverConfig: generateHTMLPage(undefined, '<script src="script.js"></script>')
         },


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Allow no-protocol-relative-urls like "//host_name_to_prefetch.com" when rel="dns-prefetch" is specified.

Fixes #3505