### PR TITLE
Fix: Add missing $ prefix to awk expression

### DIFF
--- a/packages/connector-puppeteer/src/lib/chromium-finder.ts
+++ b/packages/connector-puppeteer/src/lib/chromium-finder.ts
@@ -134,7 +134,7 @@ const darwin = (browser: Browser) => {
     const lines = execSync(
         `${LSREGISTER} -dump` +
         ` | grep -i '\.app'` + // eslint-disable-line
-        ` | awk '{print $2,3}'`)
+        ` | awk '{print $2,$3}'`)
         .toString()
         .split(newLineRegex);
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

I noticed a problem when running the latest version of the puppeteer connector on macOS (Mojave in my case). It couldn't find Chrome anymore. After some tweaking I could make it work by adding the missing $ sign to the awk expression. Unfortunately I don't know enough about awk to say if this is a bug or just a new syntax which does not yet work on Mojave.

Feel free to close this pull request if the missing $ sign was intended.