### PR TITLE
Docs: Fix broken table rows and related lint rule

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,6 +1,7 @@
 {
     "MD013": {
-        "code_blocks": false
+        "code_blocks": false,
+        "tables": false
     },
     "MD014": false,
     "MD026": {

--- a/packages/hint/docs/user-guide/concepts/hints.md
+++ b/packages/hint/docs/user-guide/concepts/hints.md
@@ -80,20 +80,11 @@ allowed `severity` ratings.
 
 | `Severity` value | Details |
 |:--- |:--- |
-| `off` | The `hint` is not run. The same as deleting the `hint` from the
-`.hintrc`. |
-| `error` | If the `hint` finds a major issue that affects one or more
-targeted browsers. The specified content is broken and you should fix
-immediately. |
-| `warning` | If the `hint` finds an issue. The specified content is a problem
-that you should investigate and fix. The issue may not cause problems in
-practice. |
-| `hint` | If the `hint` finds a minor issue, such as something to fix. The
-specified content should be tracked and may cause problems in the future. The
-issue does not cause problems, but may become a `warning` in the future. |
-| `information` | The `hint` provides information. The specified content is
-highlighted since it is relevant to you.  The information may help identify
-parts of a feature or provide instances of a feature for tracking. |
+| `off` | The `hint` is not run. The same as deleting the `hint` from the `.hintrc`. |
+| `error` | If the `hint` finds a major issue that affects one or more targeted browsers. The specified content is broken and you should fix immediately. |
+| `warning` | If the `hint` finds an issue. The specified content is a problem that you should investigate and fix. The issue may not cause problems in practice. |
+| `hint` | If the `hint` finds a minor issue, such as something to fix. The specified content should be tracked and may cause problems in the future. The issue does not cause problems, but may become a `warning` in the future. |
+| `information` | The `hint` provides information. The specified content is highlighted since it is relevant to you.  The information may help identify parts of a feature or provide instances of a feature for tracking. |
 
 You may configure hints using either the array or object syntax.
 

--- a/packages/hint/docs/user-guide/configuring-webhint/summary.md
+++ b/packages/hint/docs/user-guide/configuring-webhint/summary.md
@@ -21,11 +21,8 @@ hint configuration properties, which are defined in the following table.
 |:--- |:--- |
 | `connector` | How to access the resources. |
 | `formatters` | How to output the results. Multiple instances may exist. |
-| `parsers` | How to handle special files such as stylesheets, JavaScript,
-manifest, and so on.  Multiple instances may exist. |
-| `hints` | What to test for and the
-[severity][UserGuideConceptsHintsHintConfiguration] it should have. Multiple
-instances may exist. |
+| `parsers` | How to handle special files such as stylesheets, JavaScript, manifest, and so on.  Multiple instances may exist. |
+| `hints` | What to test for and the [severity][UserGuideConceptsHintsHintConfiguration] it should have. Multiple instances may exist. |
 
 For additional information about `severity` and hint configurations, go to
 [Hint configuration[UserGuideConceptsHintsHintConfiguration].


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] N/A ~Added/Updated related documentation.~
- [ ] N/A ~Added/Updated related tests.~

## Short description of the change(s)

`markdownlint` is configured to break lines that are too long. This includes table rows, which causes the content after the line-break to start a new table row.

This PR enables the `markdownlint` configuration flag to ignore line-length for table rows.

----

### Live site

![image](https://user-images.githubusercontent.com/2304337/103169172-661bc900-4807-11eb-99ef-a53e4c98b36d.png)

----

### Before

![image](https://user-images.githubusercontent.com/2304337/103169057-a3cc2200-4806-11eb-9549-222cacaffa33.png)

----

### After

![image](https://user-images.githubusercontent.com/2304337/103169064-b5adc500-4806-11eb-93bf-e66a6b7e6133.png)


<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
