### PR TITLE
Fix: Handle DocumentFragment under <template>

### DIFF
--- a/packages/utils-dom/src/node.ts
+++ b/packages/utils-dom/src/node.ts
@@ -34,6 +34,10 @@ export class Node {
 
         if ('children' in this._node) {
             for (const child of this._node.children) {
+                if (child.type === 'root') {
+                    continue; // Ignore DocumentFragment under <template>.
+                }
+
                 result.push(this._owner.getNodeFromData(child));
             }
         }


### PR DESCRIPTION
The backing ElementData lists <template> content as children to align
with parse5 behavior. However, this should not be exposed in the
childNodes collection of Node instances. Fixed by filtering out
DocumentFragment instances when returning childNodes.

- - - - - - - - - - - - - - - - - - - - -

Fix #3781

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
