### PR TITLE
Fix: Improve perf by using pageDOM.querySelector in hint-axe

### DIFF
--- a/packages/hint-axe/src/util/axe.ts
+++ b/packages/hint-axe/src/util/axe.ts
@@ -33,11 +33,10 @@ type RegistrationMap = Map<EngineKey, Map<string, Registration[]>>;
  */
 const registrationMap: RegistrationMap = new Map();
 
-const getElement = (context: HintContext, node: AxeNodeResult): HTMLElement => {
+const getElement = (context: HintContext, node: AxeNodeResult): HTMLElement | undefined | null => {
     const selector = node.target[0];
-    const elements = context.querySelectorAll(selector);
 
-    return elements[0];
+    return context.pageDOM?.querySelector(selector);
 };
 
 /** Validate if an axe check result has data associated with it. */


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

This change improves the performance of hint-axe by using `pageDOM.querySelector` instead of `HintContext.querySelectorAll`. The latter will stop DOM traversal after the first match: best case O(1), the former always does complete DOM traversal: best case O(N).

The typing changed to include `undefined` however this is was the case before because the zero index of an empty array is `undefined`.