### PR TITLE
Chore: Remove file-url in favor of simpler inline logic

### DIFF
--- a/packages/utils-network/package.json
+++ b/packages/utils-network/package.json
@@ -14,7 +14,6 @@
     "@hint/utils-string": "^1.0.8",
     "@hint/utils-types": "^1.1.3",
     "content-type": "^1.0.4",
-    "file-url": "^3.0.0",
     "lodash": "^4.17.21",
     "request": "^2.88.2"
   },

--- a/packages/utils-network/src/as-uri.ts
+++ b/packages/utils-network/src/as-uri.ts
@@ -1,7 +1,6 @@
 import * as url from 'url';
 import { URL } from 'url'; // this is necessary to avoid TypeScript mixes types.
 
-import * as fileUrl from 'file-url';
 import compact = require('lodash/compact'); // `require` used because `lodash/compact` exports a function
 
 import { debug as d } from '@hint/utils-debug';
@@ -46,7 +45,7 @@ export const getAsUri = (source: string): URL | null => {
      * If it does exist and it's a regular file.
      */
     if (isFile(source) || isDirectory(source)) {
-        target = new URL(fileUrl(source));
+        target = new URL(`file://${source}`);
         debug(`Adding valid target: ${url.format(target)}`);
 
         return target;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4447,11 +4447,6 @@ file-type@^16.5.0:
     strtok3 "^6.0.3"
     token-types "^2.0.0"
 
-file-url@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/file-url/-/file-url-3.0.0.tgz#247a586a746ce9f7a8ed05560290968afc262a77"
-  integrity sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA==
-
 filelist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.1.tgz#f10d1a3ae86c1694808e8f20906f43d4c9132dbb"


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

The 'file-url' dependency has switched to ESM making it harder to import and use until all of webhint is switched to ESM. Examining the usage of this dependency in webhint revealed it wasn't really needed as the paths being processed are already ensured to be absolute and can simply be prefixed with `file://`.

Closes #4469 