### PR TITLE
Fix: Ignore input[inputmode]

### DIFF
--- a/packages/hint-compat-api/docs/html.md
+++ b/packages/hint-compat-api/docs/html.md
@@ -91,7 +91,8 @@ default value is:
     "integrity",
     "link[rel]",
     "main",
-    "spellcheck"
+    "spellcheck",
+    "input[inputmode]"
 ]
 ```
 

--- a/packages/hint-compat-api/docs/html.md
+++ b/packages/hint-compat-api/docs/html.md
@@ -88,11 +88,11 @@ default value is:
     "a[rel=noopener]",
     "autocomplete",
     "crossorigin",
+    "input[inputmode]",
     "integrity",
     "link[rel]",
     "main",
-    "spellcheck",
-    "input[inputmode]"
+    "spellcheck"
 ]
 ```
 

--- a/packages/hint-compat-api/src/html.ts
+++ b/packages/hint-compat-api/src/html.ts
@@ -80,7 +80,8 @@ export default class HTMLCompatHint implements IHint {
             'integrity',
             'link[rel]',
             'main',
-            'spellcheck'
+            'spellcheck',
+            'input[inputmode]'
         ], context.hintOptions);
 
         context.on('element::*', ({ element, resource }) => {

--- a/packages/hint-compat-api/src/html.ts
+++ b/packages/hint-compat-api/src/html.ts
@@ -77,11 +77,11 @@ export default class HTMLCompatHint implements IHint {
             'a[rel=noopener]', // handled by hint-disown-opener
             'autocomplete',
             'crossorigin',
+            'input[inputmode]',
             'integrity',
             'link[rel]',
             'main',
-            'spellcheck',
-            'input[inputmode]'
+            'spellcheck'
         ], context.hintOptions);
 
         context.on('element::*', ({ element, resource }) => {

--- a/packages/hint-compat-api/tests/fixtures/html/ignore.html
+++ b/packages/hint-compat-api/tests/fixtures/html/ignore.html
@@ -1,3 +1,3 @@
 <script integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"></script>
-<input autocomplete="off">
+<input autocomplete="off" inputmode="email">
 <a href="https://webhint.io" rel="noopener">Test</a>


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)
Fix for issue https://github.com/webhintio/hint/issues/4547 to allow ignoring of `inputmode` attribute in `input` elements. While Safari and Firefox do not support the attribute, it is still useful in other browsers, thus should not trigger a hint.
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
