### PR TITLE
Fix: Restore handling relative file paths in getAsUri

### DIFF
--- a/packages/utils-network/src/as-uri.ts
+++ b/packages/utils-network/src/as-uri.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import * as url from 'url';
 import { URL } from 'url'; // this is necessary to avoid TypeScript mixes types.
 
@@ -45,7 +46,7 @@ export const getAsUri = (source: string): URL | null => {
      * If it does exist and it's a regular file.
      */
     if (isFile(source) || isDirectory(source)) {
-        target = new URL(`file://${source}`);
+        target = new URL(`file://${path.resolve(source)}`);
         debug(`Adding valid target: ${url.format(target)}`);
 
         return target;

--- a/packages/utils-network/tests/as-uri.ts
+++ b/packages/utils-network/tests/as-uri.ts
@@ -43,3 +43,9 @@ test('getAsUris drops invalid URLs', (t) => {
 
     t.is(uris.length, 1, `getAsUris didn't return the expected number of URIs`);
 });
+
+test('getAsUri resolves relative file paths', (t) => {
+    const uri = getAsUri('.');
+
+    t.is(uri?.hostname, '', `getAsUri didn't resolve relative path to an absolute path`);
+});


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
This was regressed when attempting to simplify dependencies.
An incorrect assumption was made about passed paths already
being absolute, but in the CLI relative paths can make it here.

Fixed by resolving the passed paths before converting to a URL.
Also added a new test to validate relative paths are converted.

- - - - - - - - - - - - - - - - - - - -

Fix #4836