### PR TITLE
Fix: Add extension cache-control directives

### DIFF
--- a/packages/hint-http-cache/src/hint.ts
+++ b/packages/hint-http-cache/src/hint.ts
@@ -142,7 +142,8 @@ export default class HttpCacheHint implements IHint {
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
             const directives = ['must-revalidate', 'no-cache', 'no-store', 'no-transform', 'public', 'private', 'proxy-revalidate'];
             const valueDirectives = ['max-age', 's-maxage'];
-            const extensionDirectives = ['immutable', 'stale-while-revalidate', 'stale-if-error'];
+            const extensionDirectives = ['immutable'];
+            const extensionValueDirectives = ['stale-while-revalidate', 'stale-if-error'];
 
             const usedDirectives = cacheControlHeader.split(',').map((value) => {
                 return value.trim();
@@ -162,7 +163,7 @@ export default class HttpCacheHint implements IHint {
                      * Check if the directive has a value when it shouldn't
                      * E.g.: no-cache=12345
                      */
-                    if (!valueDirectives.includes(directive)) {
+                    if (!valueDirectives.includes(directive) && !extensionValueDirectives.includes(directive)) {
                         parsed.invalidValues.set(directive, value);
 
                         return parsed;


### PR DESCRIPTION
Add`stale-while-revalidate` and `stale-if-error` to
extensionValueDirectives and add corresponding validation

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #3691 

(Assuming this is a trivial change) Before this fix, scans detecting use of `stale-if-error` and `stale-while-revalidate` would showed the following error (the test URL was https://simbiat.ru/): 

![image](https://user-images.githubusercontent.com/48158362/107869910-9a078800-6e61-11eb-90b3-eb28b306b0a5.png)

After the fix, these errors no longer appear at all:

<img width="713" alt="Screen Shot 2021-02-14 at 1 13 22 AM" src="https://user-images.githubusercontent.com/48158362/107869934-d6d37f00-6e61-11eb-84b7-c5ecbe91641a.png">

However, there may be an even better way to do this where `stale-if-error` and `stale-while-revalidate` trigger warnings that these directives are experimental and may change according to MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
