### PR TITLE
Changed variable name to results

### DIFF
--- a/packages/hint/docs/user-guide/api/using-api.md
+++ b/packages/hint/docs/user-guide/api/using-api.md
@@ -45,7 +45,7 @@ const options: CreateAnalyzerOptions
 const webhint = Analyzer.create(userConfig, options);
 
 const analysisOptions: AnalyzerOptions;
-const result: AnalyzerResult[] = await webhint.analyze('http://example.com', options);
+const results: AnalyzerResult[] = await webhint.analyze('http://example.com', options);
 ```
 
 `webhint.analyze` receive as a first parameter an `Endpoint`.


### PR DESCRIPTION
Not sure about this. But shouldn't the output of `webhint.analyze` be named `results` instead of `result`. Nothing wrong with the current name, but when iterating over the results later on in the page, the name `results` is used.