### PR TITLE
Fix: Sending VS Code telemetry when opted-in

### DIFF
--- a/packages/extension-vscode/src/server.ts
+++ b/packages/extension-vscode/src/server.ts
@@ -75,8 +75,13 @@ initTelemetry({
                 reject(err);
             });
 
-            request.write(data);
-            request.end();
+            /*
+             * Don't use request.write or request will be sent chunked.
+             * Chunked requests break in node-based v2 Azure Functions,
+             * which are used to run the webhint telemetry service.
+             * https://github.com/Azure/azure-functions-host/issues/4926
+             */
+            request.end(data);
         });
     }
 });


### PR DESCRIPTION
Ultimately due to a bug in Azure Functions failing to handle chunked requests for node environments. Given that can't be easily addressed, this change works around the issue by ensuring the sent telemetry request is not chunked.
