### PR TITLE
New: Allow disabling included hints by default

### DIFF
--- a/packages/utils-worker/README.md
+++ b/packages/utils-worker/README.md
@@ -65,6 +65,22 @@ worker.postMessage({
 });
 ```
 
+All included hints are enabled by default. To disable all included
+hints and selectively enable only a few, change the default severity.
+
+```ts
+worker.postMessage({
+    config: {
+        defaultHintSeverity: 'off',
+        userConfig: {
+            hints: {
+                'button-type': 'default'
+            }
+        }
+    }
+});
+```
+
 ## Contributing to the worker
 
 To contribute to the worker please read the [`CONTRIBUTING.md`][contributing]

--- a/packages/utils-worker/src/shared/types.ts
+++ b/packages/utils-worker/src/shared/types.ts
@@ -2,8 +2,10 @@ import { DocumentData } from '@hint/utils-dom';
 import { Problem } from '@hint/utils-types';
 import { FetchEnd, FetchStart } from 'hint/dist/src/lib/types';
 import { UserConfig } from '@hint/utils';
+import { Severity } from '@hint/utils-types';
 
 export type Config = {
+    defaultHintSeverity?: keyof typeof Severity;
     resource: string;
     userConfig?: UserConfig;
 };

--- a/packages/utils-worker/src/webhint.ts
+++ b/packages/utils-worker/src/webhint.ts
@@ -27,13 +27,12 @@ const reportError = (message: string, stack: string) => {
     });
 };
 
-const main = async ({ resource, userConfig = {} }: Config) => {
+const main = async ({ defaultHintSeverity = 'default', resource, userConfig = {} }: Config) => {
     const enabledHints: IHintConstructor[] = [];
     const configuredHints = normalizeHints(userConfig.hints || []);
 
-    // Automatically enable bundled hints unless explicitly turned off.
     const hintsConfig = hints.reduce((o, hint) => {
-        o[hint.meta.id] = configuredHints[hint.meta.id] || 'default';
+        o[hint.meta.id] = configuredHints[hint.meta.id] || defaultHintSeverity;
 
         if (o[hint.meta.id] !== 'off') {
             enabledHints.push(hint);


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [X] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [X] Added/Updated related documentation.
- [X] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
This change introduces a `defaultHintSeverity` configuration option. Most notably it can be set to `"off"` to allow consumers of the worker to explicitly choose when to enable newly added hints.