### PR TITLE
Fix: Increase build timeout to allow windows pass the tests

### DIFF
--- a/azure-pipelines/all-versions.yml
+++ b/azure-pipelines/all-versions.yml
@@ -16,5 +16,5 @@ jobs:
        node_version: 12.x
   steps:
   - template: ${{ parameters.worker }}
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
   condition: ${{ parameters.condition }}

--- a/azure-pipelines/latest-version.yml
+++ b/azure-pipelines/latest-version.yml
@@ -14,5 +14,5 @@ jobs:
         node_version: 12.x
   steps:
   - template: ${{ parameters.worker }}
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
   condition: ${{ parameters.condition }}


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

Windows is timing out a lot lately, this PR will increase the CI timeout to 120 minutes.