### PR TITLE
Chore: Improve utils-dom perf with matches() refactor

### DIFF
--- a/packages/utils-dom/src/cached-css-selectors.ts
+++ b/packages/utils-dom/src/cached-css-selectors.ts
@@ -1,4 +1,0 @@
-import { CompiledQuery } from 'css-select';
-
-// TODO: Use quick-lru so that it doesn't grow without bounds
-export const CACHED_CSS_SELECTORS: Map<string, CompiledQuery> = new Map();

--- a/packages/utils-dom/src/cached-css-selectors.ts
+++ b/packages/utils-dom/src/cached-css-selectors.ts
@@ -1,0 +1,4 @@
+import { CompiledQuery } from 'css-select';
+
+// TODO: Use quick-lru so that it doesn't grow without bounds
+export const CACHED_CSS_SELECTORS: Map<string, CompiledQuery> = new Map();

--- a/packages/utils-dom/src/get-compiled-selector.ts
+++ b/packages/utils-dom/src/get-compiled-selector.ts
@@ -1,0 +1,16 @@
+import { compile, CompiledQuery } from 'css-select';
+
+// TODO: Use quick-lru so that it doesn't grow without bounds
+const CACHED_CSS_SELECTORS: Map<string, CompiledQuery> = new Map();
+
+/**
+ * Helper to get a compiled cached css-select query function.
+ * @param selector css selector
+ */
+export const getCompiledSelector = (selector: string): CompiledQuery => {
+    if (!CACHED_CSS_SELECTORS.has(selector)) {
+        CACHED_CSS_SELECTORS.set(selector, compile(selector));
+    }
+
+    return CACHED_CSS_SELECTORS.get(selector)!;
+};

--- a/packages/utils-dom/src/htmldocument.ts
+++ b/packages/utils-dom/src/htmldocument.ts
@@ -12,8 +12,7 @@ import { Node } from './node';
 import { Text } from './text';
 import { DocumentData, ElementData, NodeData } from './types';
 
-// TODO: Use quick-lru so that it doesn't grow without bounds
-const CACHED_CSS_SELECTORS: Map<string, cssSelect.CompiledQuery> = new Map();
+import { CACHED_CSS_SELECTORS } from './cached-css-selectors';
 
 /**
  * https://developer.mozilla.org/docs/Web/API/HTMLDocument

--- a/packages/utils-dom/src/htmldocument.ts
+++ b/packages/utils-dom/src/htmldocument.ts
@@ -11,8 +11,7 @@ import { DocumentType } from './documenttype';
 import { Node } from './node';
 import { Text } from './text';
 import { DocumentData, ElementData, NodeData } from './types';
-
-import { CACHED_CSS_SELECTORS } from './cached-css-selectors';
+import { getCompiledSelector } from './get-compiled-selector';
 
 /**
  * https://developer.mozilla.org/docs/Web/API/HTMLDocument
@@ -165,12 +164,8 @@ export class HTMLDocument extends Node {
      * https://developer.mozilla.org/docs/Web/API/Document/querySelector
      */
     public querySelector(selector: string): HTMLElement | null {
-        if (!CACHED_CSS_SELECTORS.has(selector)) {
-            CACHED_CSS_SELECTORS.set(selector, cssSelect.compile(selector));
-        }
-
         const data = cssSelect.selectOne(
-            CACHED_CSS_SELECTORS.get(selector) as cssSelect.CompiledQuery,
+            getCompiledSelector(selector),
             this._document.children
         );
 
@@ -181,12 +176,8 @@ export class HTMLDocument extends Node {
      * https://developer.mozilla.org/docs/Web/API/Document/querySelectorAll
      */
     public querySelectorAll(selector: string): HTMLElement[] {
-        if (!CACHED_CSS_SELECTORS.has(selector)) {
-            CACHED_CSS_SELECTORS.set(selector, cssSelect.compile(selector));
-        }
-
         const matches: any[] = cssSelect(
-            CACHED_CSS_SELECTORS.get(selector) as cssSelect.CompiledQuery,
+            getCompiledSelector(selector),
             this._document.children
         );
 

--- a/packages/utils-dom/src/htmlelement.ts
+++ b/packages/utils-dom/src/htmlelement.ts
@@ -1,4 +1,3 @@
-import { compile } from 'css-select';
 import * as parse5 from 'parse5';
 import * as htmlparser2Adapter from 'parse5-htmlparser2-tree-adapter';
 
@@ -10,7 +9,7 @@ import { ElementData, INamedNodeMap } from './types';
 import { Node } from './node';
 import { CSSStyleDeclaration } from './cssstyledeclaration';
 import { HTMLDocument } from './htmldocument';
-import { CACHED_CSS_SELECTORS } from './cached-css-selectors';
+import { getCompiledSelector } from './get-compiled-selector';
 
 /**
  * https://developer.mozilla.org/docs/Web/API/HTMLElement
@@ -235,11 +234,7 @@ export class HTMLElement extends Node {
      * https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
      */
     public matches(selector: string): boolean {
-        if (!CACHED_CSS_SELECTORS.has(selector)) {
-            CACHED_CSS_SELECTORS.set(selector, compile(selector));
-        }
-
-        return CACHED_CSS_SELECTORS.get(selector)!(this._element);
+        return getCompiledSelector(selector)(this._element);
     }
 
     /**

--- a/packages/utils-dom/src/htmlelement.ts
+++ b/packages/utils-dom/src/htmlelement.ts
@@ -1,3 +1,4 @@
+import { compile } from 'css-select';
 import * as parse5 from 'parse5';
 import * as htmlparser2Adapter from 'parse5-htmlparser2-tree-adapter';
 
@@ -9,6 +10,7 @@ import { ElementData, INamedNodeMap } from './types';
 import { Node } from './node';
 import { CSSStyleDeclaration } from './cssstyledeclaration';
 import { HTMLDocument } from './htmldocument';
+import { CACHED_CSS_SELECTORS } from './cached-css-selectors';
 
 /**
  * https://developer.mozilla.org/docs/Web/API/HTMLElement
@@ -233,7 +235,11 @@ export class HTMLElement extends Node {
      * https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
      */
     public matches(selector: string): boolean {
-        return this.ownerDocument.querySelectorAll(selector).includes(this);
+        if (!CACHED_CSS_SELECTORS.has(selector)) {
+            CACHED_CSS_SELECTORS.set(selector, compile(selector));
+        }
+
+        return CACHED_CSS_SELECTORS.get(selector)!(this._element);
     }
 
     /**

--- a/packages/utils-dom/tests/htmlelement.ts
+++ b/packages/utils-dom/tests/htmlelement.ts
@@ -71,3 +71,9 @@ test('isAttributeAnExpression', (t) => {
     t.true(doc.body.children[0].isAttributeAnExpression('id'));
     t.false(doc.body.children[0].isAttributeAnExpression('class'));
 });
+
+test('matches', (t) => {
+    const doc = createHTMLDocument('<div id="match-me"></div>', 'http://localhost/');
+
+    t.true(doc.body.children[0].matches('#match-me'));
+});


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

This change improves the performance of `utils-dom` by refactoring `Element.matches`.

#### webhint.io
| before (ms) | after (ms) |
| ------------  | ---------- |
|    0.7199      |   0.7000   |

#### cnn.com
| before (ms) | after (ms) |
| ------------  | ---------- |
|    +60000    |  16.4900  |

_Previously cnn.com could take minutes to complete._

The problem was matches relied on querySelectorAll which will always check every dom node O(N). Now we compile the selector  test function from `css-select` directly and invoke it on the current element O(1). This performance is not bottlenecked by `compile`.

This change also pulls `CACHED_CSS_SELECTORS` into a shared module used by `htmldocument.ts` and `htmlelement.ts`,

Close #3904