### PR TITLE
Chore: Fix test coverage issue by ensuring one test is headless

### DIFF
--- a/packages/connector-puppeteer/tests/request-response.ts
+++ b/packages/connector-puppeteer/tests/request-response.ts
@@ -48,7 +48,7 @@ test(`[${name}] requestResponse`, async (t) => {
     const engineEmitAsyncSpy = sinon.spy(engine, 'emitAsync');
     const engineEmitSpy = sinon.spy(engine, 'emit');
 
-    const connector: IConnector = new Connector(engine, { detached: true });
+    const connector: IConnector = new Connector(engine, { detached: true, headless: true });
     const server = await Server.create();
 
     const html = Server.updateLocalhost(sourceHtml, server.port);


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
In CI all tests are headless, but locally most run showing the
browser UI. This caused getFavIcon to not be called as it's only
needed when running in headless mode. This in turn caused branch
coverage to be just short of our 80% goal when running locally.

Fixed by ensuring at least one test runs in headless mode even
locally so this branch of code is executed.