### PR TITLE
Add a few special disallowed headers

### DIFF
--- a/packages/hint-no-disallowed-headers/src/_locales/en/messages.json
+++ b/packages/hint-no-disallowed-headers/src/_locales/en/messages.json
@@ -11,6 +11,30 @@
         "description": "Report message when the 'server' header contains more than the server name",
         "message": "The 'server' header should only contain the server name."
     },
+    "disallowedExpiresHeader": {
+        "description": "Report message when the response includes the Expires header",
+        "message": "The 'Expires' header should not be used, 'Cache-Control' should be preferred."
+    },
+    "disallowedHostHeader": {
+        "description": "Report message when the response includes the Host header",
+        "message": "The 'Host' header should not be used, it is a request header only."
+    },
+    "disallowedP3PHeader": {
+        "description": "Report message when the response includes the P3P header",
+        "message": "The 'P3P' header should not be used, it is a non-standard header only implemented in Internet Explorer."
+    },
+    "disallowedPragmaHeader": {
+        "description": "Report message when the response includes the Pragma header",
+        "message": "The 'Pragma' header should not be used, it is deprecated and is a request header only."
+    },
+    "disallowedViaHeader": {
+        "description": "Report message when the response includes the Via header",
+        "message": "The 'Via' header should not be used, it is a request header only."
+    },
+    "disallowedXFrameOptionsHeader": {
+        "description": "Report message when the response includes the X-Frame-Options header",
+        "message": "The 'X-Frame-Options' header should not be used. A similar effect, with more consistent support and stronger checks, can be achieved with the 'Content-Security-Policy' header and 'frame-ancestors' directive."
+    },
     "name": {
         "description": "Metadata name",
         "message": "Disallowed HTTP headers"

--- a/packages/hint-no-disallowed-headers/src/hint.ts
+++ b/packages/hint-no-disallowed-headers/src/hint.ts
@@ -17,9 +17,61 @@ import { FetchEnd, IHint } from 'hint/dist/src/lib/types';
 import { Severity } from '@hint/utils-types';
 
 import meta from './meta';
-import { getMessage } from './i18n.import';
+import { getMessage, MessageName } from './i18n.import';
 
 const debug = d(__filename);
+
+/*
+ * ------------------------------------------------------------------------------
+ * Private
+ * ------------------------------------------------------------------------------
+ */
+
+const serverHeaderContainsTooMuchInformation = (serverHeaderValue: string): boolean => {
+    const regex = [
+        /*
+         * Version numbers.
+         *
+         * e.g.:
+         *
+         *   apache/2.2.24 (unix) mod_ssl/2.2.24 openssl/1.0.1e-fips mod_fastcgi/2.4.6
+         *   marrakesh 1.9.9
+         *   omniture dc/2.0.0
+         *   microsoft-iis/8.5
+         *   pingmatch/v2.0.30-165-g51bed16#rel-ec2-master i-077d449239c04b184@us-west-2b@dxedge-app_us-west-2_prod_asg
+         */
+
+        /\/?v?\d\.(\d+\.?)*/,
+
+        /*
+         * OS/platforms names (usually enclose between parentheses).
+         *
+         * e.g.:
+         *
+         *  apache/2.2.24 (unix) mod_ssl/2.2.24 openssl/1.0.1e-fips mod_fastcgi/2.4.6
+         *  apache/2.2.34 (amazon)
+         *  nginx/1.4.6 (ubuntu)
+         */
+
+        /\(.*\)/,
+
+        /*
+         * Compiled-in modules.
+         *
+         * e.g.:
+         *
+         *  apache/2.2.24 (unix) mod_ssl/2.2.24 openssl/1.0.1e-fips mod_fastcgi/2.4.6
+         *  apache/2.4.6 (centos) php/5.4.16
+         *  jino.ru/mod_pizza
+         */
+
+        /(mod_|openssl|php)/
+    ];
+
+    return regex.some((r) => {
+        return r.test(serverHeaderValue);
+    });
+};
 
 /*
  * ------------------------------------------------------------------------------
@@ -27,13 +79,18 @@ const debug = d(__filename);
  * ------------------------------------------------------------------------------
  */
 
+interface ISpecialHeadersWithMessage {
+    [key: string]: MessageName;
+}
+
 export default class NoDisallowedHeadersHint implements IHint {
 
     public static readonly meta = meta;
 
     public constructor(context: HintContext) {
 
-        let disallowedHeaders: string[] = [
+        // These are general disallowed headers for which this hint doesn't have anything specific to say.
+        let generalDisallowedHeaders: string[] = [
             'public-key-pins',
             'public-key-pins-report-only',
             'x-aspnet-version',
@@ -43,75 +100,53 @@ export default class NoDisallowedHeadersHint implements IHint {
             'x-version'
         ];
 
+        // These headers are disallowed for specific reasons.
+        const specialDisallowedHeaders: ISpecialHeadersWithMessage = {
+            expires: 'disallowedExpiresHeader',
+            host: 'disallowedHostHeader',
+            p3p: 'disallowedP3PHeader',
+            pragma: 'disallowedPragmaHeader',
+            via: 'disallowedViaHeader',
+            'x-frame-options': 'disallowedXFrameOptionsHeader'
+        };
+
         let includeHeaders: string[];
         let ignoreHeaders: string[];
 
+        /*
+         * Augment the list of generally disallowed headers with those configured in options.include, and remove those
+         * configured in options.ignore.
+         */
         const loadHintConfigs = () => {
             includeHeaders = (context.hintOptions && context.hintOptions.include) || [];
             ignoreHeaders = (context.hintOptions && context.hintOptions.ignore) || [];
 
-            disallowedHeaders = mergeIgnoreIncludeArrays(disallowedHeaders, ignoreHeaders, includeHeaders);
+            generalDisallowedHeaders = mergeIgnoreIncludeArrays(generalDisallowedHeaders, ignoreHeaders, includeHeaders);
         };
 
-        const serverHeaderContainsTooMuchInformation = (serverHeaderValue: string): boolean => {
-
-            const regex = [
-                /*
-                 * Version numbers.
-                 *
-                 * e.g.:
-                 *
-                 *   apache/2.2.24 (unix) mod_ssl/2.2.24 openssl/1.0.1e-fips mod_fastcgi/2.4.6
-                 *   marrakesh 1.9.9
-                 *   omniture dc/2.0.0
-                 *   microsoft-iis/8.5
-                 *   pingmatch/v2.0.30-165-g51bed16#rel-ec2-master i-077d449239c04b184@us-west-2b@dxedge-app_us-west-2_prod_asg
-                 */
-
-                /\/?v?\d\.(\d+\.?)*/,
-
-                /*
-                 * OS/platforms names (usually enclose between parentheses).
-                 *
-                 * e.g.:
-                 *
-                 *  apache/2.2.24 (unix) mod_ssl/2.2.24 openssl/1.0.1e-fips mod_fastcgi/2.4.6
-                 *  apache/2.2.34 (amazon)
-                 *  nginx/1.4.6 (ubuntu)
-                 */
-
-                /\(.*\)/,
-
-                /*
-                 * Compiled-in modules.
-                 *
-                 * e.g.:
-                 *
-                 *  apache/2.2.24 (unix) mod_ssl/2.2.24 openssl/1.0.1e-fips mod_fastcgi/2.4.6
-                 *  apache/2.4.6 (centos) php/5.4.16
-                 *  jino.ru/mod_pizza
-                 */
-
-                /(mod_|openssl|php)/
-            ];
-
-            return regex.some((r) => {
-                return r.test(serverHeaderValue);
-            });
-        };
-
-        const validate = ({ response, resource }: FetchEnd) => {
-            // This check does not make sense for data URI.
-
-            if (isDataURI(resource)) {
-                debug(`Check does not apply for data URI: ${resource}`);
-
-                return;
-            }
-
-            const headers: string[] = includedHeaders(response.headers, disallowedHeaders);
+        const validateGeneralHeaders = ({ response, resource }: FetchEnd) => {
+            const headers = includedHeaders(response.headers, generalDisallowedHeaders);
             const numberOfHeaders: number = headers.length;
 
+            if (numberOfHeaders > 0) {
+                const message = getMessage('disallowedHeaders', context.language, headers.join(', '));
+
+                const codeSnippet = headers.reduce((total, header) => {
+                    return `${total}${total ? '\n' : ''}${header}: ${normalizeHeaderValue(response.headers, header)}`;
+                }, '');
+                const codeLanguage = 'http';
+
+                context.report(
+                    resource,
+                    message,
+                    {
+                        codeLanguage, codeSnippet,
+                        severity: Severity.warning
+                    });
+            }
+        };
+
+        const validateServerHeader = ({ response, resource }: FetchEnd) => {
             /*
              * If the response contains the `server` header, and
              * `server` is not specified by the user as a disallowed
@@ -132,7 +167,7 @@ export default class NoDisallowedHeadersHint implements IHint {
             const serverHeaderValue = normalizeHeaderValue(response.headers, 'server');
             const codeLanguage = 'http';
 
-            if (!disallowedHeaders.includes('server') &&
+            if (!generalDisallowedHeaders.includes('server') &&
                 !toLowerCaseArray(ignoreHeaders).includes('server') &&
                 serverHeaderValue &&
                 serverHeaderContainsTooMuchInformation(serverHeaderValue)
@@ -148,22 +183,43 @@ export default class NoDisallowedHeadersHint implements IHint {
                         severity: Severity.warning
                     });
             }
+        };
 
-            if (numberOfHeaders > 0) {
-                const message = getMessage('disallowedHeaders', context.language, headers.join(', '));
+        const validateSpecialHeaders = ({ response, resource }: FetchEnd) => {
+            const codeLanguage = 'http';
 
-                const codeSnippet = headers.reduce((total, header) => {
-                    return `${total}${total ? '\n' : ''}${header}: ${normalizeHeaderValue(response.headers, header)}`;
-                }, '');
+            for (const key of Object.keys(response.headers)) {
+                const lowercaseKey: string = key.toLowerCase();
 
-                context.report(
-                    resource,
-                    message,
-                    {
-                        codeLanguage, codeSnippet,
-                        severity: Severity.warning
-                    });
+                const messageName = specialDisallowedHeaders[lowercaseKey];
+
+                if (messageName && !toLowerCaseArray(ignoreHeaders).includes(lowercaseKey)) {
+                    const message = getMessage(messageName, context.language);
+                    const headerValue = normalizeHeaderValue(response.headers, lowercaseKey);
+
+                    context.report(
+                        resource,
+                        message,
+                        {
+                            codeLanguage,
+                            codeSnippet: `${key}: ${headerValue}`,
+                            severity: Severity.warning
+                        });
+                }
             }
+        };
+
+        const validate = (event: FetchEnd) => {
+            // This check does not make sense for data URI.
+            if (isDataURI(event.resource)) {
+                debug(`Check does not apply for data URI: ${event.resource}`);
+
+                return;
+            }
+
+            validateGeneralHeaders(event);
+            validateServerHeader(event);
+            validateSpecialHeaders(event);
         };
 
         loadHintConfigs();

--- a/packages/hint-no-disallowed-headers/tests/tests.ts
+++ b/packages/hint-no-disallowed-headers/tests/tests.ts
@@ -172,6 +172,75 @@ const testsForConfigs: HintTest[] = [
     }
 ];
 
+const testForSpecialHeaders: HintTest[] = [
+    {
+        name: `HTML page is served with disallowed Expires header`,
+        reports: [{
+            message: 'The \'Expires\' header should not be used, \'Cache-Control\' should be preferred.',
+            severity: Severity.warning
+        }],
+        serverConfig: { '/': { headers: { Expires: 'Thu, 01 Dec 1994 16:00:00 GMT' } } }
+    },
+    {
+        name: `HTML page is served with disallowed Host header`,
+        reports: [{
+            message: 'The \'Host\' header should not be used, it is a request header only.',
+            severity: Severity.warning
+        }],
+        serverConfig: { '/': { headers: { Host: 'example.com' } } }
+    },
+    {
+        name: `HTML page is served with disallowed P3P header`,
+        reports: [{
+            message: 'The \'P3P\' header should not be used, it is a non-standard header only implemented in Internet Explorer.',
+            severity: Severity.warning
+        }],
+        serverConfig: { '/': { headers: { P3P: 'cp="this is not a p3p policy"' } } }
+    },
+    {
+        name: `HTML page is served with disallowed Pragma header`,
+        reports: [{
+            message: 'The \'Pragma\' header should not be used, it is deprecated and is a request header only.',
+            severity: Severity.warning
+        }],
+        serverConfig: { '/': { headers: { Pragma: 'no-cache' } } }
+    },
+    {
+        name: `HTML page is served with disallowed Via header`,
+        reports: [{
+            message: 'The \'Via\' header should not be used, it is a request header only.',
+            severity: Severity.warning
+        }],
+        serverConfig: { '/': { headers: { Via: '1.1 varnish, 1.1 squid' } } }
+    },
+    {
+        name: `HTML page is served with disallowed X-Frame-Options header`,
+        reports: [{
+            message: 'The \'X-Frame-Options\' header should not be used. A similar effect, with more consistent support and stronger checks, can be achieved with the \'Content-Security-Policy\' header and \'frame-ancestors\' directive.',
+            severity: Severity.warning
+        }],
+        serverConfig: { '/': { headers: { 'X-Frame-Options': 'SAMEORIGIN' } } }
+    }
+];
+
+const testForIgnoredSpecialHeaders: HintTest[] = [
+    {
+        name: `HTML page served with disallowed, but ignored, special headers does not lead to warnings`,
+        serverConfig: {
+            '/': {
+                headers: {
+                    Expires: 'Thu, 01 Dec 1994 16:00:00 GMT',
+                    Host: 'example.com',
+                    P3P: 'cp="this is not a p3p policy"',
+                    Pragma: 'no-cache',
+                    Via: '1.1 varnish, 1.1 squid',
+                    'X-Frame-Options': 'SAMEORIGIN'
+                }
+            }
+        }
+    }
+];
+
 testHint(hintPath, testsForDefaults);
 testHint(hintPath, testsForDifferentServerHeaderValues);
 testHint(hintPath, testsForIgnoreConfigs, { hintOptions: { ignore: ['Server', 'X-Powered-By', 'X-Test-1'] } });
@@ -180,5 +249,18 @@ testHint(hintPath, testsForConfigs, {
     hintOptions: {
         ignore: ['Server', 'X-Test-2', 'X-Test-3'],
         include: ['X-Powered-By', 'X-Test-1', 'X-Test-2']
+    }
+});
+testHint(hintPath, testForSpecialHeaders);
+testHint(hintPath, testForIgnoredSpecialHeaders, {
+    hintOptions: {
+        ignore: [
+            'Expires',
+            'Host',
+            'P3P',
+            'Pragma',
+            'Via',
+            'X-Frame-Options'
+        ]
     }
 });


### PR DESCRIPTION
This PR should fix #1096.

It adds warnings for the following HTTP response headers:

* Expires
* Host
* P3P
* Pragma
* Via
* X-Frame-Options
* X-UA-Compatible

These were added based on https://www.fastly.com/blog/headers-we-dont-want.

Instead of adding these headers to the existing list of disallowed headers, I added specific checks for these ones. The idea is, this way, we can have specific messages for each of them.

I created a couple of preliminary commits to prepare the code for this, then added the logic for this in a third commit, and finished adding all warnings in a 4th commit.
Finally, I made sure the ignored headers, as configured by users, would also ignore these special headers.