### PR TITLE
Fix: Improve utils-dom querySelector perf by using cssSelect.selectOne

### DIFF
--- a/packages/utils-dom/src/htmldocument.ts
+++ b/packages/utils-dom/src/htmldocument.ts
@@ -165,8 +165,17 @@ export class HTMLDocument extends Node {
     /**
      * https://developer.mozilla.org/docs/Web/API/Document/querySelector
      */
-    public querySelector(selector: string): HTMLElement {
-        return this.querySelectorAll(selector)[0];
+    public querySelector(selector: string): HTMLElement | null {
+        if (!CACHED_CSS_SELECTORS.has(selector)) {
+            CACHED_CSS_SELECTORS.set(selector, cssSelect.compile(selector));
+        }
+
+        const data: any | undefined = cssSelect.selectOne(
+            CACHED_CSS_SELECTORS.get(selector) as cssSelect.CompiledQuery,
+            this._document.children
+        );
+
+        return data ? this.getNodeFromData(data) as HTMLElement : null;
     }
 
     /**

--- a/packages/utils-dom/src/htmldocument.ts
+++ b/packages/utils-dom/src/htmldocument.ts
@@ -170,7 +170,7 @@ export class HTMLDocument extends Node {
             CACHED_CSS_SELECTORS.set(selector, cssSelect.compile(selector));
         }
 
-        const data: any | undefined = cssSelect.selectOne(
+        const data = cssSelect.selectOne(
             CACHED_CSS_SELECTORS.get(selector) as cssSelect.CompiledQuery,
             this._document.children
         );

--- a/packages/utils-dom/tests/htmldocument.ts
+++ b/packages/utils-dom/tests/htmldocument.ts
@@ -11,3 +11,21 @@ test('title', (t) => {
     t.is(doc2.title, '');
     t.is(doc3.title, 'test');
 });
+
+test('querySelectorAll', (t) => {
+    const doc = createHTMLDocument('<div id="d1">div1</div><div id="d2">div2</div>', 'http://localhost/');
+
+    t.is(doc.querySelectorAll('div').length, 2);
+    t.is(doc.querySelectorAll('#d1').length, 1);
+    t.is(doc.querySelectorAll('#d2').length, 1);
+    t.is(doc.querySelectorAll('#d1')[0].textContent, 'div1');
+    t.is(doc.querySelectorAll('#d2')[0].textContent, 'div2');
+    t.is(doc.querySelectorAll('div')[0], doc.querySelectorAll('#d1')[0]);
+    t.is(doc.querySelectorAll('div')[1], doc.querySelectorAll('#d2')[0]);
+});
+
+test('querySelector', (t) => {
+    const doc = createHTMLDocument('<div>div1</div>', 'http://localhost/');
+
+    t.is(doc.querySelector('div').textContent, 'div1');
+});

--- a/packages/utils-dom/tests/htmldocument.ts
+++ b/packages/utils-dom/tests/htmldocument.ts
@@ -27,5 +27,6 @@ test('querySelectorAll', (t) => {
 test('querySelector', (t) => {
     const doc = createHTMLDocument('<div>div1</div>', 'http://localhost/');
 
-    t.is(doc.querySelector('div').textContent, 'div1');
+    t.is(doc.querySelector('div')?.textContent, 'div1');
+    t.is(doc.querySelector('not-div'), null);
 });


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

This change improves `querySelector` best case performance from O(N) to O(1).

Previously `querySelector` called `querySelectorAll` which had a best case of O(N) traversing all nodes in the DOM (passed in via `_document.children`).

The new implementation re-uses the css-select query cached (shared with `querySelectorAll`) and then leverages `cssSelect.selectOne` which internally leverages [domUtil's `findOne`][1] which has the improved performance (over `findAll`).


[1]: https://github.com/fb55/domutils/blob/d7d349c25f78a50cc3f29d9e83f86cbbcf93b2a9/src/querying.ts#L75