### PR TITLE
Fix: Discover tslib in projects with nested structure

### DIFF
--- a/packages/hint-typescript-config/src/import-helpers.ts
+++ b/packages/hint-typescript-config/src/import-helpers.ts
@@ -33,11 +33,10 @@ export default class TypeScriptConfigImportHelpers implements IHint {
         const validateTslibInstalled = (evt: ScanEnd) => {
             const { resource } = evt;
 
-            const pathToTslib = path.dirname(require.resolve('tslib', { paths: [resource] }));
-
-            debug(`Searching "tslib" in ${pathToTslib}`);
-
             try {
+                const pathToTslib = path.dirname(require.resolve('tslib', { paths: [resource] }));
+
+                debug(`Searching "tslib" relative to ${resource}`);
                 loadPackage(pathToTslib);
                 debug(`"tslib" found`);
             } catch (e) {

--- a/packages/hint-typescript-config/src/import-helpers.ts
+++ b/packages/hint-typescript-config/src/import-helpers.ts
@@ -33,7 +33,7 @@ export default class TypeScriptConfigImportHelpers implements IHint {
         const validateTslibInstalled = (evt: ScanEnd) => {
             const { resource } = evt;
 
-            const pathToTslib = path.join(process.cwd(), 'node_modules', 'tslib');
+            const pathToTslib = path.dirname(require.resolve('tslib', { paths: [resource] }));
 
             debug(`Searching "tslib" in ${pathToTslib}`);
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
Change pathToTslib to resolve the path to tslib based on the tsconfig.json location rather than current working directory. Fixes #4175.
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
