### PR TITLE
Chore: Connector puppeteer use lock only in detached mode

### DIFF
--- a/packages/connector-puppeteer/src/lib/lifecycle.ts
+++ b/packages/connector-puppeteer/src/lib/lifecycle.ts
@@ -196,6 +196,9 @@ export const launch = async (options: LifecycleLaunchOptions) => {
      * Only try to connect to an existing browser when in detached mode,
      * otherwise the browser will be closed when one of the puppeteer
      * instances finishes.
+     *
+     * This is used mostly by the test runner, because if a new browser
+     * is open for each test, the machine can run out of resources.
      */
     /* istanbul ignore else */
     if (options.detached) {
@@ -221,6 +224,11 @@ export const launch = async (options: LifecycleLaunchOptions) => {
     const connection = await startBrowser(options);
     const { browser } = connection;
 
+    /**
+     * In detach mode, we need to store the browser information so
+     * the next call will rehuse the same browser, instead of opening
+     * a new instance.
+     */
     if (options.detached) {
         try {
             await writeBrowserInfo(browser);


### PR DESCRIPTION
Fix #4089

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

Detach mode is used mostly for the test runner, to avoid opening multiple instances of the browser. To do so, it store in disk the browser information of the first instance opened, so the next calls can reuse that information.

Before this PR, the writing/reading of the disk were done even if it wasn't running in detach mode.

This PR disables the writings to disk if we are not in detach mode. This will save some time accessing to disk, but more important, it will solve a problem running `connector-puppeteer` in Azure Functions Consumption plan.

Azure Function Consumption plan doesn't allow writing in the disk, except for the tmp folder, so this change is needed if we want to complete https://github.com/webhintio/serverless-online-service/issues/143

