### PR TITLE
Fix: Detect invalid backslash in cookie

### DIFF
--- a/packages/hint-validate-set-cookie-header/src/hint.ts
+++ b/packages/hint-validate-set-cookie-header/src/hint.ts
@@ -38,12 +38,12 @@ export default class ValidateSetCookieHeaderHint implements IHint {
          * A collection of illegal characters in cookie name
          * Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Directives
          */
-        const illegalCookieNameChars = '()<>@,;:\"/[]?={}'; // eslint-disable-line no-useless-escape
+        const illegalCookieNameChars = '()<>@,;:\\"/[]?={}';
         /**
          * A collection of illegal characters in cookie value
          * Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Directives
          */
-        const illegalCookieValueChars = ',;"/';
+        const illegalCookieValueChars = ',;"\\';
         /** Header name used in report */
         const headerName = 'set-cookie';
 

--- a/packages/hint-validate-set-cookie-header/tests/tests.ts
+++ b/packages/hint-validate-set-cookie-header/tests/tests.ts
@@ -23,6 +23,7 @@ const noHttpOnlyHeader = setCookie(`cookieName=cookieValue; Secure`);
 
 const invalidNameHeader = setCookie(`"cookieName"=cookieValue; Secure; HttpOnly`);
 const invalidValueHeader = setCookie(`cookieName=cookie value; Secure; HttpOnly`);
+const invalidHeaderBackslash = setCookie(`cookie\\Name=cookie\\Value; Secure; HttpOnly`);
 const invalidDateFormatHeader = setCookie(`cookieName=cookieValue; expires=Wed, 31-Dec-97 23:59:59 GMT; Secure; HttpOnly`);
 const trailingSemicolonHeader = setCookie(`cookieName=cookieValue; Secure; HttpOnly;`);
 const multipleErrorsHeader = setCookie(`"cookieName"=cookie value`);
@@ -120,6 +121,18 @@ const defaultTests: HintTest[] = [
             severity: Severity.error
         }],
         serverConfig: { '/': { headers: invalidValueHeader } }
+    },
+    {
+        name: `Cookie name and value contains invalid character (backslash)`,
+        reports: [{
+            message: messages('cookie\\name').invalidNameError,
+            severity: Severity.error
+        },
+        {
+            message: messages('cookie\\name').invalidValueError,
+            severity: Severity.error
+        }],
+        serverConfig: { '/': { headers: invalidHeaderBackslash } }
     },
     {
         name: `'Expires' directive contains invalid date format`,


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Correctly detect disallowed backslash (`\`) characters in cookie name or value.
Also allows accidentally disallowed forward slash in cookie value.
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Directives
> [cookie name] must not contain a separator character like the following: 
`( ) < > @ , ; : \ " / [ ] ? = { }`.

> [cookie value can be any charachter] excluding control characters, Whitespace, double quotes, comma, semicolon, and backslash