### PR TITLE
[Docs] Adds clarification in user-guide documentation

### DIFF
--- a/packages/hint/docs/user-guide/index.md
+++ b/packages/hint/docs/user-guide/index.md
@@ -28,7 +28,9 @@ best practices that may be applied to your site, complete the following steps.
    ```bash
    npx hint https://example.com
    ```
+   
    or
+   
    ```bash
    npx hint ./path/to/my.html
    ```

--- a/packages/hint/docs/user-guide/index.md
+++ b/packages/hint/docs/user-guide/index.md
@@ -26,7 +26,7 @@ best practices that may be applied to your site, complete the following steps.
    uses `npx` to run the `npm` package without installing it.
 
    ```bash
-   npx hint https://example.com // or path e.g. './path/to/my.html'
+   npx hint https://example.com // or relative path e.g. './path/to/my.html'
    ```
 
 1. After the `webhint` process completes, a summary is presented in the bash

--- a/packages/hint/docs/user-guide/index.md
+++ b/packages/hint/docs/user-guide/index.md
@@ -26,7 +26,7 @@ best practices that may be applied to your site, complete the following steps.
    uses `npx` to run the `npm` package without installing it.
 
    ```bash
-   npx hint https://example.com
+   npx hint https://example.com // or path e.g. './path/to/my.html'
    ```
 
 1. After the `webhint` process completes, a summary is presented in the bash

--- a/packages/hint/docs/user-guide/index.md
+++ b/packages/hint/docs/user-guide/index.md
@@ -26,7 +26,11 @@ best practices that may be applied to your site, complete the following steps.
    uses `npx` to run the `npm` package without installing it.
 
    ```bash
-   npx hint https://example.com // or relative path e.g. './path/to/my.html'
+   npx hint https://example.com
+   ```
+   or
+   ```bash
+   npx hint ./path/to/my.html
    ```
 
 1. After the `webhint` process completes, a summary is presented in the bash

--- a/packages/hint/docs/user-guide/index.md
+++ b/packages/hint/docs/user-guide/index.md
@@ -28,9 +28,9 @@ best practices that may be applied to your site, complete the following steps.
    ```bash
    npx hint https://example.com
    ```
-   
+
    or
-   
+
    ```bash
    npx hint ./path/to/my.html
    ```


### PR DESCRIPTION
it is not clear or documented anywhere that a local file path is an option as argument to the path parameter.
cli _help_ scheme, as well, implies the last argument to be a url (`hint [options] https://url.com`).
as only starting to use webhint cli I had this only clarified in a response in the gitter channel

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
