### PR TITLE
New IE flexbox compat hint

### DIFF
--- a/packages/hint-ie-flexbox-compat/.npmrc
+++ b/packages/hint-ie-flexbox-compat/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/hint-ie-flexbox-compat/LICENSE.txt
+++ b/packages/hint-ie-flexbox-compat/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright JS Foundation and other contributors, https://js.foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/hint-ie-flexbox-compat/README.md
+++ b/packages/hint-ie-flexbox-compat/README.md
@@ -1,0 +1,76 @@
+# Internet Explorer Flexbox Compatibility (`ie-flexbox-compat`)
+
+`ie-flexbox-compat` warns about potential CSS Flexbox compatibility bugs with Internet Explorer.
+
+## Why is this important?
+
+Internet Explorer 11 and older suffer from a number of CSS Flexbox compatibility bugs.\
+In some cases, the CSS Flexbox specification changed after Internet Explorer implemented it, in others, the
+implementation was just incorrect.
+
+Because of this, the layout on your site may be different between Internet Explorer and other browsers if you
+use Flexbox.\
+The size or alignment of elements may be incorrect or content may overflow.
+
+As described in [Microsoft's support policy for Internet Explorer][IE support policy], support for older
+versions of this browser ended and Microsoft no longer provides security updates or technical support for
+these versions.\
+It is therefore discouraged to introduce flexbox if you still need to target IE.
+
+You can find more information about each individual bug as well workarounds for them on the
+[Flexbugs repository][flexbugs].
+
+## What does the hint check?
+
+This hint checks two things:
+
+* That the configured target browsers include Internet Explorer.
+* And that CSS on your site uses flexbox.
+
+### Examples that **trigger** the hint
+
+If your site declares a flexbox container by using:
+
+```css
+#container {
+    display: flex;
+}
+```
+
+Or by using:
+
+```css
+#container {
+    display: inline-flex;
+}
+```
+
+## How to use this hint?
+
+This package is installed automatically by webhint:
+
+```bash
+npm install hint --save-dev
+```
+
+To use it, activate it via the [`.hintrc`][hintrc] configuration file:
+
+```json
+{
+    "connector": {...},
+    "formatters": [...],
+    "hints": {
+        "ie-flexbox-compat": "warning",
+        ...
+    },
+    "parsers": [...],
+    ...
+}
+```
+
+**Note**: The recommended way of running webhint is as a `devDependency` of
+your project.
+
+[hintrc]: https://webhint.io/docs/user-guide/configuring-webhint/summary/
+[IE support policy]: https://www.microsoft.com/en-us/microsoft-365/windows/end-of-ie-support
+[flexbugs]: https://github.com/philipwalton/flexbugs

--- a/packages/hint-ie-flexbox-compat/README.md
+++ b/packages/hint-ie-flexbox-compat/README.md
@@ -1,24 +1,28 @@
 # Internet Explorer Flexbox Compatibility (`ie-flexbox-compat`)
 
-`ie-flexbox-compat` warns about potential CSS Flexbox compatibility bugs with Internet Explorer.
+`ie-flexbox-compat` warns about potential CSS Flexbox compatibility bugs with
+Internet Explorer.
 
 ## Why is this important?
 
-Internet Explorer 11 and older suffer from a number of CSS Flexbox compatibility bugs.\
-In some cases, the CSS Flexbox specification changed after Internet Explorer implemented it, in others, the
-implementation was just incorrect.
+Internet Explorer 11 and older suffer from a number of CSS Flexbox
+compatibility bugs.\
+In some cases, the CSS Flexbox specification changed after Internet Explorer
+implemented it, in others, the implementation was just incorrect.
 
-Because of this, the layout on your site may be different between Internet Explorer and other browsers if you
-use Flexbox.\
+Because of this, the layout on your site may be different between Internet
+Explorer and other browsers if you use Flexbox.\
 The size or alignment of elements may be incorrect or content may overflow.
 
-As described in [Microsoft's support policy for Internet Explorer][IE support policy], support for older
-versions of this browser ended and Microsoft no longer provides security updates or technical support for
-these versions.\
-It is therefore discouraged to introduce flexbox if you still need to target IE.
+As described in
+[Microsoft's support policy for Internet Explorer][IE support policy], support
+for older versions of this browser ended and Microsoft no longer provides
+security updates or technical support for these versions.\
+It is therefore discouraged to introduce flexbox if you still need to target
+IE.
 
-You can find more information about each individual bug as well workarounds for them on the
-[Flexbugs repository][flexbugs].
+You can find more information about each individual bug as well workarounds for
+them on the [Flexbugs repository][flexbugs].
 
 ## What does the hint check?
 

--- a/packages/hint-ie-flexbox-compat/package.json
+++ b/packages/hint-ie-flexbox-compat/package.json
@@ -1,0 +1,73 @@
+{
+  "ava": {
+    "failFast": false,
+    "files": [
+      "dist/tests/**/*.js",
+      "!dist/tests/**/fixtures/**/*.js"
+    ],
+    "timeout": "1m"
+  },
+  "dependencies": {
+    "@hint/utils-debug": "^1.0.2",
+    "@hint/utils-i18n": "^1.0.5",
+    "@hint/utils-types": "^1.1.0"
+  },
+  "description": "hint that informs about potential flexbox compatibility bugs with Internet Explorer",
+  "devDependencies": {
+    "@hint/utils-create-server": "^3.4.6",
+    "@hint/utils-tests-helpers": "^6.3.0",
+    "@types/node": "^14.11.2",
+    "@typescript-eslint/eslint-plugin": "^4.0.1",
+    "@typescript-eslint/parser": "^4.0.1",
+    "ava": "^3.12.1",
+    "cpx": "^1.5.0",
+    "eslint": "^7.8.1",
+    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-markdown": "^1.0.2",
+    "npm-run-all": "^4.1.5",
+    "nyc": "^15.1.0",
+    "rimraf": "^3.0.2",
+    "typescript": "^4.0.2"
+  },
+  "files": [
+    "dist/src"
+  ],
+  "homepage": "https://webhint.io/",
+  "keywords": [
+    "hint",
+    "ie-flexbox-compat",
+    "ie-flexbox-compat-hint"
+  ],
+  "license": "Apache-2.0",
+  "main": "dist/src/hint.js",
+  "name": "@hint/hint-ie-flexbox-compat",
+  "nyc": {
+    "extends": "../../.nycrc"
+  },
+  "peerDependencies": {
+    "hint": "^6.0.0"
+  },
+  "private": true,
+  "repository": "webhintio/hint",
+  "scripts": {
+    "build": "npm run i18n && npm-run-all build:*",
+    "build-release": "npm run clean && npm run i18n && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
+    "build:assets": "cpx \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
+    "build:ts": "tsc -b",
+    "clean": "rimraf dist",
+    "i18n": "node ../../scripts/create-i18n.js",
+    "lint": "npm-run-all lint:*",
+    "lint:js": "eslint . --cache --ext .js,.md,.ts --ignore-path ../../.eslintignore",
+    "lint:dependencies": "node ../../scripts/lint-dependencies.js",
+    "lint:md": "node ../../scripts/lint-markdown.js",
+    "test": "npm run i18n && npm run lint && npm run build && npm run test-only",
+    "test-only": "nyc ava",
+    "test-release": "npm run i18n && npm run lint && npm run build-release && ava",
+    "init": "npm install && npm run build",
+    "watch": "npm run build && npm-run-all --parallel -c watch:*",
+    "watch:assets": "npm run build:assets -- -w --no-initial",
+    "watch:test": "ava --watch",
+    "watch:ts": "npm run build:ts -- --watch"
+  },
+  "version": "0.0.1"
+}

--- a/packages/hint-ie-flexbox-compat/package.json
+++ b/packages/hint-ie-flexbox-compat/package.json
@@ -8,9 +8,11 @@
     "timeout": "1m"
   },
   "dependencies": {
-    "@hint/utils-debug": "^1.0.2",
     "@hint/utils-i18n": "^1.0.5",
-    "@hint/utils-types": "^1.1.0"
+    "@hint/utils-types": "^1.1.0",
+    "@hint/utils-fs": "^1.0.5",
+    "@hint/utils-css": "^1.0.5",
+    "@hint/parser-css": "^3.0.21"
   },
   "description": "hint that informs about potential flexbox compatibility bugs with Internet Explorer",
   "devDependencies": {

--- a/packages/hint-ie-flexbox-compat/src/_locales/en/messages.json
+++ b/packages/hint-ie-flexbox-compat/src/_locales/en/messages.json
@@ -9,6 +9,6 @@
     },
     "usingFlexWithIE": {
         "description": "String warning users that flex is used and IE is a target browser",
-        "message": "The Internet Explorer brower versions 11 and older suffer from a number of CSS Flexbox compatibility bugs. The layout on this page may be different between Internet Explorer and other, more recent, browsers. The size or alignment of elements may be incorrect and content may overflow.\nSupport for older versions of Internet Explorer ended and Microsoft no longer provides security updates or technical support for these versions."
+        "message": "CSS Flexbox may render differently in Internet Explorer than more recent browsers. Check this page in IE then see the documentation for workarounds if needed."
     }
 }

--- a/packages/hint-ie-flexbox-compat/src/_locales/en/messages.json
+++ b/packages/hint-ie-flexbox-compat/src/_locales/en/messages.json
@@ -1,0 +1,14 @@
+{
+    "description": {
+        "description": "Metadata description",
+        "message": "Informs users that Internet Explorer suffers from Flexbox compatibility bugs."
+    },
+    "name": {
+        "description": "Metadata name",
+        "message": "IE Flexbox Compatibility"
+    },
+    "usingFlexWithIE": {
+        "description": "String warning users that flex is used and IE is a target browser",
+        "message": "TBD"
+    }
+}

--- a/packages/hint-ie-flexbox-compat/src/_locales/en/messages.json
+++ b/packages/hint-ie-flexbox-compat/src/_locales/en/messages.json
@@ -9,6 +9,6 @@
     },
     "usingFlexWithIE": {
         "description": "String warning users that flex is used and IE is a target browser",
-        "message": "TBD"
+        "message": "The Internet Explorer brower versions 11 and older suffer from a number of CSS Flexbox compatibility bugs. The layout on this page may be different between Internet Explorer and other, more recent, browsers. The size or alignment of elements may be incorrect and content may overflow.\nSupport for older versions of Internet Explorer ended and Microsoft no longer provides security updates or technical support for these versions."
     }
 }

--- a/packages/hint-ie-flexbox-compat/src/hint.ts
+++ b/packages/hint-ie-flexbox-compat/src/hint.ts
@@ -1,0 +1,84 @@
+import { Category } from '@hint/utils-types';
+import { HintContext } from 'hint/dist/src/lib/hint-context';
+import { HintScope } from 'hint/dist/src/lib/enums/hint-scope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+import { IHint } from 'hint/dist/src/lib/types';
+import { getFullCSSCodeSnippet, getCSSLocationFromNode } from '@hint/utils-css';
+import { StyleEvents, StyleParse } from '@hint/parser-css';
+import { Severity } from '@hint/utils-types';
+
+import { getMessage } from './i18n.import';
+
+/*
+ * ------------------------------------------------------------------------------
+ * Public
+ * ------------------------------------------------------------------------------
+ */
+
+export default class IEFlexboxCompatHint implements IHint {
+    public static readonly meta: HintMetadata = {
+        docs: {
+            category: Category.compatibility,
+            description: getMessage('description', 'en'),
+            name: getMessage('name', 'en')
+        },
+        /* istanbul ignore next */
+        getDescription(language: string) {
+            return getMessage('description', language);
+        },
+        /* istanbul ignore next */
+        getName(language: string) {
+            return getMessage('name', language);
+        },
+        id: 'ie-flexbox-compat',
+        schema: [],
+        scope: HintScope.any
+    }
+
+    public constructor(context: HintContext<StyleEvents>) {
+        if (!context.targetedBrowsers.some((browser) => {
+            return browser.startsWith('ie ');
+        })) {
+            return;
+        }
+
+        let reported = false;
+
+        context.on('parse::end::css', ({ ast, element, resource }: StyleParse) => {
+            if (reported) {
+                return;
+            }
+
+            ast.walkRules((rule) => {
+                if (reported) {
+                    return;
+                }
+
+                rule.each((declaration) => {
+                    if (reported) {
+                        return;
+                    }
+
+                    if (!('prop' in declaration)) {
+                        return;
+                    }
+
+                    if (declaration.prop !== 'display' || !declaration.value.endsWith('flex')) {
+                        return;
+                    }
+
+                    const codeSnippet = getFullCSSCodeSnippet(declaration);
+                    const message = getMessage('usingFlexWithIE', context.language);
+                    const location = getCSSLocationFromNode(declaration, { isValue: true });
+                    const severity = Severity.warning;
+
+                    context.report(
+                        resource,
+                        message,
+                        { codeLanguage: 'css', codeSnippet, element, location, severity });
+                    reported = true;
+                });
+            });
+        });
+    }
+}

--- a/packages/hint-ie-flexbox-compat/src/hint.ts
+++ b/packages/hint-ie-flexbox-compat/src/hint.ts
@@ -1,12 +1,10 @@
-import { Category } from '@hint/utils-types';
 import { HintContext } from 'hint/dist/src/lib/hint-context';
-import { HintScope } from 'hint/dist/src/lib/enums/hint-scope';
-import { HintMetadata } from 'hint/dist/src/lib/types';
 import { IHint } from 'hint/dist/src/lib/types';
 import { getFullCSSCodeSnippet, getCSSLocationFromNode } from '@hint/utils-css';
 import { StyleEvents, StyleParse } from '@hint/parser-css';
 import { Severity } from '@hint/utils-types';
 
+import meta from './meta';
 import { getMessage } from './i18n.import';
 
 /*
@@ -16,24 +14,7 @@ import { getMessage } from './i18n.import';
  */
 
 export default class IEFlexboxCompatHint implements IHint {
-    public static readonly meta: HintMetadata = {
-        docs: {
-            category: Category.compatibility,
-            description: getMessage('description', 'en'),
-            name: getMessage('name', 'en')
-        },
-        /* istanbul ignore next */
-        getDescription(language: string) {
-            return getMessage('description', language);
-        },
-        /* istanbul ignore next */
-        getName(language: string) {
-            return getMessage('name', language);
-        },
-        id: 'ie-flexbox-compat',
-        schema: [],
-        scope: HintScope.any
-    }
+    public static readonly meta = meta;
 
     public constructor(context: HintContext<StyleEvents>) {
         if (!context.targetedBrowsers.some((browser) => {

--- a/packages/hint-ie-flexbox-compat/src/hint.ts
+++ b/packages/hint-ie-flexbox-compat/src/hint.ts
@@ -1,7 +1,7 @@
 import { HintContext } from 'hint/dist/src/lib/hint-context';
 import { IHint } from 'hint/dist/src/lib/types';
 import { getFullCSSCodeSnippet, getCSSLocationFromNode } from '@hint/utils-css';
-import { StyleEvents, StyleParse } from '@hint/parser-css';
+import { StyleEvents } from '@hint/parser-css';
 import { Severity } from '@hint/utils-types';
 
 import meta from './meta';

--- a/packages/hint-ie-flexbox-compat/src/hint.ts
+++ b/packages/hint-ie-flexbox-compat/src/hint.ts
@@ -25,7 +25,11 @@ export default class IEFlexboxCompatHint implements IHint {
 
         let reported = false;
 
-        context.on('parse::end::css', ({ ast, element, resource }: StyleParse) => {
+        context.on('scan::end', () => {
+            reported = false;
+        });
+
+        context.on('parse::end::css', ({ ast, element, resource }) => {
             if (reported) {
                 return;
             }

--- a/packages/hint-ie-flexbox-compat/src/hint.ts
+++ b/packages/hint-ie-flexbox-compat/src/hint.ts
@@ -37,7 +37,7 @@ export default class IEFlexboxCompatHint implements IHint {
 
     public constructor(context: HintContext<StyleEvents>) {
         if (!context.targetedBrowsers.some((browser) => {
-            return browser.startsWith('ie ');
+            return browser.toLowerCase().startsWith('ie ');
         })) {
             return;
         }

--- a/packages/hint-ie-flexbox-compat/src/meta.ts
+++ b/packages/hint-ie-flexbox-compat/src/meta.ts
@@ -1,0 +1,26 @@
+import { Category } from '@hint/utils-types';
+import { HintScope } from 'hint/dist/src/lib/enums/hint-scope';
+import { HintMetadata } from 'hint/dist/src/lib/types';
+
+import { getMessage } from './i18n.import';
+
+const meta: HintMetadata = {
+    docs: {
+        category: Category.compatibility,
+        description: getMessage('description', 'en'),
+        name: getMessage('name', 'en')
+    },
+    /* istanbul ignore next */
+    getDescription(language: string) {
+        return getMessage('description', language);
+    },
+    /* istanbul ignore next */
+    getName(language: string) {
+        return getMessage('name', language);
+    },
+    id: 'ie-flexbox-compat',
+    schema: [],
+    scope: HintScope.any
+};
+
+export default meta;

--- a/packages/hint-ie-flexbox-compat/tests/fixtures/inline.css
+++ b/packages/hint-ie-flexbox-compat/tests/fixtures/inline.css
@@ -1,0 +1,3 @@
+body {
+    display: inline-flex;
+}

--- a/packages/hint-ie-flexbox-compat/tests/fixtures/keyframe-rule.css
+++ b/packages/hint-ie-flexbox-compat/tests/fixtures/keyframe-rule.css
@@ -1,0 +1,9 @@
+@keyframes anim {
+    from {
+        display: block;
+    }
+
+    to {
+        display: flex;
+    }
+}

--- a/packages/hint-ie-flexbox-compat/tests/fixtures/multiple-displays-in-rule.css
+++ b/packages/hint-ie-flexbox-compat/tests/fixtures/multiple-displays-in-rule.css
@@ -1,0 +1,6 @@
+.rule {
+    display: flex;
+    color: red;
+    display: flex;
+    margin: 0;
+}

--- a/packages/hint-ie-flexbox-compat/tests/fixtures/multiple-displays.css
+++ b/packages/hint-ie-flexbox-compat/tests/fixtures/multiple-displays.css
@@ -1,0 +1,21 @@
+.test {
+    display: block;
+}
+
+.test.foo {
+    display: none;
+}
+
+.fieldset {
+    border: none;
+    margin: 0;
+    padding: 0;
+    display: inline-flex;
+}
+
+.fieldset.bar {
+    border: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+}

--- a/packages/hint-ie-flexbox-compat/tests/fixtures/no-flex.css
+++ b/packages/hint-ie-flexbox-compat/tests/fixtures/no-flex.css
@@ -1,0 +1,14 @@
+.foo {
+    display: block;
+    color: red;
+}
+
+.bar {
+    display: inline-block;
+    color: gold;
+}
+
+.baz {
+    display: table;
+    color: aquamarine;
+}

--- a/packages/hint-ie-flexbox-compat/tests/fixtures/simple.css
+++ b/packages/hint-ie-flexbox-compat/tests/fixtures/simple.css
@@ -1,0 +1,3 @@
+body {
+    display: flex;
+}

--- a/packages/hint-ie-flexbox-compat/tests/tests.ts
+++ b/packages/hint-ie-flexbox-compat/tests/tests.ts
@@ -33,7 +33,7 @@ const serverConfigs = {
     simple: generateConfig('simple')
 };
 
-const message = `The Internet Explorer brower versions 11 and older suffer from a number of CSS Flexbox compatibility bugs. The layout on this page may be different between Internet Explorer and other, more recent, browsers. The size or alignment of elements may be incorrect and content may overflow.\nSupport for older versions of Internet Explorer ended and Microsoft no longer provides security updates or technical support for these versions.`;
+const message = `CSS Flexbox may render differently in Internet Explorer than more recent browsers. Check this page in IE then see the documentation for workarounds if needed.`;
 
 const testsWithIE: HintTest[] = [
     {

--- a/packages/hint-ie-flexbox-compat/tests/tests.ts
+++ b/packages/hint-ie-flexbox-compat/tests/tests.ts
@@ -33,11 +33,13 @@ const serverConfigs = {
     simple: generateConfig('simple')
 };
 
+const message = `The Internet Explorer brower versions 11 and older suffer from a number of CSS Flexbox compatibility bugs. The layout on this page may be different between Internet Explorer and other, more recent, browsers. The size or alignment of elements may be incorrect and content may overflow.\nSupport for older versions of Internet Explorer ended and Microsoft no longer provides security updates or technical support for these versions.`;
+
 const testsWithIE: HintTest[] = [
     {
         name: 'Simple `display:flex;`',
         reports: [{
-            message: `TBD`,
+            message,
             severity: Severity.warning
         }],
         serverConfig: serverConfigs.simple
@@ -45,7 +47,7 @@ const testsWithIE: HintTest[] = [
     {
         name: 'Simple `display:inline-flex;`',
         reports: [{
-            message: `TBD`,
+            message,
             severity: Severity.warning
         }],
         serverConfig: serverConfigs.inline
@@ -53,7 +55,7 @@ const testsWithIE: HintTest[] = [
     {
         name: 'Multiple different display properties',
         reports: [{
-            message: `TBD`,
+            message,
             severity: Severity.warning
         }],
         serverConfig: serverConfigs.multipleDisplays
@@ -61,7 +63,7 @@ const testsWithIE: HintTest[] = [
     {
         name: 'Multiple display properties spread across multiple stylesheets',
         reports: [{
-            message: `TBD`,
+            message,
             severity: Severity.warning
         }],
         serverConfig: serverConfigs.multipleStyleSheets
@@ -69,7 +71,7 @@ const testsWithIE: HintTest[] = [
     {
         name: 'Multiple display flexbox properties in one rule',
         reports: [{
-            message: `TBD`,
+            message,
             severity: Severity.warning
         }],
         serverConfig: serverConfigs.multipleDisplaysInRule
@@ -81,7 +83,7 @@ const testsWithIE: HintTest[] = [
     {
         name: 'Display properties nested in a keyframe rule',
         reports: [{
-            message: `TBD`,
+            message,
             severity: Severity.warning
         }],
         serverConfig: serverConfigs.keyframeRule

--- a/packages/hint-ie-flexbox-compat/tests/tests.ts
+++ b/packages/hint-ie-flexbox-compat/tests/tests.ts
@@ -1,0 +1,111 @@
+import { generateHTMLPage } from '@hint/utils-create-server';
+import { getHintPath, HintTest, testHint } from '@hint/utils-tests-helpers';
+import { readFile } from '@hint/utils-fs';
+import { Severity } from '@hint/utils-types';
+
+const hintPath = getHintPath(__filename);
+
+const generateConfig = (...fileNames: string[]) => {
+    const requests: {[key: string]: any} = {};
+    let html = '';
+
+    for (const fileName of fileNames) {
+        const content = readFile(`${__dirname}/fixtures/${fileName}.css`);
+        const headers = { 'Content-Type': 'text/css' };
+        const path = `/${fileName}.css`;
+
+        requests[path] = { content, headers };
+        html += `<link rel="stylesheet" href="${fileName}.css">`;
+    }
+
+    requests['/'] = generateHTMLPage(html);
+
+    return requests;
+};
+
+const serverConfigs = {
+    inline: generateConfig('inline'),
+    keyframeRule: generateConfig('keyframe-rule'),
+    multipleDisplays: generateConfig('multiple-displays'),
+    multipleDisplaysInRule: generateConfig('multiple-displays-in-rule'),
+    multipleStyleSheets: generateConfig('simple', 'inline', 'multiple-displays'),
+    noFlex: generateConfig('no-flex'),
+    simple: generateConfig('simple')
+};
+
+const testsWithIE: HintTest[] = [
+    {
+        name: 'Simple `display:flex;`',
+        reports: [{
+            message: `TBD`,
+            severity: Severity.warning
+        }],
+        serverConfig: serverConfigs.simple
+    },
+    {
+        name: 'Simple `display:inline-flex;`',
+        reports: [{
+            message: `TBD`,
+            severity: Severity.warning
+        }],
+        serverConfig: serverConfigs.inline
+    },
+    {
+        name: 'Multiple different display properties',
+        reports: [{
+            message: `TBD`,
+            severity: Severity.warning
+        }],
+        serverConfig: serverConfigs.multipleDisplays
+    },
+    {
+        name: 'Multiple display properties spread across multiple stylesheets',
+        reports: [{
+            message: `TBD`,
+            severity: Severity.warning
+        }],
+        serverConfig: serverConfigs.multipleStyleSheets
+    },
+    {
+        name: 'Multiple display flexbox properties in one rule',
+        reports: [{
+            message: `TBD`,
+            severity: Severity.warning
+        }],
+        serverConfig: serverConfigs.multipleDisplaysInRule
+    },
+    {
+        name: 'No flex display',
+        serverConfig: serverConfigs.noFlex
+    },
+    {
+        name: 'Display properties nested in a keyframe rule',
+        reports: [{
+            message: `TBD`,
+            severity: Severity.warning
+        }],
+        serverConfig: serverConfigs.keyframeRule
+    }
+];
+
+const testsWithoutIE: HintTest[] = [
+    {
+        name: 'Simple `display:flex;` without IE',
+        serverConfig: serverConfigs.simple
+    },
+    {
+        name: 'Simple `display:inline-flex;` without IE',
+        serverConfig: serverConfigs.inline
+    },
+    {
+        name: 'Multiple different display properties without IE',
+        serverConfig: serverConfigs.multipleDisplays
+    },
+    {
+        name: 'No flex display without IE',
+        serverConfig: serverConfigs.noFlex
+    }
+];
+
+testHint(hintPath, testsWithIE, { browserslist: ['IE 10', 'Chrome 63'], parsers: ['css'] });
+testHint(hintPath, testsWithoutIE, { browserslist: ['Chrome 87', 'Edge 15'], parsers: ['css'] });

--- a/packages/hint-ie-flexbox-compat/tsconfig.json
+++ b/packages/hint-ie-flexbox-compat/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "outDir": "dist",
+        "strict": true
+    },
+    "exclude": [
+        "dist",
+        "node_modules"
+    ],
+    "extends": "../../tsconfig.json",
+    "include": [
+        "src/**/*.ts",
+        "tests/**/*.ts"
+    ]
+}


### PR DESCRIPTION
This is an attempt to address #4072.

A hint that warns users when they do configure IE as a target browser and flexbox is used in one of the stylesheets.
This is mostly to get the ball rolling and gather feedback.

Let me know what you think.