### PR TITLE
Fix: Wrap some JSX expressions placeholders in list items

### DIFF
--- a/packages/parser-jsx/src/parser.ts
+++ b/packages/parser-jsx/src/parser.ts
@@ -207,6 +207,52 @@ const addChild = (data: ElementData | TextData, parent: JSXElement, children: Ch
 };
 
 /**
+ * Is the node a list container (`<ul>/<ol>`).
+ */
+const isListNode = (node: JSXElement | JSXAttribute | undefined): node is JSXElement => {
+    return !!(node && node.type === 'JSXElement' &&
+        node.openingElement.name.type === 'JSXIdentifier' &&
+        (node.openingElement.name.name === 'ol' || node.openingElement.name.name === 'ul'));
+};
+
+/**
+ * Create a JSXElement.
+ */
+const createJSXElement = (name: string, selfClosing: boolean = false): JSXElement => {
+    return {
+        children: [],
+        closingElement: selfClosing ? null : {
+            name: {
+                name,
+                type: 'JSXIdentifier'
+            },
+            type: 'JSXClosingElement'
+        },
+        openingElement: {
+            attributes: [],
+            name: {
+                name,
+                type: 'JSXIdentifier'
+            },
+            selfClosing,
+            type: 'JSXOpeningElement'
+        },
+        type: 'JSXElement'
+    };
+};
+
+/**
+ * Wrap the given `textData` in a list item (`<li>textData</li>).
+ */
+const wrapInListItem = (textData: TextData, parent: JSXElement, childMap: ChildMap): ElementData => {
+    const node = createJSXElement('li');
+
+    addChild(textData, node, childMap);
+
+    return mapElement(node, childMap);
+};
+
+/**
  * Generate an HTML document representing a fragment containing the
  * provided roots derived from the specified resource.
  */
@@ -252,8 +298,10 @@ export default class JSXParser extends Parser<HTMLEvents> {
                     }
                 },
                 JSXExpressionContainer(node, /* istanbul ignore next */ ancestors = []) {
-                    const data = mapExpression(node);
                     const parent = getParentAttributeOrElement(ancestors);
+                    const textData = mapExpression(node);
+                    const data = isListNode(parent) ? wrapInListItem(textData, parent, childMap) :
+                        textData;
 
                     if (parent && parent.type !== 'JSXAttribute') {
                         addChild(data, parent, childMap);

--- a/packages/parser-jsx/src/parser.ts
+++ b/packages/parser-jsx/src/parser.ts
@@ -209,7 +209,7 @@ const addChild = (data: ElementData | TextData, parent: JSXElement, children: Ch
 /**
  * Is the node a list container (`<ul>/<ol>`).
  */
-const isListNode = (node: JSXElement | JSXAttribute | undefined): node is JSXElement => {
+const isListNode = (node?: JSXElement | JSXAttribute): node is JSXElement => {
     return !!(node && node.type === 'JSXElement' &&
         node.openingElement.name.type === 'JSXIdentifier' &&
         (node.openingElement.name.name === 'ol' || node.openingElement.name.name === 'ul'));

--- a/packages/parser-jsx/tests/tests.ts
+++ b/packages/parser-jsx/tests/tests.ts
@@ -147,6 +147,20 @@ test('It replaces expressions with text placeholders', async (t) => {
     t.is(div.innerHTML, '{expression}');
 });
 
+test('It wraps expression placeholder text with <li> when parented to <ul>', async (t) => {
+    const { document } = await parseJSX(`const jsx = <ul>{myText}</ul>;`);
+    const ul = document.querySelectorAll('ul')[0];
+
+    t.is(ul.innerHTML, '<li>{expression}</li>');
+});
+
+test('It wraps expression placeholder text with <li> when parented to <ol>', async (t) => {
+    const { document } = await parseJSX(`const jsx = <ol>{myText}</ol>;`);
+    const ol = document.querySelectorAll('ol')[0];
+
+    t.is(ol.innerHTML, '<li>{expression}</li>');
+});
+
 test('It translates source locations correctly', async (t) => {
     const { document } = await parseJSX(`const a = 4;\nconst jsx = <div>{myText}</div>;`);
     const div = document.querySelectorAll('div')[0];


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)
This changes follows [the recommendation][1] from @antross to wrap the `{expression}` placeholders parented to lists (`<ul>/<ol>`) in list items `<li>`.

This avoids a false-positive hint failure that the lists contain non-list items.

[1]: https://github.com/webhintio/hint/issues/3486#issuecomment-592649518

Fixes #3486 