### PR TITLE
Fix: Add experimental cache-control directives

### DIFF
--- a/packages/hint-http-cache/src/hint.ts
+++ b/packages/hint-http-cache/src/hint.ts
@@ -142,7 +142,8 @@ export default class HttpCacheHint implements IHint {
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
             const directives = ['must-revalidate', 'no-cache', 'no-store', 'no-transform', 'public', 'private', 'proxy-revalidate'];
             const valueDirectives = ['max-age', 's-maxage'];
-            const extensionDirectives = ['immutable', 'stale-while-revalidate', 'stale-if-error'];
+            const extensionDirectives = ['immutable'];
+            const extensionValueDirectives = ['stale-while-revalidate', 'stale-if-error'];
 
             const usedDirectives = cacheControlHeader.split(',').map((value) => {
                 return value.trim();
@@ -159,10 +160,10 @@ export default class HttpCacheHint implements IHint {
                 // Validate directive with value. E.g.: max-age=<seconds>
                 if (directive && value) {
                     /*
-                     * Check if the directive has a value when it shouldn't
+                     * Check if the directive has a value when it shouldn't, including extension directives
                      * E.g.: no-cache=12345
                      */
-                    if (!valueDirectives.includes(directive)) {
+                    if (!valueDirectives.includes(directive) && !extensionValueDirectives.includes(directive)) {
                         parsed.invalidValues.set(directive, value);
 
                         return parsed;


### PR DESCRIPTION
Added stale-while-revalidate and stale-if-error to newly created
extensionValueDirectives with appropriate validation.

Fixes issue #3691 
