### PR TITLE
Chore: Prefer querySelector over querySelectorAll

### DIFF
--- a/packages/utils-dom/src/htmldocument.ts
+++ b/packages/utils-dom/src/htmldocument.ts
@@ -48,7 +48,7 @@ export class HTMLDocument extends Node {
     }
 
     private getBaseUrl(finalHref: string): string {
-        const baseElement = this.querySelectorAll('base[href]')[0];
+        const baseElement = this.querySelector('base[href]');
         const baseHref = baseElement ? baseElement.getAttribute('href') : null;
 
         if (!baseHref) {
@@ -77,7 +77,7 @@ export class HTMLDocument extends Node {
      * https://developer.mozilla.org/docs/Web/API/Document/body
      */
     public get body(): HTMLElement {
-        return this.querySelectorAll('body')[0];
+        return this.querySelector('body') as HTMLElement;
     }
 
     /**
@@ -102,7 +102,7 @@ export class HTMLDocument extends Node {
      * https://developer.mozilla.org/docs/Web/API/Document/title
      */
     public get title(): string {
-        return this.querySelectorAll('title')[0]?.textContent || '';
+        return this.querySelector('title')?.textContent || '';
     }
 
     /**


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

This change prefers `querySelector` over `querySelectorAll` in utils-dom.

This is semantically more correct (better expresses the intent of the code) and leverages the upcoming performance improvement in #3861 
