### PR TITLE
Chore: Add no-inline-styles hint to default configurations

### DIFF
--- a/packages/configuration-development/index.json
+++ b/packages/configuration-development/index.json
@@ -22,6 +22,7 @@
         "meta-charset-utf-8",
         "meta-viewport",
         "no-bom",
+        "no-inline-styles",
         "no-protocol-relative-urls",
         "scoped-svg-styles",
         "sri",

--- a/packages/configuration-development/package.json
+++ b/packages/configuration-development/package.json
@@ -17,6 +17,7 @@
     "@hint/hint-meta-charset-utf-8": "^4.0.3",
     "@hint/hint-meta-viewport": "^5.0.3",
     "@hint/hint-no-bom": "^4.2.7",
+    "@hint/hint-no-inline-styles": "^1.0.0",
     "@hint/hint-no-protocol-relative-urls": "^3.0.3",
     "@hint/hint-scoped-svg-styles": "^1.3.7",
     "@hint/hint-sri": "^4.0.3",

--- a/packages/configuration-development/package.json
+++ b/packages/configuration-development/package.json
@@ -17,7 +17,7 @@
     "@hint/hint-meta-charset-utf-8": "^4.0.3",
     "@hint/hint-meta-viewport": "^5.0.3",
     "@hint/hint-no-bom": "^4.2.7",
-    "@hint/hint-no-inline-styles": "^1.0.0",
+    "@hint/hint-no-inline-styles": "^0.0.1",
     "@hint/hint-no-protocol-relative-urls": "^3.0.3",
     "@hint/hint-scoped-svg-styles": "^1.3.7",
     "@hint/hint-sri": "^4.0.3",

--- a/packages/configuration-web-recommended/index.json
+++ b/packages/configuration-web-recommended/index.json
@@ -29,6 +29,7 @@
         "no-friendly-error-pages",
         "no-html-only-headers",
         "no-http-redirects",
+        "no-inline-styles",
         "no-protocol-relative-urls",
         "no-vulnerable-javascript-libraries",
         "scoped-svg-styles",

--- a/packages/configuration-web-recommended/package.json
+++ b/packages/configuration-web-recommended/package.json
@@ -27,6 +27,7 @@
     "@hint/hint-no-friendly-error-pages": "^3.3.7",
     "@hint/hint-no-html-only-headers": "^3.0.3",
     "@hint/hint-no-http-redirects": "^3.0.3",
+    "@hint/hint-no-inline-styles": "^1.0.0",
     "@hint/hint-no-protocol-relative-urls": "^3.0.3",
     "@hint/hint-no-vulnerable-javascript-libraries": "^2.12.1",
     "@hint/hint-scoped-svg-styles": "^1.3.7",

--- a/packages/configuration-web-recommended/package.json
+++ b/packages/configuration-web-recommended/package.json
@@ -27,7 +27,7 @@
     "@hint/hint-no-friendly-error-pages": "^3.3.7",
     "@hint/hint-no-html-only-headers": "^3.0.3",
     "@hint/hint-no-http-redirects": "^3.0.3",
-    "@hint/hint-no-inline-styles": "^1.0.0",
+    "@hint/hint-no-inline-styles": "^0.0.1",
     "@hint/hint-no-protocol-relative-urls": "^3.0.3",
     "@hint/hint-no-vulnerable-javascript-libraries": "^2.12.1",
     "@hint/hint-scoped-svg-styles": "^1.3.7",

--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -31,7 +31,7 @@
     "@hint/hint-no-disallowed-headers": "^3.1.2",
     "@hint/hint-no-html-only-headers": "^3.0.3",
     "@hint/hint-no-http-redirects": "^3.0.3",
-    "@hint/hint-no-inline-styles": "^1.0.0",
+    "@hint/hint-no-inline-styles": "^0.0.1",
     "@hint/hint-no-protocol-relative-urls": "^3.0.3",
     "@hint/hint-no-vulnerable-javascript-libraries": "^2.12.1",
     "@hint/hint-scoped-svg-styles": "^1.3.7",

--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -31,6 +31,7 @@
     "@hint/hint-no-disallowed-headers": "^3.1.2",
     "@hint/hint-no-html-only-headers": "^3.0.3",
     "@hint/hint-no-http-redirects": "^3.0.3",
+    "@hint/hint-no-inline-styles": "^1.0.0",
     "@hint/hint-no-protocol-relative-urls": "^3.0.3",
     "@hint/hint-no-vulnerable-javascript-libraries": "^2.12.1",
     "@hint/hint-scoped-svg-styles": "^1.3.7",

--- a/packages/extension-browser/tsconfig.json
+++ b/packages/extension-browser/tsconfig.json
@@ -35,6 +35,7 @@
         { "path": "../hint-no-disallowed-headers" },
         { "path": "../hint-no-html-only-headers" },
         { "path": "../hint-no-http-redirects" },
+        { "path": "../hint-no-inline-styles" },
         { "path": "../hint-no-protocol-relative-urls" },
         { "path": "../hint-no-vulnerable-javascript-libraries" },
         { "path": "../hint-scoped-svg-styles" },

--- a/packages/hint-no-inline-styles/package.json
+++ b/packages/hint-no-inline-styles/package.json
@@ -73,5 +73,5 @@
     "watch:test": "ava --watch",
     "watch:ts": "npm run build:ts -- --watch"
   },
-  "version": "1.0.0"
+  "version": "0.0.1"
 }

--- a/packages/hint-no-inline-styles/src/hint.ts
+++ b/packages/hint-no-inline-styles/src/hint.ts
@@ -1,10 +1,7 @@
 /**
  * @fileoverview Invalidate the use of CSS inline styles in HTML
  */
-import {
-    HintContext,
-    IHint
-} from 'hint';
+import { HintContext, IHint } from 'hint';
 import { HTMLElement } from '@hint/utils-dom';
 import { Severity } from '@hint/utils-types';
 import { HTMLEvents, HTMLParse } from '@hint/parser-html';
@@ -30,14 +27,18 @@ export default class NoInlineStylesHint implements IHint {
                 'style'
             );
 
+            const severity = Severity.warning;
+
             debug(`Validating rule no-inline-styles`);
 
-            if (requireNoStyleElement && styleElements.length > 0) {
-                context.report(
-                    resource,
-                    getMessage('styleElementFound', context.language),
-                    { severity: Severity.hint }
-                );
+            if (requireNoStyleElement) {
+                styleElements.forEach((element) => {
+                    context.report(
+                        resource,
+                        getMessage('styleElementFound', context.language),
+                        { element, severity }
+                    );
+                });
             }
 
             // - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -50,20 +51,23 @@ export default class NoInlineStylesHint implements IHint {
                 '[style]'
             );
 
-            if (elementsWithStyleAttribute.length > 0) {
+            elementsWithStyleAttribute.forEach((element) => {
                 context.report(
                     resource,
                     getMessage(
                         'elementsWithStyleAttributeFound',
                         context.language
                     ),
-                    { severity: Severity.hint }
+                    { element, severity }
                 );
-            }
+            });
         };
 
         const loadHintConfigs = () => {
-            requireNoStyleElement = (context.hintOptions && context.hintOptions.requireNoStyleElement) || false;
+            requireNoStyleElement =
+                (context.hintOptions &&
+                    context.hintOptions.requireNoStyleElement) ||
+                false;
         };
 
         loadHintConfigs();

--- a/packages/hint-no-inline-styles/src/meta.ts
+++ b/packages/hint-no-inline-styles/src/meta.ts
@@ -5,7 +5,7 @@ import { getMessage } from './i18n.import';
 
 const meta: HintMetadata = {
     docs: {
-        category: Category.other,
+        category: Category.pitfalls,
 
         description: getMessage('description', 'en'),
         name: getMessage('name', 'en')

--- a/packages/hint-no-inline-styles/tests/test.ts
+++ b/packages/hint-no-inline-styles/tests/test.ts
@@ -10,6 +10,8 @@ const style = {
     elementWithStyleAttribute: '<div style="color: blue"></div>',
     elementWithStyleAttributeCapitalised: '<span Style="color: blue"></span>',
     elementWithStyleAttributeUpperCase: '<span Style="color: blue"></span>',
+    multipleElementWithStyleAttribute: '<div style="color: blue;"></div><span style="display: block;"></span><p style="color: blue;"></p>',
+    multipleStyleElement: '<style></style><span></span><style></style><div></div><style></style>',
     styleElement: '<style></style>',
     styleElementCapitalised: '<Style></Style>',
     styleElementUpperCase: '<STYLE></STYLE>'
@@ -29,17 +31,35 @@ const tests: HintTest[] = [
         reports: [
             {
                 message: `CSS inline styles should not be used, move styles to an external CSS file`,
-                severity: Severity.hint
+                severity: Severity.warning
             }
         ],
         serverConfig: generateHTMLPage('', style.elementWithStyleAttribute)
+    },
+    {
+        name: 'Element with multiple style attribute fails',
+        reports: [
+            {
+                message: `CSS inline styles should not be used, move styles to an external CSS file`,
+                severity: Severity.warning
+            },
+            {
+                message: `CSS inline styles should not be used, move styles to an external CSS file`,
+                severity: Severity.warning
+            },
+            {
+                message: `CSS inline styles should not be used, move styles to an external CSS file`,
+                severity: Severity.warning
+            }
+        ],
+        serverConfig: generateHTMLPage('', style.multipleElementWithStyleAttribute)
     },
     {
         name: 'Element with capitalised style attribute fails',
         reports: [
             {
                 message: `CSS inline styles should not be used, move styles to an external CSS file`,
-                severity: Severity.hint
+                severity: Severity.warning
             }
         ],
         serverConfig: generateHTMLPage(
@@ -52,7 +72,7 @@ const tests: HintTest[] = [
         reports: [
             {
                 message: `CSS inline styles should not be used, move styles to an external CSS file`,
-                severity: Severity.hint
+                severity: Severity.warning
             }
         ],
         serverConfig: generateHTMLPage(
@@ -90,17 +110,35 @@ const testsForRequireNoStyleElementConfig: HintTest[] = [
         reports: [
             {
                 message: `CSS internal styles should not be used, move styles to an external CSS file`,
-                severity: Severity.hint
+                severity: Severity.warning
             }
         ],
         serverConfig: generateHTMLPage('', style.styleElement)
+    },
+    {
+        name: 'Element with multiple style element fails',
+        reports: [
+            {
+                message: `CSS internal styles should not be used, move styles to an external CSS file`,
+                severity: Severity.warning
+            },
+            {
+                message: `CSS internal styles should not be used, move styles to an external CSS file`,
+                severity: Severity.warning
+            },
+            {
+                message: `CSS internal styles should not be used, move styles to an external CSS file`,
+                severity: Severity.warning
+            }
+        ],
+        serverConfig: generateHTMLPage('', style.multipleStyleElement)
     },
     {
         name: 'Element with capitalised style element fails',
         reports: [
             {
                 message: `CSS internal styles should not be used, move styles to an external CSS file`,
-                severity: Severity.hint
+                severity: Severity.warning
             }
         ],
         serverConfig: generateHTMLPage(
@@ -113,7 +151,7 @@ const testsForRequireNoStyleElementConfig: HintTest[] = [
         reports: [
             {
                 message: `CSS internal styles should not be used, move styles to an external CSS file`,
-                severity: Severity.hint
+                severity: Severity.warning
             }
         ],
         serverConfig: generateHTMLPage(

--- a/packages/utils-worker/package.json
+++ b/packages/utils-worker/package.json
@@ -31,7 +31,7 @@
     "@hint/hint-no-disallowed-headers": "^3.1.2",
     "@hint/hint-no-html-only-headers": "^3.0.3",
     "@hint/hint-no-http-redirects": "^3.0.3",
-    "@hint/hint-no-inline-styles": "^1.0.0",
+    "@hint/hint-no-inline-styles": "^0.0.1",
     "@hint/hint-no-protocol-relative-urls": "^3.0.3",
     "@hint/hint-scoped-svg-styles": "^1.3.7",
     "@hint/hint-sri": "^4.0.3",

--- a/packages/utils-worker/package.json
+++ b/packages/utils-worker/package.json
@@ -31,6 +31,7 @@
     "@hint/hint-no-disallowed-headers": "^3.1.2",
     "@hint/hint-no-html-only-headers": "^3.0.3",
     "@hint/hint-no-http-redirects": "^3.0.3",
+    "@hint/hint-no-inline-styles": "^1.0.0",
     "@hint/hint-no-protocol-relative-urls": "^3.0.3",
     "@hint/hint-scoped-svg-styles": "^1.3.7",
     "@hint/hint-sri": "^4.0.3",


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

This PR 

- [x] Adds `no-inline-styles` hint to default configurations as follow-up PR of https://github.com/webhintio/hint/pull/4161
- [x]  I changed the `severity` from `hint` to `warning` 
- [x]  The category is also changed from 'other' to 'pitfalls'
- [x]  I use loop to go through all the selected elements to report affected element each 