### PR TITLE
New: Try puppeteer's Chromium if no browser is specified

### DIFF
--- a/packages/connector-puppeteer/README.md
+++ b/packages/connector-puppeteer/README.md
@@ -49,10 +49,11 @@ All properties of `options` are optional.
 * `auth`: The credentials and elements to authenticate on a website.
   See next section for further details.
 * `browser (Chrome|Chromium|Edge)`: Tells the preferred browser to
-  use. Webhint will search the executable for the given one and fail
+  use. If unspecified webhint will look for a `puppeteer` installation
+  before falling back to searching for an installed browser and fail
   if it does not find one. Keep in mind that not all browsers are
-  available in all platforms and that you need to **manually install
-  the browser**.
+  available on all platforms and that you need to **manually install
+  either puppeteer or a browser** for this connector to work.
 * `headless (boolean)`: Indicates if the browser should run in headless
   mode or not. It is `true` by default when running on CI or
   in WSL, `false` otherwise.

--- a/packages/connector-puppeteer/src/lib/chromium-finder.ts
+++ b/packages/connector-puppeteer/src/lib/chromium-finder.ts
@@ -337,7 +337,8 @@ const resolveChromiumPath = () => {
 
 /**
  * Searchs for a valid Chromium browser from the ones supported. The current priority list is:
- * `Chrome Canary`, `Chrome`, `Chromium`, `Edge Canary`, `Edge Dev` (`Edge` only on `win32 platforms).
+ * `Puppeteer`, `Chrome Canary`, `Chrome`, `Chromium`, `Edge Canary`, `Edge Dev` (`Edge` only
+ * on `win32 platforms).
  *
  * A user can also pass the browser to use (`Chrome`, `Chromium`, `Edge`) via the `options` parameter
  * or a `path` to the executable to use (`getInstallationPath` will only verify it exists, not if
@@ -369,6 +370,17 @@ export const getInstallationPath = (options?: { browser?: Browser; browserPath?:
         }
 
         throw new Error(ERRORS.NoInstallationFound`${options.browser}`);
+    }
+
+    /**
+     * When unspecified, prefer using the version of Chromium bundled
+     * with puppeteer first (if available) as it is the most likely to
+     * be compatible with the used version of puppeteer-core.
+     */
+    try {
+        return require('puppeteer').executablePath();
+    } catch (e) {
+        // Fall back to searching for installed browsers.
     }
 
     /** The order in which to search for browsers in case none are provided. */

--- a/packages/connector-puppeteer/tests/actions.ts
+++ b/packages/connector-puppeteer/tests/actions.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 
 import test from 'ava';
 import { Engine, Events } from 'hint';
-import { executablePath } from 'puppeteer';
 
 import Connector from '../src/connector';
 
@@ -30,8 +29,7 @@ test(`[${name}] Connector throws an exception if action is not found`, (t) => {
                 file: `fake-file`,
                 on: 'beforeTargetNavigation'
             }],
-            detached: true,
-            puppeteerOptions: { executablePath: executablePath() }
+            detached: true
         });
 
         connector.close();
@@ -68,8 +66,7 @@ test(`[${name}] Connector loads an action and throws if it does not have the rig
                 file: actionPath,
                 on: 'afterTargetNavigation'
             }],
-            detached: true,
-            puppeteerOptions: { executablePath: executablePath() }
+            detached: true
         });
 
         connector.close();
@@ -107,8 +104,7 @@ test(`[${name}] Connector loads an action and doesn't throw if it has the right 
                 file: actionPath,
                 on: 'afterTargetNavigation'
             }],
-            detached: true,
-            puppeteerOptions: { executablePath: executablePath() }
+            detached: true
         });
 
         connector.close();

--- a/packages/connector-puppeteer/tests/authentication.ts
+++ b/packages/connector-puppeteer/tests/authentication.ts
@@ -2,7 +2,6 @@ import { URL } from 'url';
 
 import test from 'ava';
 import * as sinon from 'sinon';
-import { executablePath } from 'puppeteer';
 
 import { generateHTMLPage, Server } from '@hint/utils-create-server';
 import { Engine, Events } from 'hint';
@@ -68,8 +67,7 @@ test(`[${name}] Form authentication on a page works`, async (t) => {
                 value: user
             }
         },
-        detached: true,
-        puppeteerOptions: { executablePath: executablePath() }
+        detached: true
     });
 
     await connector.collect(new URL(`http://localhost:${server.port}/`));
@@ -158,8 +156,7 @@ test(`[${name}] Authenticate on a multi-step page works`, async (t) => {
                 value: user
             }
         },
-        detached: true,
-        puppeteerOptions: { executablePath: executablePath() }
+        detached: true
     });
 
     await connector.collect(new URL(`http://localhost:${server.port}/`));
@@ -224,8 +221,7 @@ test(`[${name}] Basic HTTP Authentication works`, async (t) => {
             password,
             user
         },
-        detached: true,
-        puppeteerOptions: { executablePath: executablePath() }
+        detached: true
     });
 
     await connector.collect(new URL(`http://localhost:${server.port}/`));

--- a/packages/connector-puppeteer/tests/collect.ts
+++ b/packages/connector-puppeteer/tests/collect.ts
@@ -6,7 +6,6 @@ import { URL } from 'url';
 
 import * as sinon from 'sinon';
 import anyTest, { TestInterface, ExecutionContext } from 'ava';
-import { executablePath } from 'puppeteer';
 
 import { generateHTMLPage, Server, ServerConfiguration } from '@hint/utils-create-server';
 import { Engine, Events, IConnectorConstructor } from 'hint';
@@ -51,10 +50,7 @@ const pathToFaviconInLinkElement = path.join(__dirname, './fixtures/common/favic
 const runTest = async (t: ExecutionContext<CollectContext>, Connector: IConnectorConstructor, serverConfig: ServerConfiguration) => {
     const server = await Server.create({ configuration: serverConfig });
     const { engine } = t.context;
-    const connector = new Connector(engine, {
-        detached: true,
-        puppeteerOptions: { executablePath: executablePath() }
-    });
+    const connector = new Connector(engine, { detached: true });
 
     await connector.collect(new URL(`http://localhost:${server.port}/`));
     await Promise.all([connector.close(), server.stop()]);

--- a/packages/connector-puppeteer/tests/events.ts
+++ b/packages/connector-puppeteer/tests/events.ts
@@ -12,7 +12,6 @@ import { URL } from 'url';
 import groupBy = require('lodash/groupBy');
 import * as sinon from 'sinon';
 import anyTest, { TestInterface } from 'ava';
-import { executablePath } from 'puppeteer';
 import { Server } from '@hint/utils-create-server';
 import { Engine, Events, IConnector } from 'hint';
 
@@ -181,10 +180,7 @@ test.afterEach.always((t) => {
 
 test(`[${name}] Events`, async (t) => {
     const { engine } = t.context;
-    const connector: IConnector = new Connector(engine, {
-        detached: true,
-        puppeteerOptions: { executablePath: executablePath() }
-    });
+    const connector: IConnector = new Connector(engine, { detached: true });
 
     t.context.connector = connector;
 

--- a/packages/connector-puppeteer/tests/fetch-content.ts
+++ b/packages/connector-puppeteer/tests/fetch-content.ts
@@ -5,7 +5,6 @@ import * as path from 'path';
 import { URL } from 'url';
 
 import test from 'ava';
-import { executablePath } from 'puppeteer';
 import { Server } from '@hint/utils-create-server';
 import { Engine, Events, IConnector, NetworkData } from 'hint';
 
@@ -25,10 +24,7 @@ test(`[${name}] Fetch Content`, async (t) => {
     } as any;
 
     const file = fs.readFileSync(path.join(__dirname, './fixtures/common/nellie.png'));
-    const connector: IConnector = new Connector(engine, {
-        detached: true,
-        puppeteerOptions: { executablePath: executablePath() }
-    });
+    const connector: IConnector = new Connector(engine, { detached: true });
     const server = await Server.create({ configuration: { '/nellie.png': { content: file } } });
 
     const result: NetworkData = await (connector.fetchContent ? connector.fetchContent(new URL(`http://localhost:${server.port}/nellie.png`)) : {} as NetworkData);

--- a/packages/connector-puppeteer/tests/invalid-url.ts
+++ b/packages/connector-puppeteer/tests/invalid-url.ts
@@ -1,7 +1,6 @@
 import { URL } from 'url';
 
 import test from 'ava';
-import { executablePath } from 'puppeteer';
 
 import { Engine, Events, IConnector } from 'hint';
 
@@ -20,10 +19,7 @@ test(`[${name}] Load an invalid url throws an error`, async (t) => {
         }
     } as any;
 
-    const connector: IConnector = new Connector(engine, {
-        detached: true,
-        puppeteerOptions: { executablePath: executablePath() }
-    });
+    const connector: IConnector = new Connector(engine, { detached: true });
 
     // Target doesn't exist
     await t.throwsAsync(connector.collect(new URL('https://localhome')));

--- a/packages/connector-puppeteer/tests/request-response.ts
+++ b/packages/connector-puppeteer/tests/request-response.ts
@@ -12,7 +12,6 @@ import * as zlib from 'zlib';
 
 import * as sinon from 'sinon';
 import test from 'ava';
-import { executablePath } from 'puppeteer';
 
 import { Server } from '@hint/utils-create-server';
 import { Engine, Events, IConnector } from 'hint';
@@ -49,10 +48,7 @@ test(`[${name}] requestResponse`, async (t) => {
     const engineEmitAsyncSpy = sinon.spy(engine, 'emitAsync');
     const engineEmitSpy = sinon.spy(engine, 'emit');
 
-    const connector: IConnector = new Connector(engine, {
-        detached: true,
-        puppeteerOptions: { executablePath: executablePath() }
-    });
+    const connector: IConnector = new Connector(engine, { detached: true });
     const server = await Server.create();
 
     const html = Server.updateLocalhost(sourceHtml, server.port);

--- a/packages/extension-browser/tests/webhint.ts
+++ b/packages/extension-browser/tests/webhint.ts
@@ -1,5 +1,4 @@
 import test from 'ava';
-import { executablePath } from 'puppeteer';
 
 import { Analyzer } from 'hint';
 
@@ -9,12 +8,6 @@ test('It passes all configured hints from webhint', async (t) => {
     const [server, urls] = await hostUI();
 
     const config = Analyzer.getUserConfig()!;
-
-    config.connector = {
-        name: 'puppeteer',
-        options: { puppeteerOptions: { executablePath: executablePath() } } as any
-    };
-
     const webhint = Analyzer.create(config);
     const results = await webhint.analyze(urls);
 

--- a/packages/utils-tests-helpers/package.json
+++ b/packages/utils-tests-helpers/package.json
@@ -5,13 +5,11 @@
     "@hint/utils-fs": "^1.0.0",
     "@hint/utils-network": "^1.0.1",
     "@hint/utils-types": "^1.0.0",
-    "ava": "^2.4.0",
-    "puppeteer": "^2.1.1"
+    "ava": "^2.4.0"
   },
   "description": "hint tests helpers",
   "devDependencies": {
     "@types/node": "^12.12.14",
-    "@types/puppeteer": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.12.0",
     "cpx": "^1.5.0",

--- a/packages/utils-tests-helpers/src/hint-runner.ts
+++ b/packages/utils-tests-helpers/src/hint-runner.ts
@@ -13,8 +13,6 @@ import { HintsConfigObject } from '@hint/utils';
 import { Configuration, Engine, IHintConstructor, utils } from 'hint';
 import { Problem, ProblemLocation } from '@hint/utils-types';
 
-import * as puppeteer from 'puppeteer';
-
 import { HintTest, HintLocalTest, Report, MatchProblemLocation } from './hint-test-type';
 
 const { resourceLoader } = utils;
@@ -138,10 +136,7 @@ const createConfig = (id: string, connector: string, opts?: any): Configuration 
     config.connector.options = {
         detached: true,
         ignoreHTTPSErrors: true,
-        puppeteerOptions: {
-            executablePath: puppeteer.executablePath(),
-            timeout: 60000
-        },
+        puppeteerOptions: { timeout: 60000 },
         waitUntil: 'networkidle0'
     };
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Expand the cases where webhint will "just work" by allowing it to
use the version of Chromium bundled with a local puppeteer
installation if one is available.

This will also fix current CI issues on Mac which are failing due to
an inability to find a Chrome installation (puppeteer is present).