### PR TITLE
Include Analyzer instance resources when calling formatters

### DIFF
--- a/packages/hint/src/lib/analyzer.ts
+++ b/packages/hint/src/lib/analyzer.ts
@@ -262,10 +262,9 @@ export class Analyzer {
      * @param {Problem[]} problems Problems to format.
      * @param {FormatterOptions} options Options for the formatters.
      */
-    public async format(problems: Problem[], options?: FormatterOptions): Promise<void> {
-        if (options) {
-            options.language = options.language || this.configuration.language;
-        }
+    public async format(problems: Problem[], options: FormatterOptions = {}): Promise<void> {
+        options.language = options.language || this.configuration.language;
+        options.resources = options.resources || this.resources;
 
         for (const formatter of this.formatters) {
             await formatter.format(problems, options);

--- a/packages/hint/tests/lib/analyzer.ts
+++ b/packages/hint/tests/lib/analyzer.ts
@@ -10,7 +10,8 @@ import {
     AnalyzerError,
     HintResources,
     IFetchOptions,
-    IFormatter
+    IFormatter,
+    FormatterOptions
 } from '../../src/lib/types';
 import { AnalyzerErrorStatus } from '../../src/lib/enums/error-status';
 import { Problem } from '@hint/utils-types';
@@ -554,6 +555,41 @@ test('format should call to all the formatters', async (t) => {
     await webhint.format([]);
 
     t.true(formatterFormatStub.calledOnce);
+});
+
+test('format should call to formatters using the Analyzer resources, if no resources provided as options', async (t) => {
+    const sandbox = t.context.sandbox;
+
+    class FakeFormatter implements IFormatter {
+        public constructor() { }
+
+        public format(problems: Problem[], options: FormatterOptions) {
+        }
+    }
+
+    const formatter = new FakeFormatter();
+
+    const { Analyzer, engine } = loadScript(t.context);
+
+    const formatterFormatStub = sandbox.stub(formatter, 'format').resolves();
+
+    sandbox.stub(engine, 'executeOn').resolves([]);
+    sandbox.stub(engine, 'close').resolves();
+
+    const resources: HintResources = {
+        connector: null,
+        formatters: [],
+        hints: [],
+        incompatible: [],
+        missing: [],
+        parsers: []
+    };
+
+    const webhint = new Analyzer({}, resources, [formatter]);
+
+    await webhint.format([]);
+
+    t.true(formatterFormatStub.calledWithMatch([], { resources }));
 });
 
 test('resources should returns all the resources', (t) => {


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- n/a Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

Fixes #3910

Formatters need to know which hints were used during analyze, and so by including the `Analyzer.resources` when calling formatters, they can then display only the categories that were actually used.
