### PR TITLE
Fix: Icon purpose doesn't support combination of values

### DIFF
--- a/packages/hint-manifest-icons/package.json
+++ b/packages/hint-manifest-icons/package.json
@@ -14,7 +14,8 @@
     "@hint/utils-i18n": "^1.0.3",
     "@hint/utils-types": "^1.0.1",
     "image-size": "^0.8.3",
-    "image-type": "^4.1.0"
+    "image-type": "^4.1.0",
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@hint/parser-manifest": "^2.2.18",

--- a/packages/hint-manifest-icons/src/_locales/en/messages.json
+++ b/packages/hint-manifest-icons/src/_locales/en/messages.json
@@ -11,6 +11,14 @@
         "description": "Report message when an icon request return an status code !== 200",
         "message": "Icon could not be fetched (status code: $1)."
     },
+    "iconPurposeDuplicate": {
+        "description": "Report message when an icon has a duplicate value in the property purpose",
+        "message": "Duplicate value(s) '$1' found in icon purpose property."
+    },
+    "iconPurposeInvalid": {
+        "description": "Report message when an icon has an invalid value in the property purpose",
+        "message": "Invalid icon property $1."
+    },
     "iconShouldBeValidImageType": {
         "description": "Report message when the image type is not valid",
         "message": "Icon should be a valid image type $1"
@@ -44,7 +52,7 @@
         "message": "Sizes not specifed for icon"
     },
     "validIconsNotFound": {
-        "description": "Report message when ",
+        "description": "Report message when a valid icon is not found",
         "message": "Valid icons property was not found in the web app manifest"
     }
 }

--- a/packages/hint-manifest-icons/tests/tests.ts
+++ b/packages/hint-manifest-icons/tests/tests.ts
@@ -125,7 +125,7 @@ const tests: HintTest[] = [
                             "sizes": "512x512",
                             "type": "image/png"
                         }
-                        ]
+                    ]
                 }`
             }
         }
@@ -189,7 +189,7 @@ const tests: HintTest[] = [
                             "sizes": "512x512",
                             "type": "image/png"
                         }
-                        ]
+                    ]
                 }`
             }
         }
@@ -214,7 +214,113 @@ const tests: HintTest[] = [
                                 "sizes": "192x192",
                                 "type": "image/png"
                             }
-                            ]
+                        ]
+                    }`
+            }
+        }
+    },
+    {
+        name: 'Duplicated purpose found',
+        reports: [
+            {
+                message: `Duplicate value(s) 'any' found in icon purpose property.`,
+                position: { match: `icons` },
+                severity: Severity.warning
+            },
+            {
+                message: `Duplicate value(s) 'any maskable' found in icon purpose property.`,
+                position: { match: `icons` },
+                severity: Severity.warning
+            },
+            {
+                message: `Duplicate value(s) 'any' found in icon purpose property.`,
+                position: { match: `icons` },
+                severity: Severity.warning
+            }
+        ],
+        serverConfig: {
+            '/': htmlWithManifestSpecified,
+            '/fixtures/icon-192x192.png': generateImageData(icon192px),
+            '/fixtures/icon-512x512.png': generateImageData(icon512px),
+            '/site.webmanifest': {
+                content: `{
+                        "icons": [
+                            {
+                                "purpose": "any maskable any",
+                                "src": "fixtures/icon-192x192.png",
+                                "sizes": "192x192",
+                                "type": "image/png"
+                            },
+                            {
+                                "purpose": "any maskable any maskable",
+                                "src": "fixtures/icon-512x512.png",
+                                "sizes": "512x512",
+                                "type": "image/png"
+                            },
+                            {
+                                "purpose": "  any maskable  any  ",
+                                "src": "fixtures/icon-512x512.png",
+                                "sizes": "512x512",
+                                "type": "image/png"
+                            }
+                        ]
+                    }`
+            }
+        }
+    },
+    {
+        name: 'Invalid purpose found',
+        reports: [
+            {
+                message: 'Invalid icon property purpose.',
+                position: {
+                    column: 33,
+                    line: 3
+                },
+                severity: Severity.error
+            },
+            {
+                message: 'Invalid icon property purpose.',
+                position: {
+                    column: 33,
+                    line: 9
+                },
+                severity: Severity.error
+            },
+            {
+                message: 'Invalid icon property purpose.',
+                position: {
+                    column: 33,
+                    line: 15
+                },
+                severity: Severity.error
+            }
+        ],
+        serverConfig: {
+            '/': htmlWithManifestSpecified,
+            '/fixtures/icon-192x192.png': generateImageData(icon192px),
+            '/site.webmanifest': {
+                content: `{
+                        "icons": [
+                            {
+                                "purpose": "invalidPurpose",
+                                "src": "fixtures/icon-192x192.png",
+                                "sizes": "192x192",
+                                "type": "image/png"
+                            },
+                            {
+                                "purpose": "any invalidPurpose",
+                                "src": "fixtures/icon-192x192.png",
+                                "sizes": "192x192",
+                                "type": "image/png"
+                            },
+                            {
+                                "purpose": "  any  invalidPurpose  ",
+                                "src": "fixtures/icon-192x192.png",
+                                "sizes": "192x192",
+                                "type": "image/png"
+                            }
+                        ]
                     }`
             }
         }
@@ -229,6 +335,7 @@ const tests: HintTest[] = [
                 content: `{
                     "icons": [
                         {
+                            "purpose": "maskable",
                             "src": "fixtures/icon-192x192.png",
                             "sizes": "192x192",
                             "type": "image/png"
@@ -238,7 +345,7 @@ const tests: HintTest[] = [
                             "sizes": "512x512",
                             "type": "image/png"
                         }
-                        ]
+                    ]
                 }`
             }
         }

--- a/packages/parser-manifest/src/schema.json
+++ b/packages/parser-manifest/src/schema.json
@@ -10,13 +10,7 @@
                 },
                 "purpose": {
                     "default": "any",
-                    "enum": [
-                        "any",
-                        "any badge",
-                        "badge",
-                        "badge any",
-                        "maskable"
-                    ],
+                    "pattern": "^\\s*(any|maskable|badge)(\\s+(any|maskable|badge)?)*$",
                     "type": "string"
                 },
                 "sizes": {

--- a/packages/parser-manifest/src/types.ts
+++ b/packages/parser-manifest/src/types.ts
@@ -22,12 +22,12 @@ export type ManifestPlatform =
 
 export type ManifestImageResource = {
     platform?: ManifestPlatform;
-    purpose:
-        'any' |
-        'badge' |
-        'any badge' |
-        'badge any' |
-        'maskable';
+    /*
+     * Until TypeScript supports regex, I think a string is the best we
+     * can use for the property purpose, the purpose value will be validated for the parser.
+     * https://github.com/microsoft/TypeScript/issues/6579.
+     */
+    purpose: string;
     sizes?: string;
     src: string;
     type?: string;


### PR DESCRIPTION
Fix #3791

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

Allow to the icons in manifest to have a combination of values.