### PR TITLE
Fix: Support for URI reserved characters in paths

### DIFF
--- a/packages/connector-local/src/connector.ts
+++ b/packages/connector-local/src/connector.ts
@@ -353,7 +353,7 @@ export default class LocalConnector implements IConnector {
          * and then get the path string.
          */
         const uri = getAsUri(target);
-        const filePath: string = uri ? asPathString(uri).replace('%20', ' ') : '';
+        const filePath: string = uri ? asPathString(uri) : '';
         const rawContent: Buffer = options && options.content ? Buffer.from(options.content) : await readFileAsBuffer(filePath);
         const contentType = await getContentTypeData(null as any, filePath, null, rawContent);
         let content = '';
@@ -395,7 +395,7 @@ export default class LocalConnector implements IConnector {
 
         this.engine.emitAsync('scan::start', initialEvent);
 
-        const pathString = asPathString(target).replace('%20', ' ');
+        const pathString = asPathString(target);
         let files: string[];
 
         if (isFile(pathString)) {

--- a/packages/connector-local/tests/fixtures/folder with spaces and [brackets]/script with spaces and [brackets].js
+++ b/packages/connector-local/tests/fixtures/folder with spaces and [brackets]/script with spaces and [brackets].js
@@ -1,0 +1,5 @@
+module.exports = {
+    hello() {
+        return 'hello world';
+    }
+};

--- a/packages/connector-local/tests/tests.ts
+++ b/packages/connector-local/tests/tests.ts
@@ -80,7 +80,7 @@ test.afterEach.always((t) => {
     t.context.sandbox.restore();
 });
 
-test(`it should now throw if target path has spaces and [brackets]`, async (t) => {
+test(`it should not throw if target path has spaces and [brackets]`, async (t) => {
     const fileUri = getAsUri(path.join(__dirname, 'fixtures', 'folder with spaces and [brackets]', 'script with spaces and [brackets].js'));
     const { engine, isFileStub, LocalConnector } = mockContext(t.context);
 

--- a/packages/connector-local/tests/tests.ts
+++ b/packages/connector-local/tests/tests.ts
@@ -80,6 +80,19 @@ test.afterEach.always((t) => {
     t.context.sandbox.restore();
 });
 
+test(`it should now throw if target path has spaces and [brackets]`, async (t) => {
+    const fileUri = getAsUri(path.join(__dirname, 'fixtures', 'folder with spaces and [brackets]', 'script with spaces and [brackets].js'));
+    const { engine, isFileStub, LocalConnector } = mockContext(t.context);
+
+    isFileStub.returns(true);
+
+    const connector = new LocalConnector(engine as any, {});
+
+    if (fileUri) {
+        await t.notThrowsAsync(connector.collect(fileUri), 'connector does not throw');
+    }
+});
+
 test(`If target is a file, it should emit 'fetch::start::target' event`, async (t) => {
     const sandbox = t.context.sandbox;
     const fileUri = getAsUri(path.join(__dirname, 'fixtures', 'no-watch', 'script.js'));

--- a/packages/utils-network/src/as-path-string.ts
+++ b/packages/utils-network/src/as-path-string.ts
@@ -4,8 +4,9 @@ import { URL } from 'url';
 /**
  * Returns the pathname of a URL, normalizing depending on the platform. E.g.:
  *
- * * `file:///c:/projects/` --> `c:/projects/`
- * * `file:///mnt/projects/` --> `/mnt/projects/`
+ * * `file:///c:/projects/`       --> `c:/projects/`
+ * * `file:///c:/program%20files/ --> `c:/program files/`
+ * * `file:///mnt/projects/`      --> `/mnt/projects/`
  */
 export const asPathString = (uri: URL) => {
 
@@ -17,5 +18,5 @@ export const asPathString = (uri: URL) => {
         uri.pathname.substr(1) :
         uri.pathname;
 
-    return pathname;
+    return decodeURI(pathname);
 };

--- a/packages/utils-network/tests/as-path-string.ts
+++ b/packages/utils-network/tests/as-path-string.ts
@@ -13,6 +13,22 @@ test('asPathString returns the path name of an "http://" URL', (t) => {
     t.is(actual, expected, `asPathString doesn't return the path name of an http:// URL`);
 });
 
+test('asPathString returns the encoded path name of an "https://" URL', (t) => {
+    const url = new URL('https://myresource.com/my/path/%5B-dont-%20-decode-%5D');
+    const expected = '/my/path/%5B-dont-%20-decode-%5D';
+    const actual = asPathString(url);
+
+    t.is(actual, expected, `asPathString doesn't return the encoded path name of an https:// URL`);
+});
+
+test('asPathString returns the decoded path name of an "file:///" URL', (t) => {
+    const url = new URL('file:///my/path/%5Bdecode%20me%5D');
+    const expected = '/my/path/[decode me]';
+    const actual = asPathString(url);
+
+    t.is(actual, expected, `asPathString doesn't return the decoded path name of an file:/// URL`);
+});
+
 test('asPathString returns the path name of of a file:// URL', (t) => {
     const expected = platform() === 'win32' ?
         'c:/my/path' :

--- a/packages/utils-network/tests/as-path-string.ts
+++ b/packages/utils-network/tests/as-path-string.ts
@@ -21,12 +21,18 @@ test('asPathString returns the encoded path name of an "https://" URL', (t) => {
     t.is(actual, expected, `asPathString doesn't return the encoded path name of an https:// URL`);
 });
 
-test('asPathString returns the decoded path name of an "file:///" URL', (t) => {
-    const url = new URL('file:///my/path/%5Bdecode%20me%5D');
-    const expected = '/my/path/[decode me]';
+test('asPathString returns the decoded path name of an "file://" URL', (t) => {
+    const url = platform() === 'win32' ?
+        new URL(`file://c:/my/path/%5Bdecode%20me%5D`) :
+        new URL(`file:///my/path/%5Bdecode%20me%5D`);
+
+    const expected = platform() === 'win32' ?
+        'c:/my/path/[decode me]' :
+        '/my/path/[decode me]';
+
     const actual = asPathString(url);
 
-    t.is(actual, expected, `asPathString doesn't return the decoded path name of an file:/// URL`);
+    t.is(actual, expected, `asPathString doesn't return the decoded path name of a file:// URL`);
 });
 
 test('asPathString returns the path name of of a file:// URL', (t) => {


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

### Problem
Local connector normalizes paths by converting all paths to URIs
with file protocol which encodes URI reserved characters
(e.g. " space " and [brackets]). This is done with `encodeURI` in
[`file-url`][1] called on packages/utils-network/src/as-uri.ts:49.

The encoded URI pathnames are then passed to the OS and not found:
file:///mnt/[id]/script.js -> (`encodeURI`)
             -> file:///mnt/%5Bid%5D/script.js -> /mnt/%5Bid%5D/script.js

 ### Solution
Decode file protocol pathnames:
/mnt/%5Bid%5D/script.js -> (`decodeURI`) -> /mnt/[id]/script.js

This is the same problem as #3401 which solved the problem of %20 with
string replace in #3409, because `decodeURI` handles all URI encodings
I reverted those lines.

This fix has been tested against:
- https://github.com/vercel/next.js/tree/e28fd50441cfaa22554db2b8e5bb7d03061e67d4/examples/dynamic-routing
- https://github.com/jamesgecko/webhint-space-error/tree/5cb0727264cf8e589bea32e1cf0eefc5a79a8cfe/src

[1]: https://github.com/sindresorhus/file-url/blob/68a06434424e65edf754ea759c24b6a5c05042b5/index.js#L29

Partial revert of #3409
Fix #4201, #3401
