### PR TITLE
Docs: Fix broken README.md links on npmjs.org

### DIFF
--- a/packages/hint-babel-config/README.md
+++ b/packages/hint-babel-config/README.md
@@ -44,5 +44,5 @@ your project.
 <!-- Link labels: -->
 
 [babel documentation]: https://babeljs.io/docs/usage/babelrc/
-[is-valid]: ./docs/is-valid.md
+[is-valid]: https://github.com/webhintio/hint/blob/HEAD/packages/hint-babel-config/docs/is-valid.md
 [hintrc]: https://webhint.io/docs/user-guide/configuring-webhint/summary/

--- a/packages/hint-compat-api/README.md
+++ b/packages/hint-compat-api/README.md
@@ -42,7 +42,7 @@ your project.
 
 <!-- Link labels: -->
 
-[compat-api-css]: ./docs/css.md
-[compat-api-html]: ./docs/html.md
+[compat-api-css]: https://github.com/webhintio/hint/blob/HEAD/packages/hint-compat-api/docs/css.md
+[compat-api-html]: https://github.com/webhintio/hint/blob/HEAD/packages/hint-compat-api/docs/html.md
 [hintrc]: https://webhint.io/docs/user-guide/configuring-webhint/summary/
 [npm docs]: https://docs.npmjs.com/cli/install

--- a/packages/hint-typescript-config/README.md
+++ b/packages/hint-typescript-config/README.md
@@ -50,10 +50,10 @@ your project.
 
 <!-- Link labels: -->
 
-[import-helpers]: ./docs/import-helpers.md
-[is-valid]: ./docs/is-valid.md
-[no-comments]: ./docs/no-comments.md
+[import-helpers]: https://github.com/webhintio/hint/blob/HEAD/packages/hint-typescript-config/docs/import-helpers.md
+[is-valid]: https://github.com/webhintio/hint/blob/HEAD/packages/hint-typescript-config/docs/is-valid.md
+[no-comments]: https://github.com/webhintio/hint/blob/HEAD/packages/hint-typescript-config/docs/no-comments.md
 [hintrc]: https://webhint.io/docs/user-guide/configuring-webhint/summary/
-[strict]: ./docs/strict.md
-[target]: ./docs/target.md
+[strict]: https://github.com/webhintio/hint/blob/HEAD/packages/hint-typescript-config/docs/strict.md
+[target]: https://github.com/webhintio/hint/blob/HEAD/packages/hint-typescript-config/docs/target.md
 [typescript docs]: https://www.typescriptlang.org/docs/home.html

--- a/packages/hint-webpack-config/README.md
+++ b/packages/hint-webpack-config/README.md
@@ -54,11 +54,11 @@ your project.
 
 <!-- Link labels: -->
 
-[config-exists]: ./docs/config-exists.md
-[is-installed]: ./docs/is-installed.md
-[is-valid]: ./docs/is-valid.md
-[module-esnext-typescript]: ./docs/module-esnext-typescript.md
-[modules-false-babel]: ./docs/modules-false-babel.md
-[no-devtool-in-prod]: ./docs/no-devtool-in-prod.md
+[config-exists]: https://github.com/webhintio/hint/blob/HEAD/packages/hint-webpack-config/docs/config-exists.md
+[is-installed]: https://github.com/webhintio/hint/blob/HEAD/packages/hint-webpack-config/docs/is-installed.md
+[is-valid]: https://github.com/webhintio/hint/blob/HEAD/packages/hint-webpack-config/docs/is-valid.md
+[module-esnext-typescript]: https://github.com/webhintio/hint/blob/HEAD/packages/hint-webpack-config/docs/module-esnext-typescript.md
+[modules-false-babel]: https://github.com/webhintio/hint/blob/HEAD/packages/hint-webpack-config/docs/modules-false-babel.md
+[no-devtool-in-prod]: https://github.com/webhintio/hint/blob/HEAD/packages/hint-webpack-config/docs/no-devtool-in-prod.md
 [hintrc]: https://webhint.io/docs/user-guide/configuring-webhint/summary/
 [webpack docs]: https://webpack.js.org/concepts/

--- a/packages/hint/README.md
+++ b/packages/hint/README.md
@@ -39,18 +39,18 @@ You can also run webhint from within [VS Code][] and as a
 [browser extension][].
 
 **NOTE**: If you run into any issues during the install process
-please check the [troubleshoot section](./docs/user-guide/troubleshoot/summary.md).
+please check the [troubleshoot section](https://github.com/webhintio/hint/blob/HEAD/packages/hint/docs/user-guide/troubleshoot/summary.md).
 
 ### Further reading
 
 Now that you have `webhint` up and running, it is time to learn a bit
 more about the different pieces:
 
-* [Configurations](./docs/user-guide/concepts/configurations.md)
-* [Hints](./docs/user-guide/concepts/hints.md)
-* [Connectors](./docs/user-guide/concepts/connectors.md)
-* [Formatters](./docs/user-guide/concepts/formatters.md)
-* [Parsers](./docs/user-guide/concepts/parsers.md)
+* [Configurations](https://github.com/webhintio/hint/blob/HEAD/packages/hint/docs/user-guide/concepts/configurations.md)
+* [Hints](https://github.com/webhintio/hint/blob/HEAD/packages/hint/docs/user-guide/concepts/hints.md)
+* [Connectors](https://github.com/webhintio/hint/blob/HEAD/packages/hint/docs/user-guide/concepts/connectors.md)
+* [Formatters](https://github.com/webhintio/hint/blob/HEAD/packages/hint/docs/user-guide/concepts/formatters.md)
+* [Parsers](https://github.com/webhintio/hint/blob/HEAD/packages/hint/docs/user-guide/concepts/parsers.md)
 
 ## Contributing to webhint
 
@@ -58,7 +58,7 @@ To know more about the internals of `webhint`, the structure of the
 project, how to create new hints, collectors, formatters, etc, take a
 look at the online [contributor
 guide](https://webhint.io/docs/contributor-guide/) (or the [local
-version](./docs/contributor-guide/index.md)).
+version](https://github.com/webhintio/hint/blob/HEAD/packages/hint/docs/contributor-guide/index.md)).
 
 ## Code of Conduct
 


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messagesx

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

Some links on the following npmjs.org pages 404.
- https://www.npmjs.com/package/hint/v/6.0.7#further-reading
- https://www.npmjs.com/package/@hint/hint-compat-api/v/4.3.5#hints
- https://www.npmjs.com/package/@hint/hint-babel-config/v/2.4.6#hints
- https://www.npmjs.com/package/@hint/hint-typescript-config/v/2.4.6#hints
- https://www.npmjs.com/package/@hint/hint-webpack-config/v/2.4.6#hints

This is caused by https://github.com/npm/marky-markdown/issues/449

The workaround is to provide fully qualified URLs to github in the READM.md files, this is already a pattern in some hint/packages.

Fixes #3792 
Closes #3937