### PR TITLE
Fix: Avoid false-positives on localhost

### DIFF
--- a/packages/hint-http-cache/src/meta.ts
+++ b/packages/hint-http-cache/src/meta.ts
@@ -1,3 +1,4 @@
+import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
 import { Category } from '@hint/utils-types';
 import { HintScope } from 'hint/dist/src/lib/enums/hint-scope';
 import { HintMetadata } from 'hint/dist/src/lib/types';
@@ -19,6 +20,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'http-cache',
+    ignoredUrls: [rxLocalhost],
     schema: [{
         additionalProperties: false,
         definitions: {

--- a/packages/hint-http-compression/src/meta.ts
+++ b/packages/hint-http-compression/src/meta.ts
@@ -1,3 +1,4 @@
+import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
 import { Category } from '@hint/utils-types';
 import { HintMetadata, HintScope } from 'hint';
 
@@ -18,6 +19,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'http-compression',
+    ignoredUrls: [rxLocalhost],
     schema: [{
         additionalProperties: false,
         definitions: {

--- a/packages/hint-https-only/src/meta.ts
+++ b/packages/hint-https-only/src/meta.ts
@@ -1,3 +1,4 @@
+import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
 import { Category } from '@hint/utils-types';
 import { HintMetadata, HintScope } from 'hint';
 
@@ -18,6 +19,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'https-only',
+    ignoredUrls: [rxLocalhost],
     schema: [],
     scope: HintScope.site
 };

--- a/packages/hint-minified-js/package.json
+++ b/packages/hint-minified-js/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@hint/utils-debug": "^1.0.3",
     "@hint/utils-i18n": "^1.0.6",
+    "@hint/utils-network": "^1.0.7",
     "@hint/utils-types": "^1.1.1"
   },
   "description": "hint that that checks if the JavaScript used by the web page is minified",

--- a/packages/hint-minified-js/src/meta.ts
+++ b/packages/hint-minified-js/src/meta.ts
@@ -1,3 +1,4 @@
+import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
 import { Category } from '@hint/utils-types';
 import { HintScope } from 'hint/dist/src/lib/enums/hint-scope';
 import { HintMetadata } from 'hint/dist/src/lib/types';
@@ -19,6 +20,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'minified-js',
+    ignoredUrls: [rxLocalhost],
     schema: [{
         additionalProperties: false,
         properties: { threshold: { type: 'number' } }

--- a/packages/hint-minified-js/tests/tests.ts
+++ b/packages/hint-minified-js/tests/tests.ts
@@ -72,3 +72,11 @@ testHint(hintPath, tests, { parsers: ['javascript'] });
  * we calculate will be always less than 100
  */
 testHint(hintPath, testsWithHighThreshold, { hintOptions: { threshold: 100 }, parsers: ['javascript'] });
+
+// Verify the rule ignores localhost URLs by default
+testHint(hintPath, [
+    {
+        name: 'Unminified content on localhost should pass by default',
+        serverConfig: generateHTMLPage(generateScriptTag(unminifiedJS))
+    }
+], { ignoredUrls: [], parsers: ['javascript'] });

--- a/packages/hint-no-disallowed-headers/src/meta.ts
+++ b/packages/hint-no-disallowed-headers/src/meta.ts
@@ -1,3 +1,4 @@
+import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
 import { Category } from '@hint/utils-types';
 import { HintScope } from 'hint/dist/src/lib/enums/hint-scope';
 import { HintMetadata } from 'hint/dist/src/lib/types';
@@ -19,6 +20,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'no-disallowed-headers',
+    ignoredUrls: [rxLocalhost],
     schema: [{
         additionalProperties: false,
         definitions: {

--- a/packages/hint-performance-budget/src/meta.ts
+++ b/packages/hint-performance-budget/src/meta.ts
@@ -1,3 +1,4 @@
+import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
 import { Category } from '@hint/utils-types';
 import { HintMetadata, HintScope } from 'hint';
 
@@ -19,6 +20,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'performance-budget',
+    ignoredUrls: [rxLocalhost],
     schema: [{
         additionalProperties: false,
         properties: {

--- a/packages/hint-sri/src/meta.ts
+++ b/packages/hint-sri/src/meta.ts
@@ -1,3 +1,4 @@
+import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
 import { Category } from '@hint/utils-types';
 import { HintScope } from 'hint/dist/src/lib/enums/hint-scope';
 import { HintMetadata } from 'hint/dist/src/lib/types';
@@ -20,6 +21,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'sri',
+    ignoredUrls: [rxLocalhost],
     schema: [{
         additionalProperties: false,
         properties: {

--- a/packages/hint-ssllabs/package.json
+++ b/packages/hint-ssllabs/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@hint/utils-debug": "^1.0.3",
     "@hint/utils-i18n": "^1.0.6",
+    "@hint/utils-network": "^1.0.7",
     "@hint/utils-types": "^1.1.1",
     "node-ssllabs": "^2.1.0"
   },

--- a/packages/hint-ssllabs/src/meta.ts
+++ b/packages/hint-ssllabs/src/meta.ts
@@ -1,3 +1,4 @@
+import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
 import { Category } from '@hint/utils-types';
 import { HintMetadata, HintScope } from 'hint';
 
@@ -18,6 +19,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'ssllabs',
+    ignoredUrls: [rxLocalhost],
     schema: [{
         additionalProperties: false,
         properties: {

--- a/packages/hint-strict-transport-security/src/meta.ts
+++ b/packages/hint-strict-transport-security/src/meta.ts
@@ -1,3 +1,4 @@
+import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
 import { Category } from '@hint/utils-types';
 import { HintMetadata, HintScope } from 'hint';
 
@@ -18,6 +19,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'strict-transport-security',
+    ignoredUrls: [rxLocalhost],
     schema: [{
         properties: {
             checkPreload: { type: 'boolean' },

--- a/packages/hint-x-content-type-options/src/meta.ts
+++ b/packages/hint-x-content-type-options/src/meta.ts
@@ -1,3 +1,4 @@
+import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
 import { Category } from '@hint/utils-types';
 import { HintScope } from 'hint/dist/src/lib/enums/hint-scope';
 import { HintMetadata } from 'hint/dist/src/lib/types';
@@ -19,6 +20,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'x-content-type-options',
+    ignoredUrls: [rxLocalhost],
     schema: [],
     scope: HintScope.site
 };

--- a/packages/hint/docs/user-guide/configuring-webhint/ignoring-domains.md
+++ b/packages/hint/docs/user-guide/configuring-webhint/ignoring-domains.md
@@ -38,3 +38,8 @@ In the previous example we will:
 * Ignore all hints for any resource that matches the regex
   `.*\\.domain1\\.com/.*`.
 * Ignore the hint `disallowed-headers` for the domain `www.domain2.net`.
+
+Some hints also have a default ignore list to avoid false positives in
+certain contexts (e.g. cache headers when developing on localhost).
+These default values can be overriden by specifying your own ignore
+list for those specific hints.

--- a/packages/hint/src/lib/engine.ts
+++ b/packages/hint/src/lib/engine.ts
@@ -187,6 +187,11 @@ export class Engine<E extends Events = Events> extends EventEmitter {
             debug('Loading hints');
             const id = Hint.meta.id;
 
+            // Use default ignored URLs if no overrides are specified for this hint.
+            if (Hint.meta.ignoredUrls && !this.ignoredUrls.has(id)) {
+                this.ignoredUrls.set(id, Hint.meta.ignoredUrls);
+            }
+
             const ignoreHint = (HintCtor: IHintConstructor): boolean => {
                 const ignoredConnectors: string[] = HintCtor.meta.ignoredConnectors || [];
 

--- a/packages/hint/src/lib/types/hint-meta.ts
+++ b/packages/hint/src/lib/types/hint-meta.ts
@@ -18,6 +18,8 @@ export type HintMetadata = {
     id: string;
     /** List of connectors that should not run the hint */
     ignoredConnectors?: string[];
+    /** List of patterns matching URLs to be ignored by this hint by default */
+    ignoredUrls?: RegExp[];
     /** The schema the hint configuration must follow in order to be valid */
     schema: any[]; // TODO: this shouldn't be an Array of any
     /** The scope of the hints (local, site, any) */

--- a/packages/utils-network/README.md
+++ b/packages/utils-network/README.md
@@ -33,3 +33,4 @@ is http/https if specified.
 and lowercase it.
 * `requestAsync`: Convenience wrapper for asynchronously request an URL.
 * `requestJSONAsync`: Request response in the json format from an endpoint.
+* `rxLocalhost`: RegExp to test if a resource points to localhost.

--- a/packages/utils-network/src/index.ts
+++ b/packages/utils-network/src/index.ts
@@ -11,4 +11,5 @@ export * from './is-regular-protocol';
 export * from './normalize-header-value';
 export * from './request-async';
 export * from './request-json-async';
+export * from './rx-localhost';
 export * from './capitalize-header-name';

--- a/packages/utils-network/src/rx-localhost.ts
+++ b/packages/utils-network/src/rx-localhost.ts
@@ -1,0 +1,5 @@
+/**
+ * RegExp to test if a resource points to the local host.
+ * Identifies both localhost and 127.0.0.1 URLs.
+ */
+export const rxLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)[:/]/;

--- a/packages/utils-network/tests/rx-localhost.ts
+++ b/packages/utils-network/tests/rx-localhost.ts
@@ -1,0 +1,31 @@
+import test from 'ava';
+
+import { rxLocalhost } from '../src';
+
+test('isLocalhost detects localhost URLs', (t) => {
+    t.true(rxLocalhost.test('http://localhost/foo/bar'));
+});
+
+test('isLocalhost ignores public URLs', (t) => {
+    t.false(rxLocalhost.test('http://bing.com/foo/bar'));
+});
+
+test('isLocalhost ignores localhost sub-domains', (t) => {
+    t.false(rxLocalhost.test('http://localhost.foo.com/foo/bar'));
+});
+
+test('isLocalhost detects loopback URLs', (t) => {
+    t.true(rxLocalhost.test('http://127.0.0.1/foo/bar'));
+});
+
+test('isLocalhost ignores other IP-based URLs', (t) => {
+    t.false(rxLocalhost.test('http://198.0.0.1/foo/bar'));
+});
+
+test('isLocalhost detects HTTPS localhost URLs', (t) => {
+    t.true(rxLocalhost.test('https://localhost/foo/bar'));
+});
+
+test('isLocalhost detects localhost URLs with port', (t) => {
+    t.true(rxLocalhost.test('http://localhost:8080/foo/bar'));
+});

--- a/packages/utils-tests-helpers/src/hint-runner.ts
+++ b/packages/utils-tests-helpers/src/hint-runner.ts
@@ -121,6 +121,7 @@ const createConfig = (id: string, connector: string, opts?: any): Configuration 
     // Allow all URLs in tests (to avoid localhost being ignored).
     if (!opts.ignoredUrls) {
         const meta = require(id).default.meta;
+
         opts.ignoredUrls = [{ domain: '.^', hints: [meta.id] }];
     }
 

--- a/packages/utils-tests-helpers/src/hint-runner.ts
+++ b/packages/utils-tests-helpers/src/hint-runner.ts
@@ -118,6 +118,12 @@ const createConfig = (id: string, connector: string, opts?: any): Configuration 
         hints[id] = 'default';
     }
 
+    // Allow all URLs in tests (to avoid localhost being ignored).
+    if (!opts.ignoredUrls) {
+        const meta = require(id).default.meta;
+        opts.ignoredUrls = [{ domain: '.^', hints: [meta.id] }];
+    }
+
     const config = {
         browserslist: opts && opts.browserslist || [],
         connector: {

--- a/packages/utils-worker/tests/helpers/runner.ts
+++ b/packages/utils-worker/tests/helpers/runner.ts
@@ -15,6 +15,8 @@ declare const __webhint: {
 
 const runWorker = async (page: Page, config: Partial<Config>, test: Test) => {
     return await page.evaluate((config: Partial<Config>, test: Test) => {
+        const testUrl = 'https://example.com/';
+
         const getResourceContentType = (type: string) => {
             switch (type) {
                 case 'css':
@@ -31,9 +33,9 @@ const runWorker = async (page: Page, config: Partial<Config>, test: Test) => {
                 element: null,
                 request: {
                     headers: {},
-                    url: location.href
+                    url: testUrl
                 },
-                resource: location.href,
+                resource: testUrl,
                 response: {
                     body: {
                         content: test.html,
@@ -48,7 +50,7 @@ const runWorker = async (page: Page, config: Partial<Config>, test: Test) => {
                     hops: [],
                     mediaType: '',
                     statusCode: 200,
-                    url: location.href
+                    url: testUrl
                 }
             };
         };
@@ -58,9 +60,9 @@ const runWorker = async (page: Page, config: Partial<Config>, test: Test) => {
                 element: null,
                 request: {
                     headers: {},
-                    url: location.href
+                    url: testUrl
                 },
-                resource: location.href,
+                resource: testUrl,
                 response: {
                     body: {
                         content: resource.content,
@@ -75,7 +77,7 @@ const runWorker = async (page: Page, config: Partial<Config>, test: Test) => {
                     hops: [],
                     mediaType: '',
                     statusCode: 200,
-                    url: location.href
+                    url: testUrl
                 }
             };
         };
@@ -101,13 +103,13 @@ const runWorker = async (page: Page, config: Partial<Config>, test: Test) => {
                 if (message.requestConfig) {
                     sendMessage({
                         config: {
-                            resource: location.href,
+                            resource: testUrl,
                             ...config
                         }
                     });
                 } else if (message.ready) {
                     startTime = performance.now();
-                    sendMessage({ fetchStart: { resource: location.href } });
+                    sendMessage({ fetchStart: { resource: testUrl } });
                     sendMessage({ fetchEnd: mockFetchEnd() });
                     if (test.resources && test.resources.length > 0) {
                         for (const resource of test.resources) {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Extends the metadata available to hints to include an `ignoredUrls` field, allowing a set
of default ignored URLs to be specified for a given hint. This default value is ignored
whenever any explicit `ignoredUrls` are specified for that hint in `.hintrc`.

Updates a collection of hints (largely related to HTTP headers) to ignore localhost and
127.0.0.1 URLs by default to avoid false-positives during local development.

Fix #4229