### PR TITLE
Fix: Better wrapping logic for config page

### DIFF
--- a/packages/extension-browser/src/devtools/views/controls/valid-input.css
+++ b/packages/extension-browser/src/devtools/views/controls/valid-input.css
@@ -5,6 +5,7 @@
     color: var(--base-color);
     font-size: var(--font-size-sm);
     padding: 0.1875rem 0.75rem 0.3125rem; /* 3px 12px 5px */
+    width: 8.25rem; /* 132px */
 }
 
 .root:focus {

--- a/packages/extension-browser/src/devtools/views/pages/config.css
+++ b/packages/extension-browser/src/devtools/views/pages/config.css
@@ -10,24 +10,18 @@
     display: grid;
     gap: 1.5rem; /* 24px */
     margin-top: 1.5rem; /* 24px */
+    max-width: 56.25rem; /* 900px */
 }
 
 /* TODO: rename as this includes target browsers, etc */
 .categories {
     display: grid;
     gap: 1.5rem; /* 24px */
+    grid-template-columns: repeat(auto-fit, minmax(11.25rem, 1fr)); /* 180px */
 }
 
 .button {
     justify-self: left;
-}
-
-/* Horizontal layout */
-@media (min-width: 48rem /* 768px */) {
-    .categories {
-        grid-auto-flow: column;
-        max-width: 56.25rem; /* 900px */
-    }
 }
 
 .poweredBy {


### PR DESCRIPTION
This should fix #3528.

Using CSS grid minmax, we can make the various columns
in the config page be at least some predefined width that
avoids poor wrapping of form fields, and at most take all
the size they need.

Now, to avoid them stretching too wide and becoming hard to
read, I preserved the max-width that was already there, but
moved it to the parent element to avoid conflicting with
the auto-fit logic (see below), as this was causing overflow.

We're using auto-fit to make the number of columns adapt to
the available space.