### PR TITLE
Fix: Add regex to disable header hints for local files

### DIFF
--- a/packages/hint-http-cache/src/meta.ts
+++ b/packages/hint-http-cache/src/meta.ts
@@ -1,4 +1,5 @@
 import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
+import { rxLocalFile } from '@hint/utils-network/dist/src/rx-local-file';
 import { Category } from '@hint/utils-types';
 import { HintScope } from 'hint/dist/src/lib/enums/hint-scope';
 import { HintMetadata } from 'hint/dist/src/lib/types';
@@ -20,7 +21,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'http-cache',
-    ignoredUrls: [rxLocalhost],
+    ignoredUrls: [rxLocalhost, rxLocalFile],
     schema: [{
         additionalProperties: false,
         definitions: {

--- a/packages/hint-http-compression/src/meta.ts
+++ b/packages/hint-http-compression/src/meta.ts
@@ -1,4 +1,5 @@
 import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
+import { rxLocalFile } from '@hint/utils-network/dist/src/rx-local-file';
 import { Category } from '@hint/utils-types';
 import { HintMetadata, HintScope } from 'hint';
 
@@ -19,7 +20,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'http-compression',
-    ignoredUrls: [rxLocalhost],
+    ignoredUrls: [rxLocalhost, rxLocalFile],
     schema: [{
         additionalProperties: false,
         definitions: {

--- a/packages/hint-https-only/src/meta.ts
+++ b/packages/hint-https-only/src/meta.ts
@@ -1,4 +1,5 @@
 import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
+import { rxLocalFile } from '@hint/utils-network/dist/src/rx-local-file';
 import { Category } from '@hint/utils-types';
 import { HintMetadata, HintScope } from 'hint';
 
@@ -19,7 +20,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'https-only',
-    ignoredUrls: [rxLocalhost],
+    ignoredUrls: [rxLocalhost, rxLocalFile],
     schema: [],
     scope: HintScope.site
 };

--- a/packages/hint-minified-js/src/meta.ts
+++ b/packages/hint-minified-js/src/meta.ts
@@ -1,4 +1,5 @@
 import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
+import { rxLocalFile } from '@hint/utils-network/dist/src/rx-local-file';
 import { Category } from '@hint/utils-types';
 import { HintScope } from 'hint/dist/src/lib/enums/hint-scope';
 import { HintMetadata } from 'hint/dist/src/lib/types';
@@ -20,7 +21,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'minified-js',
-    ignoredUrls: [rxLocalhost],
+    ignoredUrls: [rxLocalhost, rxLocalFile],
     schema: [{
         additionalProperties: false,
         properties: { threshold: { type: 'number' } }

--- a/packages/hint-no-disallowed-headers/src/meta.ts
+++ b/packages/hint-no-disallowed-headers/src/meta.ts
@@ -1,4 +1,5 @@
 import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
+import { rxLocalFile } from '@hint/utils-network/dist/src/rx-local-file';
 import { Category } from '@hint/utils-types';
 import { HintScope } from 'hint/dist/src/lib/enums/hint-scope';
 import { HintMetadata } from 'hint/dist/src/lib/types';
@@ -20,7 +21,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'no-disallowed-headers',
-    ignoredUrls: [rxLocalhost],
+    ignoredUrls: [rxLocalhost, rxLocalFile],
     schema: [{
         additionalProperties: false,
         definitions: {

--- a/packages/hint-performance-budget/src/meta.ts
+++ b/packages/hint-performance-budget/src/meta.ts
@@ -1,4 +1,5 @@
 import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
+import { rxLocalFile } from '@hint/utils-network/dist/src/rx-local-file';
 import { Category } from '@hint/utils-types';
 import { HintMetadata, HintScope } from 'hint';
 
@@ -20,7 +21,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'performance-budget',
-    ignoredUrls: [rxLocalhost],
+    ignoredUrls: [rxLocalhost, rxLocalFile],
     schema: [{
         additionalProperties: false,
         properties: {

--- a/packages/hint-sri/src/meta.ts
+++ b/packages/hint-sri/src/meta.ts
@@ -1,4 +1,5 @@
 import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
+import { rxLocalFile } from '@hint/utils-network/dist/src/rx-local-file';
 import { Category } from '@hint/utils-types';
 import { HintScope } from 'hint/dist/src/lib/enums/hint-scope';
 import { HintMetadata } from 'hint/dist/src/lib/types';
@@ -21,7 +22,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'sri',
-    ignoredUrls: [rxLocalhost],
+    ignoredUrls: [rxLocalhost, rxLocalFile],
     schema: [{
         additionalProperties: false,
         properties: {

--- a/packages/hint-ssllabs/src/meta.ts
+++ b/packages/hint-ssllabs/src/meta.ts
@@ -1,4 +1,5 @@
 import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
+import { rxLocalFile } from '@hint/utils-network/dist/src/rx-local-file';
 import { Category } from '@hint/utils-types';
 import { HintMetadata, HintScope } from 'hint';
 
@@ -19,7 +20,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'ssllabs',
-    ignoredUrls: [rxLocalhost],
+    ignoredUrls: [rxLocalhost, rxLocalFile],
     schema: [{
         additionalProperties: false,
         properties: {

--- a/packages/hint-strict-transport-security/src/meta.ts
+++ b/packages/hint-strict-transport-security/src/meta.ts
@@ -1,4 +1,5 @@
 import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
+import { rxLocalFile } from '@hint/utils-network/dist/src/rx-local-file';
 import { Category } from '@hint/utils-types';
 import { HintMetadata, HintScope } from 'hint';
 
@@ -19,7 +20,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'strict-transport-security',
-    ignoredUrls: [rxLocalhost],
+    ignoredUrls: [rxLocalhost, rxLocalFile],
     schema: [{
         properties: {
             checkPreload: { type: 'boolean' },

--- a/packages/hint-x-content-type-options/src/meta.ts
+++ b/packages/hint-x-content-type-options/src/meta.ts
@@ -1,4 +1,5 @@
 import { rxLocalhost } from '@hint/utils-network/dist/src/rx-localhost';
+import { rxLocalFile } from '@hint/utils-network/dist/src/rx-local-file';
 import { Category } from '@hint/utils-types';
 import { HintScope } from 'hint/dist/src/lib/enums/hint-scope';
 import { HintMetadata } from 'hint/dist/src/lib/types';
@@ -20,7 +21,7 @@ const meta: HintMetadata = {
         return getMessage('name', language);
     },
     id: 'x-content-type-options',
-    ignoredUrls: [rxLocalhost],
+    ignoredUrls: [rxLocalhost, rxLocalFile],
     schema: [],
     scope: HintScope.site
 };

--- a/packages/utils-network/README.md
+++ b/packages/utils-network/README.md
@@ -34,3 +34,4 @@ and lowercase it.
 * `requestAsync`: Convenience wrapper for asynchronously request an URL.
 * `requestJSONAsync`: Request response in the json format from an endpoint.
 * `rxLocalhost`: RegExp to test if a resource points to localhost.
+* `rxLocalFile`: RegExp to test if a resource is loaded from a local file.

--- a/packages/utils-network/src/index.ts
+++ b/packages/utils-network/src/index.ts
@@ -13,3 +13,4 @@ export * from './request-async';
 export * from './request-json-async';
 export * from './rx-localhost';
 export * from './capitalize-header-name';
+export * from './rx-local-file';

--- a/packages/utils-network/src/rx-local-file.ts
+++ b/packages/utils-network/src/rx-local-file.ts
@@ -1,0 +1,4 @@
+/**
+ * RegExp to test if a resource is loaded from a local file.
+ */
+ export const rxLocalFile = /^file:\/\/.*/;

--- a/packages/utils-network/src/rx-local-file.ts
+++ b/packages/utils-network/src/rx-local-file.ts
@@ -1,4 +1,4 @@
 /**
  * RegExp to test if a resource is loaded from a local file.
  */
- export const rxLocalFile = /^file:\/\/.*/;
+export const rxLocalFile = /^file:\/\/.*/;

--- a/packages/utils-network/tests/rx-local-file.ts
+++ b/packages/utils-network/tests/rx-local-file.ts
@@ -1,0 +1,11 @@
+import test from 'ava';
+
+import { rxLocalFile } from '../src';
+
+test('isLocalFile detects local file URLs', (t) => {
+    t.true(rxLocalFile.test('file://C:/users/foo/bar'));
+});
+
+test('isLocalFile ignores public URLs', (t) => {
+    t.false(rxLocalFile.test('http://bing.com/foo/bar'));
+});

--- a/packages/utils-network/tests/rx-local-file.ts
+++ b/packages/utils-network/tests/rx-local-file.ts
@@ -6,6 +6,10 @@ test('isLocalFile detects local file URLs', (t) => {
     t.true(rxLocalFile.test('file://C:/users/foo/bar'));
 });
 
+test('isLocalFile detects local file URLs in UNIX style', (t) => {
+    t.true(rxLocalFile.test('file:///Users/foo/bar'));
+});
+
 test('isLocalFile ignores public URLs', (t) => {
     t.false(rxLocalFile.test('http://bing.com/foo/bar'));
 });


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [ ] Signed the Contributor License Agreement (after creating PR)
- [ ] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
This PR mirrors the changes in https://github.com/webhintio/hint/pull/4234/files in order to disable non applicable hints (like perf and security) for pages loaded from local files.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
