### PR TITLE
Fix: Disable typescript-config/import-helpers by default

### DIFF
--- a/packages/configuration-development/index.json
+++ b/packages/configuration-development/index.json
@@ -27,7 +27,6 @@
         "scoped-svg-styles",
         "sri",
         "typescript-config/consistent-casing",
-        "typescript-config/import-helpers",
         "typescript-config/is-valid",
         "typescript-config/strict",
         "typescript-config/target"


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Testing has shown this guidance does not always result in
reduced bundle sizes. Keeping the hint so folks can opt-in
but disabling by default to avoid providing guidance that
does not produce the expected result.

- - - - - - - - - - - - - - - - - - - -

Fix #4526