### PR TITLE
New: Disable typescript-config/no-comments by default

### DIFF
--- a/packages/configuration-development/index.json
+++ b/packages/configuration-development/index.json
@@ -29,7 +29,6 @@
         "typescript-config/consistent-casing",
         "typescript-config/import-helpers",
         "typescript-config/is-valid",
-        "typescript-config/no-comments",
         "typescript-config/strict",
         "typescript-config/target"
     ],

--- a/packages/hint-typescript-config/docs/no-comments.md
+++ b/packages/hint-typescript-config/docs/no-comments.md
@@ -3,6 +3,10 @@
 `typescript-config/no-comments` checks that the property `removeComments`
 is enabled in your TypeScript configuration file (i.e. `tsconfig.json`).
 
+**Note:** This hint is no longer enabled by default. Removing comments as
+part of a separate minification step is recommended instead. See
+[this webhint issue][no-comments issue] for more details.
+
 ## Why is this important?
 
 Removing the comments will make your final JavaScript files smaller. If you
@@ -59,3 +63,4 @@ Also setting the value to `false` will fail:
 * [TypeScript Documentation][typescript docs]
 
 [typescript docs]: https://www.typescriptlang.org/docs/home.html
+[no-comments issue]: https://github.com/webhintio/hint/issues/4839


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Disable the hint `typescript-config/no-comments` by default per
feedback from the TypeScript team in #4839. Also update docs
to indicate the hint is disabled.

- - - - - - - - - - - - - - - - - - - -

Fix #4839