### PR TITLE
Fix: Update return type to abortablePromise in resource loaders

### DIFF
--- a/packages/connector-jsdom/src/evaluate-resource-loader.ts
+++ b/packages/connector-jsdom/src/evaluate-resource-loader.ts
@@ -1,5 +1,5 @@
 import { Requester } from '@hint/utils-connector-tools';
-import { ResourceLoader, FetchOptions } from 'jsdom';
+import { ResourceLoader, FetchOptions, AbortablePromise } from 'jsdom';
 import { NetworkData } from 'hint';
 import { debug as d } from '@hint/utils-debug';
 
@@ -16,13 +16,13 @@ export class EvaluateCustomResourceLoader extends ResourceLoader {
         this._baseUrl = url;
     }
 
-    public async fetch(url: string, options: FetchOptions): Promise<Buffer> {
+    public fetch(url: string, options: FetchOptions): AbortablePromise<Buffer> {
         if (!url) {
             const promise = Promise.resolve(null as any);
 
             (promise as any).abort = () => { };
 
-            return await promise;
+            return promise as AbortablePromise<any>;
         }
 
         const urlAsUrl = new URL(url);
@@ -59,6 +59,6 @@ export class EvaluateCustomResourceLoader extends ResourceLoader {
             abort(error);
         };
 
-        return promise;
+        return promise as AbortablePromise<any>;
     }
 }

--- a/packages/connector-jsdom/src/resource-loader.ts
+++ b/packages/connector-jsdom/src/resource-loader.ts
@@ -6,7 +6,7 @@ import {
 } from '@hint/utils';
 import { getElementByUrl, HTMLDocument } from '@hint/utils-dom';
 import { debug as d } from '@hint/utils-debug';
-import { ResourceLoader, FetchOptions } from 'jsdom';
+import { ResourceLoader, FetchOptions, AbortablePromise } from 'jsdom';
 
 import { FetchEnd, FetchError, NetworkData } from 'hint';
 
@@ -25,14 +25,14 @@ export default class CustomResourceLoader extends ResourceLoader {
         this._HTMLDocument = htmlDocument;
     }
 
-    public async fetch(url: string, options: FetchOptions): Promise<Buffer> {
+    public fetch(url: string, options: FetchOptions): AbortablePromise<Buffer> {
         /* istanbul ignore if */
         if (!url) {
             const promise = Promise.resolve(null as any);
 
             (promise as any).abort = () => { };
 
-            return await promise;
+            return promise as AbortablePromise<any>;
         }
 
         /*
@@ -118,6 +118,6 @@ export default class CustomResourceLoader extends ResourceLoader {
             abort(error);
         };
 
-        return promise;
+        return promise as AbortablePromise<any>;
     }
 }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [ ] Signed the Contributor License Agreement (after creating PR)
- [ ] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

Update some types to address the errors when upgrading @types/jsdom 

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
