### PR TITLE
refactor: updated dependency mdn-browser-compat-data

### DIFF
--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -9,7 +9,7 @@
     "timeout": "1m"
   },
   "browserslist": "last 2 chrome versions, last 2 firefox versions",
-  "bundleSize": 742000,
+  "bundleSize": 745000,
   "description": "webhint browser extension",
   "devDependencies": {
     "@hint/hint-axe": "^4.4.3",

--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -9,7 +9,7 @@
     "timeout": "1m"
   },
   "browserslist": "last 2 chrome versions, last 2 firefox versions",
-  "bundleSize": 736000,
+  "bundleSize": 742000,
   "description": "webhint browser extension",
   "devDependencies": {
     "@hint/hint-axe": "^4.4.3",

--- a/packages/hint-compat-api/tests/utils/browsers.ts
+++ b/packages/hint-compat-api/tests/utils/browsers.ts
@@ -37,7 +37,7 @@ test('range', (t) => {
                 ['and_ff 66', { versionAdded: '67' }]
             ])
         }),
-        'Firefox < 67, Firefox Android < 67'
+        'Firefox < 67, Firefox for Android < 67'
     );
 });
 

--- a/packages/utils-compat-data/README.md
+++ b/packages/utils-compat-data/README.md
@@ -66,7 +66,7 @@ The friendly names and ids for each one are as follows:
 | Chrome Android | and_chr    | chrome_android |
 | Edge         | edge         | edge |
 | Firefox      | ff           | firefox |
-| Firefox Android | and_ff    | firefox_android |
+| Firefox for Android | and_ff    | firefox_android |
 | Internet Explorer | ie      | ie |
 | Opera        | opera        | opera |
 | Opera Android | op_mobile   | opera_android |
@@ -87,7 +87,7 @@ Get the friendly name of a browser from an id.
 ```js
 import { getFriendlyName } from '@hint/utils-compat-data';
 
-console.log(getFriendlyName('and_ff')); // "Firefox Android"
+console.log(getFriendlyName('and_ff')); // "Firefox for Android"
 console.log(getFriendlyName('ie')); // "Internet Explorer"
 ```
 

--- a/packages/utils-compat-data/package.json
+++ b/packages/utils-compat-data/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@hint/utils-css": "^1.0.7",
-    "mdn-browser-compat-data": "^1.1.2",
+    "@mdn/browser-compat-data": "^3.2.0",
     "mdn-data": "^2.0.17",
     "postcss-selector-parser": "^6.0.4",
     "postcss-value-parser": "^4.1.0",

--- a/packages/utils-compat-data/package.json
+++ b/packages/utils-compat-data/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@hint/utils-css": "^1.0.7",
-    "@mdn/browser-compat-data": "^3.2.0",
+    "@mdn/browser-compat-data": "^3.2.2",
     "mdn-data": "^2.0.17",
     "postcss-selector-parser": "^6.0.4",
     "postcss-value-parser": "^4.1.0",

--- a/packages/utils-compat-data/scripts/mdn-browser-compat-data.js
+++ b/packages/utils-compat-data/scripts/mdn-browser-compat-data.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const mdn = require('mdn-browser-compat-data');
+const mdn = require('@mdn/browser-compat-data');
 const path = require('path');
 const filename = path.resolve(`${__dirname}/../src/browser-compat-data.ts`);
 
@@ -251,7 +251,7 @@ removeFeatures(data.css);
 removeFeatures(data.html);
 
 const code = `/* eslint-disable */
-import { Browsers, PrimaryIdentifier } from 'mdn-browser-compat-data/types';
+import { Browsers, PrimaryIdentifier } from '@mdn/browser-compat-data/types';
 
 type Data = {
     browsers: Browsers;

--- a/packages/utils-compat-data/scripts/mdn-data.js
+++ b/packages/utils-compat-data/scripts/mdn-data.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const mdn = require('mdn-browser-compat-data');
+const mdn = require('@mdn/browser-compat-data');
 const path = require('path');
 const filename = path.resolve(`${__dirname}/../src/mdn-css-types.ts`);
 
@@ -66,7 +66,7 @@ const types = props.map((key) => {
     return [
         key,
         [...new Set(getTypesForProperty(key))].filter((type) => {
-            // Exclude types not present in mdn-browser-compat-data since we won't need them.
+            // Exclude types not present in @mdn/browser-compat-data since we won't need them.
             return mdn.css.types[type];
         })
     ];

--- a/packages/utils-compat-data/src/browsers.ts
+++ b/packages/utils-compat-data/src/browsers.ts
@@ -1,4 +1,4 @@
-import { Identifier, SimpleSupportStatement, SupportStatement } from 'mdn-browser-compat-data/types';
+import { Identifier, SimpleSupportStatement, SupportStatement } from '@mdn/browser-compat-data/types';
 const semver = require('semver/preload');
 
 import { mdn } from './browser-compat-data';

--- a/packages/utils-compat-data/src/css.ts
+++ b/packages/utils-compat-data/src/css.ts
@@ -1,4 +1,4 @@
-import { Identifier } from 'mdn-browser-compat-data/types';
+import { Identifier } from '@mdn/browser-compat-data/types';
 import { getUnprefixed, getVendorPrefix } from '@hint/utils-css';
 
 import { mdn } from './browser-compat-data';

--- a/packages/utils-compat-data/src/helpers.ts
+++ b/packages/utils-compat-data/src/helpers.ts
@@ -1,4 +1,4 @@
-import { Identifier } from 'mdn-browser-compat-data/types';
+import { Identifier } from '@mdn/browser-compat-data/types';
 import { getVendorPrefix, getUnprefixed } from '@hint/utils-css';
 
 /**

--- a/packages/utils-compat-data/src/html.ts
+++ b/packages/utils-compat-data/src/html.ts
@@ -1,5 +1,5 @@
 import { mdn } from './browser-compat-data';
-import { Identifier } from 'mdn-browser-compat-data/types';
+import { Identifier } from '@mdn/browser-compat-data/types';
 
 import { getUnsupportedBrowsers, UnsupportedBrowsers } from './browsers';
 import { getCachedValue } from './cache';

--- a/packages/utils-compat-data/tests/browsers.ts
+++ b/packages/utils-compat-data/tests/browsers.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { Identifier } from 'mdn-browser-compat-data/types';
+import { Identifier } from '@mdn/browser-compat-data/types';
 
 import { getUnsupportedBrowsers } from '../src/browsers';
 

--- a/packages/utils-worker/package.json
+++ b/packages/utils-worker/package.json
@@ -9,7 +9,7 @@
     ],
     "timeout": "1m"
   },
-  "bundleSize": 2500000,
+  "bundleSize": 2550000,
   "description": "webhint web worker",
   "devDependencies": {
     "@hint/hint-axe": "^4.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -244,6 +244,13 @@
   dependencies:
     extend "3.0.2"
 
+"@mdn/browser-compat-data@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-3.2.2.tgz#0d4ca55e796d96a4d15935b8e51535ced5380573"
+  integrity sha512-W+f7ZugkxsB2xvRLb283m/weDx58yatbJTDRS8FAO9kR7igrQsZeTFaUoYogw36ywzwuOSnY6vKPFHbF6Xhd5A==
+  dependencies:
+    extend "3.0.2"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -7220,13 +7227,6 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
-
-mdn-browser-compat-data@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/mdn-browser-compat-data/-/mdn-browser-compat-data-1.1.2.tgz#90d2a25ce731b34a14329396887dadfd657ea7b2"
-  integrity sha512-uBNX2P4iu3PZcXP20rL+n7fxN9PWZLj0y43QMe/1aXzqP3H6HbVOeePS0cBZCtMwcfr2Tugf1OHj+/wLam+dUg==
-  dependencies:
-    extend "3.0.2"
 
 mdn-data@^2.0.17:
   version "2.0.17"


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Updated dependency mdn-browser-compat-data from 1.1.2 to version 2 according to https://github.com/mdn/browser-compat-data/blob/v1.1.2/UPGRADE-2.0.x.md, and without any more necessary changes to version 3 (3.2.0 actually)

The change is necessary as the package has been renamed, see the following message on the shell:
> npm WARN deprecated mdn-browser-compat-data@1.1.2: mdn-browser-compat-data is deprecated. Upgrade to @mdn/browser-compat-data. Learn more: https://github.com/mdn/browser-compat-data/blob/v1.1.2/UPGRADE-2.0.x.md

Closes #4117