### PR TITLE
Chore: Remove `moment` as a dependency

### DIFF
--- a/packages/formatter-html/package.json
+++ b/packages/formatter-html/package.json
@@ -16,13 +16,11 @@
     "@hint/utils-types": "^1.1.0",
     "ejs": "^3.1.5",
     "fs-extra": "^9.0.1",
-    "lodash": "^4.17.20",
-    "moment": "^2.28.0"
+    "lodash": "^4.17.20"
   },
   "devDependencies": {
     "@types/ejs": "^3.0.4",
     "@types/fs-extra": "^9.0.1",
-    "@types/moment": "^2.13.0",
     "@types/node": "^14.11.2",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^9.0.5",

--- a/packages/formatter-html/src/result.ts
+++ b/packages/formatter-html/src/result.ts
@@ -1,7 +1,5 @@
 import * as path from 'path';
 
-import * as moment from 'moment';
-
 import cloneDeep = require('lodash/cloneDeep');
 
 import { Category, Problem, Severity } from '@hint/utils-types';
@@ -250,15 +248,18 @@ export default class AnalysisResult {
      * @param scanTime Time in milliseconds.
      */
     private parseScanTime(scanTime: number): string {
-        const duration = moment.duration(scanTime);
-        const minutes = this.pad(`${duration.get('minutes')}`);
-        const seconds = this.pad(`${duration.get('seconds')}`);
-        let time = `${minutes}:${seconds}`;
+        const seconds = Math.floor((scanTime / 1000) % 60);
+        const minutes = Math.floor((scanTime / 1000 / 60) % 60);
+        const hours = Math.floor((scanTime / 1000 / 3600));
 
-        if (duration.get('hours') > 0) {
-            const hours = this.pad(`${duration.get('hours')}`);
+        const minutesDisplay = this.pad(`${minutes}`);
+        const secondsDisplay = this.pad(`${seconds}`);
+        let time = `${minutesDisplay}:${secondsDisplay}`;
 
-            time = `${hours}:${time}`;
+        if (hours > 0) {
+            const hoursDisplay = this.pad(`${hours}`);
+
+            time = `${hoursDisplay}:${time}`;
         }
 
         return time;

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,13 +703,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/moment@^2.13.0":
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/@types/moment/-/moment-2.13.0.tgz#604ebd189bc3bc34a1548689404e61a2a4aac896"
-  integrity sha1-YE69GJvDvDShVIaJQE5hoqSqyJY=
-  dependencies:
-    moment "*"
-
 "@types/node@*", "@types/node@>= 8", "@types/node@^14.0.1", "@types/node@^14.11.2":
   version "14.11.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.2.tgz#2de1ed6670439387da1c9f549a2ade2b0a799256"
@@ -7523,7 +7516,7 @@ module-not-found-error@^1.0.1:
   resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
   integrity sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=
 
-moment@*, moment@^2.19.3, moment@^2.28.0:
+moment@^2.19.3, moment@^2.28.0:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.28.0.tgz#cdfe73ce01327cee6537b0fafac2e0f21a237d75"
   integrity sha512-Z5KOjYmnHyd/ukynmFd/WwyXHd7L4J9vTI/nn5Ap9AVUgaAE15VvQ9MOGmJJygEUklupqIrFnor/tjTwRU+tQw==


### PR DESCRIPTION
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #4044

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
This removes `moment` as a dependency. It's tempting to replace it with another time/date library, however the only function `moment` was used in is simple enough that I don't believe it justifies pulling in another dependency!