### PR TITLE
Update MDN browser compat data to 1.0.12

### DIFF
--- a/packages/hint-compat-api/tests/html.ts
+++ b/packages/hint-compat-api/tests/html.ts
@@ -41,7 +41,7 @@ testHint(hintPath,
                     severity: Severity.warning
                 },
                 {
-                    message: `'details' is not supported by Edge, Internet Explorer.`,
+                    message: `'details' is not supported by Edge < 79, Internet Explorer.`,
                     position: { match: 'details' },
                     severity: Severity.warning
                 }

--- a/packages/utils-compat-data/package.json
+++ b/packages/utils-compat-data/package.json
@@ -8,7 +8,7 @@
     "timeout": "1m"
   },
   "dependencies": {
-    "mdn-browser-compat-data": "^1.0.7",
+    "mdn-browser-compat-data": "^1.0.12",
     "postcss": "^7.0.27",
     "postcss-selector-parser": "^6.0.2",
     "postcss-value-parser": "^4.0.2",

--- a/packages/utils-compat-data/src/browsers.ts
+++ b/packages/utils-compat-data/src/browsers.ts
@@ -90,18 +90,16 @@ const isSupported = (support: SimpleSupportStatement, prefix: string, rawVersion
 
     /*
      * If feature was added but we don't know when, assume support.
-     *
-     * Note: This is likely to change to describe the version of the browser
-     * which was tested for support (e.g. `version_added = "<=60"`).
-     *
-     * https://github.com/mdn/browser-compat-data/issues/3021
+     * This includes cases which describe the version of the browser
+     * which was tested for support (e.g. `version_added = "≤60"`).
      */
-    if (support.version_added === true) {
+    if (support.version_added === true || (support.version_added || '')[0] === '≤') {
         return { support: Support.Yes };
     }
 
     // If feature was added by the target version, it's supported; if after it's not.
     if (typeof support.version_added === 'string') {
+
         if (semver.lte(coerce(support.version_added), version)) {
             return { support: Support.Yes };
         }

--- a/packages/utils-compat-data/src/css-types.ts
+++ b/packages/utils-compat-data/src/css-types.ts
@@ -1,0 +1,9 @@
+/**
+ * Map CSS properties to known value types.
+ * TODO: Propose including directly in MDN data.
+ */
+export const types = new Map<string, string[]>([
+    ['background-color', ['color']],
+    ['border-color', ['color']],
+    ['color', ['color']]
+]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7247,10 +7247,10 @@ mdn-browser-compat-data@1.0.1:
   dependencies:
     extend "3.0.2"
 
-mdn-browser-compat-data@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/mdn-browser-compat-data/-/mdn-browser-compat-data-1.0.7.tgz#d19f82b846c19f1cfda7d40087abc2eca8d70852"
-  integrity sha512-fQlPyg8Ma4YzcH++EFLCXzlU/bnj1Yum7X7SljSJ5nMLBvZ3ep98dqSObdiPv8WeSUoepRGkQBVjcxutvlfv1Q==
+mdn-browser-compat-data@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/mdn-browser-compat-data/-/mdn-browser-compat-data-1.0.12.tgz#11256a55e5d83dfc5ee11ad833fd21af8a034d32"
+  integrity sha512-YykSFfz779LbgRjyieBMQy9/VHFAIz52gf7bLOiJnCkp0xltpnC9l2kQGu4UWOkBeSxJ1R5YLcKTf4Gklq6clQ==
   dependencies:
     extend "3.0.2"
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Includes updating `utils-compat-data` to adapt to MDN schema changes.
Also updates `hint-compat-api` tests to account for Edge 79+.

Supersedes #3598  