### PR TITLE
Chore: Add script to list bundled top-level dependencies

### DIFF
--- a/packages/utils-worker/scripts/direct-dependencies.js
+++ b/packages/utils-worker/scripts/direct-dependencies.js
@@ -48,7 +48,9 @@ const main = () => {
 
     console.log('Top-level Dependencies:');
     for (const dependency of sortedDependencies) {
-        console.log(dependency);
+        if (!dependency.startsWith('@types/')) {
+            console.log(dependency);
+        }
     }
 };
 

--- a/packages/utils-worker/scripts/direct-dependencies.js
+++ b/packages/utils-worker/scripts/direct-dependencies.js
@@ -1,0 +1,55 @@
+const pkg = require('../package.json');
+
+/**
+ * @param {string} name
+ */
+const isHintPackage = (name) => {
+    return name === 'hint' || name.startsWith('@hint/');
+};
+
+/**
+ * @param {Set<*>} to
+ * @param {Set<*>} from
+ */
+const mergeIntoSet = (to, from) => {
+    for (const item of from) {
+        to.add(item);
+    }
+};
+
+/**
+ * @param {string} module
+ */
+const getModuleDependencies = (module) => {
+    const dependencies = new Set();
+    const modulePackage = require(`${module}/package.json`);
+
+    for (const dependency of Object.keys(modulePackage.dependencies || {})) {
+        if (isHintPackage(dependency)) {
+            mergeIntoSet(dependencies, getModuleDependencies(dependency));
+        } else {
+            dependencies.add(dependency);
+        }
+    }
+
+    return dependencies;
+};
+
+const main = () => {
+    const dependencies = new Set();
+
+    const webhintModules = Object.keys(pkg.devDependencies).filter(isHintPackage);
+
+    for (const module of webhintModules) {
+        mergeIntoSet(dependencies, getModuleDependencies(module));
+    }
+
+    const sortedDependencies = Array.from(dependencies).sort();
+
+    console.log('Top-level Dependencies:');
+    for (const dependency of sortedDependencies) {
+        console.log(dependency);
+    }
+};
+
+main();


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Adding a small helper script to allow us to see roughly what top-level packages we're pulling into the bundle (I haven't verified if any of these already get dropped by webpack). Currently this includes 45 packages, but I think we could reasonably stub out ~15 of them to reduce the bundle size/complexity (we already shim acorn-jsx and acorn-jsx-walk):

Output:
```
Top-level Dependencies:
acorn
acorn-jsx
acorn-jsx-walk
acorn-walk
ajv
applicationinsights
axe-core
bcp47
boxen
browserslist
chalk
color-string
configstore
content-type
css-select
debug
eventemitter2
express
file-type
file-url
globby
is-ci
is-svg
is-wsl
jsonc-parser
lodash
mdn-browser-compat-data
metaviewport-parser
npm-registry-fetch
on-headers
optionator
ora
os-locale
parse5
parse5-htmlparser2-tree-adapter
postcss
postcss-safe-parser
postcss-selector-parser
postcss-value-parser
punycode
request
semver
strip-bom
strip-json-comments
update-notifier
```

Packages I think we could shim in the future:
```
applicationinsights
bcp47
boxen
chalk
color-string
configstore
globby
is-ci
is-wsl
on-headers
optionator
ora
os-locale
punycode
request
```