### PR TITLE
Fix: Omit JSX expressions in non-text HTML parents

### DIFF
--- a/packages/parser-jsx/tests/tests.ts
+++ b/packages/parser-jsx/tests/tests.ts
@@ -147,18 +147,25 @@ test('It replaces expressions with text placeholders', async (t) => {
     t.is(div.innerHTML, '{expression}');
 });
 
-test('It wraps expression placeholder text with <li> when parented to <ul>', async (t) => {
-    const { document } = await parseJSX(`const jsx = <ul>{myText}</ul>;`);
+test('It drops expression placeholder text when parented to <ul>', async (t) => {
+    const { document } = await parseJSX(`const jsx = <ul>{myItems}</ul>;`);
     const ul = document.querySelectorAll('ul')[0];
 
-    t.is(ul.innerHTML, '<li>{expression}</li>');
+    t.is(ul.innerHTML, '');
 });
 
-test('It wraps expression placeholder text with <li> when parented to <ol>', async (t) => {
-    const { document } = await parseJSX(`const jsx = <ol>{myText}</ol>;`);
+test('It drops expression placeholder text when parented to <ol>', async (t) => {
+    const { document } = await parseJSX(`const jsx = <ol>{items.map(item=>(<li>{item}</li>))}</ol>;`);
     const ol = document.querySelectorAll('ol')[0];
 
     t.is(ol.innerHTML, '<li>{expression}</li>');
+});
+
+test('It drops expression placeholder text when parented to <dl>', async (t) => {
+    const { document } = await parseJSX(`const jsx = <dl>{myText}<dt>Term</dt><dd>Def</dd></dl>;`);
+    const ul = document.querySelectorAll('dl')[0];
+
+    t.is(ul.innerHTML, '<dt>Term</dt><dd>Def</dd>');
 });
 
 test('It translates source locations correctly', async (t) => {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the Contributor License Agreement (after creating PR)
- [X] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [X] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Normally JSX expressions are translated to text nodes to ensure
elements are considered as having content (and labels). However,
not all HTML elements allow text children, so in these cases the
expression is now omitted from the JSX-to-HTML conversion.

This replaces an earlier fix for `<ul>` where a wrapper `<li>`
was added instead. The new approach is preferred because it
still produces valid output while being more similar to the
original source code.

- - - - - - - - - - - - - - - - - - - -

Fix #4878