### PR TITLE
Fix: Assume expected parents in template fragments

### DIFF
--- a/packages/parser-jsx/src/parser.ts
+++ b/packages/parser-jsx/src/parser.ts
@@ -237,12 +237,8 @@ const allowsTextChildren = (node: JSXElement): boolean => {
  * provided roots derived from the specified resource.
  */
 const createHTMLFragment = (roots: RootMap, resource: string) => {
-    const dom = parse5.parse(
-        `<!doctype html><html data-webhint-fragment></html>`,
-        { treeAdapter: htmlparser2Adapter }
-    ) as DocumentData;
-
-    const body = (dom.children[1] as ElementData).children[1] as ElementData;
+    const dom = parse5.parse('', { treeAdapter: htmlparser2Adapter }) as DocumentData;
+    const body = (dom.children[0] as ElementData).children[1] as ElementData;
 
     roots.forEach((root) => {
         body.children.push(root);
@@ -250,7 +246,7 @@ const createHTMLFragment = (roots: RootMap, resource: string) => {
 
     restoreReferences(dom);
 
-    return new HTMLDocument(dom, resource);
+    return new HTMLDocument(dom, resource, undefined, true);
 };
 
 export default class JSXParser extends Parser<HTMLEvents> {
@@ -303,7 +299,7 @@ export default class JSXParser extends Parser<HTMLEvents> {
                 await this.engine.emitAsync(`parse::start::html`, { resource });
 
                 const document = createHTMLFragment(roots, resource);
-                const html = `<!doctype html>\n${document.documentElement.outerHTML}`;
+                const html = document.documentElement.outerHTML;
 
                 debug('Generated HTML from JSX:', html);
 

--- a/packages/parser-jsx/tests/tests.ts
+++ b/packages/parser-jsx/tests/tests.ts
@@ -56,7 +56,7 @@ test('It translates basic JSX to HTML', async (t) => {
     const { html } = await emitFetchEndJSX(engine, `const jsx = <div>Test</div>;`);
 
     t.true(receivedStart);
-    t.is(html, `<!doctype html>\n<html data-webhint-fragment=""><head></head><body><div>Test</div></body></html>`);
+    t.is(html, `<html><head></head><body><div>Test</div></body></html>`);
 });
 
 test('It does not emit HTML events if no JSX is present', async (t) => {

--- a/packages/utils-dom/src/create-html-document.ts
+++ b/packages/utils-dom/src/create-html-document.ts
@@ -10,7 +10,7 @@ import { HTMLDocument } from './htmldocument';
  * @param originalDocument - Previous snatshop of the html.
  */
 export const createHTMLDocument = (html: string, finalHref: string, originalDocument?: HTMLDocument): HTMLDocument => {
-    const isFragment = !(/<html\b/).test(html);
+    const isFragment = !(/(<!doctype|<html\b)/i).test(html);
     const dom = parse5.parse(isFragment ? '' : html, {
         sourceCodeLocationInfo: !originalDocument,
         treeAdapter: htmlparser2Adapter
@@ -30,5 +30,5 @@ export const createHTMLDocument = (html: string, finalHref: string, originalDocu
         }
     }
 
-    return new HTMLDocument(dom, finalHref, originalDocument);
+    return new HTMLDocument(dom, finalHref, originalDocument, isFragment);
 };

--- a/packages/utils-dom/src/create-html-document.ts
+++ b/packages/utils-dom/src/create-html-document.ts
@@ -1,7 +1,7 @@
 import * as parse5 from 'parse5';
 import * as htmlparser2Adapter from 'parse5-htmlparser2-tree-adapter';
 
-import { DocumentData } from './types';
+import { DocumentData, DocumentFragmentData, ElementData } from './types';
 import { HTMLDocument } from './htmldocument';
 
 /**
@@ -10,10 +10,25 @@ import { HTMLDocument } from './htmldocument';
  * @param originalDocument - Previous snatshop of the html.
  */
 export const createHTMLDocument = (html: string, finalHref: string, originalDocument?: HTMLDocument): HTMLDocument => {
-    const dom = parse5.parse(html, {
+    const isFragment = !(/<html\b/).test(html);
+    const dom = parse5.parse(isFragment ? '' : html, {
         sourceCodeLocationInfo: !originalDocument,
         treeAdapter: htmlparser2Adapter
     }) as DocumentData;
+
+    if (isFragment) {
+        const body = (dom.children[0] as ElementData).children[1] as ElementData;
+        const fragment = parse5.parseFragment(html, {
+            sourceCodeLocationInfo: !originalDocument,
+            treeAdapter: htmlparser2Adapter
+        }) as DocumentFragmentData;
+
+        body.children = fragment.children;
+
+        for (const child of body.children) {
+            child.parent = body;
+        }
+    }
 
     return new HTMLDocument(dom, finalHref, originalDocument);
 };

--- a/packages/utils-dom/src/htmldocument.ts
+++ b/packages/utils-dom/src/htmldocument.ts
@@ -12,6 +12,7 @@ import { Node } from './node';
 import { Text } from './text';
 import { DocumentData, ElementData, NodeData } from './types';
 import { getCompiledSelector } from './get-compiled-selector';
+import { ensureExpectedParentNodes } from './utils';
 
 /**
  * https://developer.mozilla.org/docs/Web/API/HTMLDocument
@@ -34,6 +35,11 @@ export class HTMLDocument extends Node {
         this._document = document;
         this._documentElement = this.findDocumentElement();
         this.originalDocument = originalDocument;
+
+        if (this.isFragment) {
+            ensureExpectedParentNodes(document);
+        }
+
         this._pageHTML = parse5.serialize(document as htmlparser2Adapter.Node, { treeAdapter: htmlparser2Adapter });
         this._base = this.getBaseUrl(finalHref);
         this._nodes.set(document, this);

--- a/packages/utils-dom/src/htmldocument.ts
+++ b/packages/utils-dom/src/htmldocument.ts
@@ -20,6 +20,7 @@ import { ensureExpectedParentNodes } from './utils';
 export class HTMLDocument extends Node {
     private _document: DocumentData;
     private _documentElement: ElementData;
+    private _isFragment: boolean;
     private _nodes = new Map<NodeData, Node>();
     private _pageHTML = '';
     private _base: string;
@@ -30,13 +31,14 @@ export class HTMLDocument extends Node {
     /**
      * Non-standard. Used internally by utils-dom to create HTMLDocument instances.
      */
-    public constructor(document: DocumentData, finalHref: string, originalDocument?: HTMLDocument) {
+    public constructor(document: DocumentData, finalHref: string, originalDocument?: HTMLDocument, isFragment = false) {
         super(document, null as any);
         this._document = document;
         this._documentElement = this.findDocumentElement();
+        this._isFragment = isFragment;
         this.originalDocument = originalDocument;
 
-        if (this.isFragment) {
+        if (isFragment) {
             ensureExpectedParentNodes(document);
         }
 
@@ -98,8 +100,7 @@ export class HTMLDocument extends Node {
      * Check if this represents a template fragment as opposed to a full document.
      */
     public get isFragment(): boolean {
-        // Document is a fragment if `<html>` wasn't part of the original source.
-        return !this.originalDocument && !this._documentElement.sourceCodeLocation;
+        return this._isFragment;
     }
 
     /**

--- a/packages/utils-dom/src/utils.ts
+++ b/packages/utils-dom/src/utils.ts
@@ -1,0 +1,107 @@
+import { DocumentData, ElementData } from './types';
+
+// Per contexts in which elements can be used in https://html.spec.whatwg.org/
+const EXPECTED_PARENTS = new Map([
+    ['col', 'colgroup'],
+    ['dd', 'dl'],
+    ['dt', 'dl'],
+    ['legend', 'fieldset'],
+    ['li', 'ul'],
+    ['optgroup', 'select'],
+    ['option', 'select'],
+    ['tbody', 'table'],
+    ['td', 'tr'],
+    ['tfoot', 'table'],
+    ['th', 'tr'],
+    ['thead', 'table'],
+    ['tr', 'table']
+]);
+
+const appendElement = (parent: ElementData, element: ElementData) => {
+    if (element.next) {
+        element.next.prev = parent;
+    }
+    if (element.prev) {
+        element.prev.next = element.next;
+    }
+    if (element.parent) {
+        element.parent.children = element.parent.children.filter((e) => {
+            return e !== element;
+        });
+    }
+
+    const last = parent.children[parent.children.length - 1];
+
+    last.next = element;
+    element.next = null;
+    element.prev = last;
+    element.parent = parent;
+    parent.children.push(element);
+};
+
+const wrapElement = (element: ElementData, wrapperName: string): ElementData => {
+    const parent: ElementData = {
+        attribs: {},
+        children: [element],
+        name: wrapperName,
+        namespace: 'http://www.w3.org/1999/xhtml',
+        next: element.next,
+        parent: element.parent,
+        prev: element.prev,
+        type: 'tag',
+        'x-attribsNamespace': {},
+        'x-attribsPrefix': {}
+    };
+
+    if (element.parent) {
+        element.parent.children = element.parent.children.map((child) => {
+            return child === element ? parent : child;
+        });
+    }
+    if (element.next) {
+        element.next.prev = parent;
+    }
+    if (element.prev) {
+        element.prev.next = parent;
+    }
+
+    element.parent = parent;
+    element.next = null;
+    element.prev = null;
+
+    return parent;
+};
+
+/**
+ * When processing template fragments, wrap top level elements in
+ * expected parent nodes (e.g. wrap `<li>` with `<ul>`) to allow
+ * hints to validate structure without individually handling fragments.
+ *
+ * @param document Data representing a document created from a fragment.
+ */
+export const ensureExpectedParentNodes = (document: DocumentData) => {
+    const html = document.children.find((child) => {
+        return child.type === 'tag' && child.name === 'html';
+    }) as ElementData;
+    const body = html.children.find((child) => {
+        return child.type === 'tag' && child.name === 'body';
+    }) as ElementData;
+    const topElements = body.children.filter((c) => {
+        return c.type === 'tag';
+    }) as ElementData[];
+
+    let parent: ElementData | null = null;
+
+    for (const element of topElements) {
+        const expectedParent = EXPECTED_PARENTS.get(element.name);
+
+        if (expectedParent) {
+            if (parent?.name === expectedParent) {
+                appendElement(parent, element); // re-use common parents
+            } else {
+                parent = wrapElement(element, expectedParent);
+                topElements.push(parent); // recursively process created parents
+            }
+        }
+    }
+};

--- a/packages/utils-dom/tests/axe.ts
+++ b/packages/utils-dom/tests/axe.ts
@@ -127,7 +127,7 @@ test.serial('list', async (t) => {
 
 test.serial('listitem', async (t) => {
     await testAxe(t, {
-        fail: '<li>test</li>',
+        fail: '<html><li>test</li></html>',
         pass: '<ul><li>test</li></ul>'
     });
 });

--- a/packages/utils-dom/tests/html.ts
+++ b/packages/utils-dom/tests/html.ts
@@ -33,10 +33,10 @@ test('HTMLDocument.compatMode should return "CSS1Compat" if standards', (t) => {
 });
 
 test('HTMLDocument.compatMode should return "BackCompat" if not standards', (t) => {
-    const document = createHTMLDocument(`<table border="1">
+    const document = createHTMLDocument(`<html><table border="1">
     <tr><td>one</td><td>two</td></tr>
     <tr><td>three</td><td bgcolor="yellow"></td></tr>
-   </table>`, 'http://example.com');
+   </table></html>`, 'http://example.com');
 
     t.is(document.compatMode, 'BackCompat');
 });

--- a/packages/utils-dom/tests/htmldocument.ts
+++ b/packages/utils-dom/tests/htmldocument.ts
@@ -12,6 +12,16 @@ test('title', (t) => {
     t.is(doc3.title, 'test');
 });
 
+test('isFragment', (t) => {
+    const doc1 = createHTMLDocument('<p>test</p>', 'http://localhost/');
+    const doc2 = createHTMLDocument('<html>test</html>', 'http://localhost/');
+    const doc3 = createHTMLDocument('<!doctype html>test', 'http://localhost/');
+
+    t.true(doc1.isFragment);
+    t.false(doc2.isFragment);
+    t.false(doc3.isFragment);
+});
+
 test('querySelectorAll', (t) => {
     const doc = createHTMLDocument('<div id="d1">div1</div><div id="d2">div2</div>', 'http://localhost/');
 

--- a/packages/utils-dom/tests/htmldocument.ts
+++ b/packages/utils-dom/tests/htmldocument.ts
@@ -30,3 +30,29 @@ test('querySelector', (t) => {
     t.is(doc.querySelector('div')?.textContent, 'div1');
     t.is(doc.querySelector('not-div'), null);
 });
+
+test('do not create required parents in full documents', (t) => {
+    const doc = createHTMLDocument('<html><li>item</li></html>', 'http://localhost/');
+
+    t.is(doc.querySelector('li')?.parentElement?.nodeName, 'BODY');
+});
+
+test('create required parents in fragments', (t) => {
+    const doc = createHTMLDocument('<li>item</li>', 'http://localhost/');
+
+    t.is(doc.querySelector('li')?.parentElement?.nodeName, 'UL');
+});
+
+test('merge common required parents in fragments', (t) => {
+    const doc = createHTMLDocument('<dt>term</dt><dd>def</dd>', 'http://localhost/');
+
+    t.is(doc.querySelector('dt')?.parentElement?.nodeName, 'DL');
+    t.is(doc.querySelector('dt')?.parentElement, doc.querySelector('dd')?.parentElement);
+});
+
+test('recursively create required parents in fragments', (t) => {
+    const doc = createHTMLDocument('<td>item</td>', 'http://localhost/');
+
+    t.is(doc.querySelector('td')?.parentElement?.nodeName, 'TR');
+    t.is(doc.querySelector('tr')?.parentElement?.nodeName, 'TABLE');
+});

--- a/packages/utils-dom/tests/node.ts
+++ b/packages/utils-dom/tests/node.ts
@@ -22,7 +22,7 @@ test('contains', (t) => {
 });
 
 test('nodeName', (t) => {
-    const doc = createHTMLDocument('<!doctype html><!--comment--><body>text<script>test</script><style>test</style></body>', 'http://localhost/');
+    const doc = createHTMLDocument('<!doctype html><!--comment--><html><body>text<script>test</script><style>test</style></body></html>', 'http://localhost/');
 
     t.is(doc.nodeName, '#document');
     t.is(doc.childNodes[0].nodeName, 'html');
@@ -34,7 +34,7 @@ test('nodeName', (t) => {
 });
 
 test('nodeType', (t) => {
-    const doc = createHTMLDocument('<!doctype html><!--comment--><body>text</body>', 'http://localhost/');
+    const doc = createHTMLDocument('<!doctype html><!--comment--><html><body>text</body></html>', 'http://localhost/');
 
     t.is(doc.nodeType, 9);
     t.is(doc.childNodes[0].nodeType, 10);
@@ -44,7 +44,7 @@ test('nodeType', (t) => {
 });
 
 test('nodeValue', (t) => {
-    const doc = createHTMLDocument('<!doctype html><!--comment--><body>text</body>', 'http://localhost/');
+    const doc = createHTMLDocument('<!doctype html><!--comment--><html><body>text</body></html>', 'http://localhost/');
 
     t.is(doc.nodeValue, null);
     t.is(doc.childNodes[0].nodeValue, null);


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Prevent false-positives when processing root elements like `<li>` in
template fragments by assuming and creating expected parent elements
so hints see the most likely fully-realized structure.

- - - - - - - - - - - - - - - - - - - -

Fix #4868