### PR TITLE
Docs: Fix broken hint-axe README.md links

### DIFF
--- a/packages/hint-axe/README.md
+++ b/packages/hint-axe/README.md
@@ -175,18 +175,18 @@ your project.
 [wai]: https://www.w3.org/WAI/intro/accessibility.php
 [wcag 2.1]: https://www.w3.org/TR/WCAG21/
 <!-- start hint links -->
-[axe/aria]: ./docs/aria.md
-[axe/color]: ./docs/color.md
-[axe/forms]: ./docs/forms.md
-[axe/keyboard]: ./docs/keyboard.md
-[axe/language]: ./docs/language.md
-[axe/name-role-value]: ./docs/name-role-value.md
-[axe/other]: ./docs/other.md
-[axe/parsing]: ./docs/parsing.md
-[axe/semantics]: ./docs/semantics.md
-[axe/sensory-and-visual-cues]: ./docs/sensory-and-visual-cues.md
-[axe/structure]: ./docs/structure.md
-[axe/tables]: ./docs/tables.md
-[axe/text-alternatives]: ./docs/text-alternatives.md
-[axe/time-and-media]: ./docs/time-and-media.md
+[axe/aria]: https://webhint.io/docs/user-guide/hints/hint-axe/aria/
+[axe/color]: https://webhint.io/docs/user-guide/hints/hint-axe/color/
+[axe/forms]: https://webhint.io/docs/user-guide/hints/hint-axe/forms/
+[axe/keyboard]: https://webhint.io/docs/user-guide/hints/hint-axe/keyboard/
+[axe/language]: https://webhint.io/docs/user-guide/hints/hint-axe/language/
+[axe/name-role-value]: https://webhint.io/docs/user-guide/hints/hint-axe/name-role-value/
+[axe/other]: https://webhint.io/docs/user-guide/hints/hint-axe/other/
+[axe/parsing]: https://webhint.io/docs/user-guide/hints/hint-axe/parsing/
+[axe/semantics]: https://webhint.io/docs/user-guide/hints/hint-axe/semantics/
+[axe/sensory-and-visual-cues]: https://webhint.io/docs/user-guide/hints/hint-axe/sensory-and-visual-cues/
+[axe/structure]: https://webhint.io/docs/user-guide/hints/hint-axe/structure/
+[axe/tables]: https://webhint.io/docs/user-guide/hints/hint-axe/tables/
+[axe/text-alternatives]: https://webhint.io/docs/user-guide/hints/hint-axe/text-alternatives/
+[axe/time-and-media]: https://webhint.io/docs/user-guide/hints/hint-axe/time-and-media/
 <!-- end hint links -->

--- a/packages/hint-axe/scripts/create/create-docs.js
+++ b/packages/hint-axe/scripts/create/create-docs.js
@@ -78,7 +78,7 @@ const updateReadme = async (categories) => {
     const hintLinks = categories.map((category) => {
         const id = categoryId(category);
 
-        return `[axe/${id}]: ./docs/${id}.md`;
+        return `[axe/${id}]: https://webhint.io/docs/user-guide/hints/hint-axe/${id}/`;
     });
 
     const content = source


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

hint-axe docs are now generated (#3418) at build time so the relative path is only good for post build local install of the repository and results in 404s for anyone browsing github or npmjs.org (the more common scenario).

To give the best experience for the more common scenario this change directs the links to webhint.io which will have the information from the latest release.

Follows up #3937 