### PR TITLE
Fix: Grep AWK path accounting for suffix

### DIFF
--- a/packages/connector-puppeteer/src/lib/chromium-finder.ts
+++ b/packages/connector-puppeteer/src/lib/chromium-finder.ts
@@ -116,10 +116,13 @@ const darwin = (browser: Browser) => {
 
     /**
      * The following generates a list of all the installed applications in macOS.
-     * The `grep` command makes sure we only get the lines that end with `.app`
+     * The `grep` command makes sure we only get the lines that contain `.app`
      * because `-dump` generates more information than the one needed.
-     * The `awk` commands makes sure we remove the initial part of the line so we
+     * The `awk` commands makes sure we remove the suffix and prefix part of the line so we
      * only get the path.
+     *
+     * Turns -> path: /Applications/Google Chrome.app (0x2134)
+     * into  -> /Applications/Google Chrome.app
      *
      * More info in:
      * http://krypted.com/mac-security/lsregister-associating-file-types-in-mac-os-x/
@@ -130,8 +133,8 @@ const darwin = (browser: Browser) => {
 
     const lines = execSync(
         `${LSREGISTER} -dump` +
-        ` | grep -i '\.app$'` + // eslint-disable-line
-        ` | awk '{$1=""; print $0}'`)
+        ` | grep -i '\.app'` + // eslint-disable-line
+        ` | awk '{print $2,3}'`)
         .toString()
         .split(newLineRegex);
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Ref https://github.com/webhintio/hint/issues/3900 This affected Mac computers. No paths are found even though the correct browsers are installed.

The fix:
* For grep, I removed the $. As seen below, the path doesn't end in .app. So this entry will never get included if we use $.
* For awk, I updated the print to provide us only index 2 and 3

from this -> `path:     /Applications/Google Chrome.app (0x2134)`
to this     ->`/Applications/Google Chrome.app`


```
const lines = execSync(
        `${LSREGISTER} -dump` +
        ` | grep -i '\.app'` + // eslint-disable-line
        ` | awk '{print $2,$3}'`)
        .toString()
        .split(newLineRegex);
```

I am not familiar with your testing framework nor the proper setup to run such. But I am finally able to run hint via CLI now.
