### PR TITLE
New: Ignore a[rel=noopener] by default

### DIFF
--- a/packages/hint-compat-api/docs/html.md
+++ b/packages/hint-compat-api/docs/html.md
@@ -85,6 +85,7 @@ default value is:
 
 ```json
 [
+    "a[rel=noopener]",
     "autocomplete",
     "crossorigin",
     "integrity",

--- a/packages/hint-compat-api/src/html.ts
+++ b/packages/hint-compat-api/src/html.ts
@@ -74,6 +74,7 @@ export default class HTMLCompatHint implements IHint {
 
     public constructor(context: HintContext) {
         const ignore = resolveIgnore([
+            'a[rel=noopener]', // handled by hint-disown-opener
             'autocomplete',
             'crossorigin',
             'integrity',

--- a/packages/hint-compat-api/tests/fixtures/html/ignore.html
+++ b/packages/hint-compat-api/tests/fixtures/html/ignore.html
@@ -1,2 +1,3 @@
 <script integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"></script>
 <input autocomplete="off">
+<a href="https://webhint.io" rel="noopener">Test</a>


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
This is covered with more nuance by `hint-disown-opener`.
No need to duplicate reporting in `hint-compat-api/html`.