### PR TITLE
Fix: Remove old CLA link from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ For the following items put an "x" between the square brackets
 
 Make sure you:
 
-- [ ] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/hint)
+- [ ] Signed the Contributor License Agreement (after creating PR)
 - [ ] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)
 
 For non-trivial changes, please make sure you also:


### PR DESCRIPTION
Given there are now multiple choices (individual/corporate) I'm inclined to avoid linking to anything for the new CLA and recommend signing it after creating the PR (since the process is more clear once the CLA bot replies).