### PR TITLE
Fix: Break header text anywhere needed

### DIFF
--- a/packages/extension-browser/src/devtools/views/pages/results/header.css
+++ b/packages/extension-browser/src/devtools/views/pages/results/header.css
@@ -13,7 +13,7 @@
 .headerText {
     font-size: 0.875rem;
     margin: 0.5rem 0 0;
-    overflow-wrap: break-word;
+    word-break: break-all;
     width: 100%;
 }
 


### PR DESCRIPTION
If a report is generated on a site with a very long URL, horizontal
overflow can happen.
We want to avoid this as it forces users to scroll horizontally to
reveal the content.

To do this, we make sure the header text can break anywhere.

Fix #3587
