### PR TITLE
Fix: Handle globals which cannot be overriden

### DIFF
--- a/packages/utils-dom/src/globals.ts
+++ b/packages/utils-dom/src/globals.ts
@@ -37,7 +37,11 @@ export const populateGlobals = (context: any, document: HTMLDocument) => {
     };
 
     for (const global of Object.keys(globals) as Array<keyof typeof globals>) {
-        context[global] = globals[global];
+        try {
+            context[global] = globals[global];
+        } catch (e) {
+            // Some globals can't be overridden if present (e.g. `self` in workers).
+        }
     }
 
     return context;

--- a/packages/utils-dom/tests/globals.ts
+++ b/packages/utils-dom/tests/globals.ts
@@ -47,5 +47,24 @@ test('instances', (t) => {
     t.is(context.document, doc);
     t.is(context.document.defaultView, context);
     t.is(context.window, context);
+    t.is(context.self, context);
     t.is(context.top, context);
+});
+
+test('existing self', (t) => {
+    const context: any = {};
+    const doc = createHTMLDocument('test', 'http://localhost/');
+
+    Object.defineProperty(context, 'self', {
+        get() {
+            return context;
+        },
+        set(value) {
+            throw new Error('Cannot override "self".');
+        }
+    });
+
+    t.notThrows(() => {
+        populateGlobals(context, doc);
+    });
 });


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Ignore if setting a global fails to allow the rest to succeed.
E.g. `self` is set in tests, but cannot be set in real workers.