### PR TITLE
Fix: Handle multiple selectors from axe-core

### DIFF
--- a/packages/hint-axe/src/util/axe.ts
+++ b/packages/hint-axe/src/util/axe.ts
@@ -34,7 +34,12 @@ type RegistrationMap = Map<EngineKey, Map<string, Registration[]>>;
 const registrationMap: RegistrationMap = new Map();
 
 const getElement = (context: HintContext, node: AxeNodeResult): HTMLElement | undefined | null => {
-    const selector = node.target[0];
+    let selector = node.target[0];
+
+    // Contrary to types, axe-core can return an array of strings. Take the first.
+    if (Array.isArray(selector)) {
+        selector = selector[0];
+    }
 
     return context.pageDOM?.querySelector(selector);
 };


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Interestingly axe-core can return an array of selectors for a target
instead of just a single string (contrary to the definitions in axe.d.ts).
This was causing problems when the array was passed down to
webhint's selectors library.

Fixed by checking if the target selector is an array, and if so,
using the first selector to find the element.

- - - - - - - - - - - - - - - - - - - -

Fix #4834