### PR TITLE
Fix: UserConfig type not exported by hint

### DIFF
--- a/packages/hint/src/lib/types/analyzer.ts
+++ b/packages/hint/src/lib/types/analyzer.ts
@@ -1,5 +1,7 @@
 import { Problem } from '@hint/utils-types';
 
+export type { UserConfig } from '@hint/utils';
+
 export type CreateAnalyzerOptions = {
     formatters?: string[];
     hints?: string[];


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

Fix missing `UserConfig` type from hint (#3952) by adding `export type { UserConfig } from '@hint/utils';` to the analyzer types.
