### PR TITLE
Fix: Avoid changing original snyk-snapshot.json on build

### DIFF
--- a/packages/hint-no-vulnerable-javascript-libraries/package.json
+++ b/packages/hint-no-vulnerable-javascript-libraries/package.json
@@ -67,7 +67,7 @@
   "scripts": {
     "build": "npm run i18n && npm run prebuild && npm-run-all build:*",
     "build-release": "npm run clean && npm run i18n && npm run prebuild && npm run build:assets && tsc --inlineSourceMap false --removeComments true",
-    "build:assets": "copyfiles \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
+    "build:assets": "copyfiles -e \"./src/snyk-snapshot.json\" \"./{src,tests}/**/{!(*.ts),.!(ts)}\" dist",
     "build:ts": "tsc -b",
     "clean": "rimraf dist",
     "i18n": "node ../../scripts/create-i18n.js",

--- a/packages/hint-no-vulnerable-javascript-libraries/scripts/pack-snyk.js
+++ b/packages/hint-no-vulnerable-javascript-libraries/scripts/pack-snyk.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const snykSnapshotPath = require.resolve('../src/snyk-snapshot.json');
-const snyk = require(snykSnapshotPath);
+const snyk = require('../src/snyk-snapshot.json');
 
 /**
  * @typedef { import('../src/types').Vulnerability } Vulnerability
@@ -64,13 +63,20 @@ fs.readFile(require.resolve('js-library-detector'), 'utf8', (err, data) => {
 
     filterSnykData(getDetectablePackages(data), snyk.npm);
 
-    const filename = path.resolve(snykSnapshotPath);
+    const dirname = path.resolve(__dirname, '../dist/src')
+    const filename = path.resolve(dirname, 'snyk-snapshot.json');
 
-    fs.writeFile(filename, JSON.stringify(snyk), (err) => {
+    fs.mkdir(dirname, { recursive: true }, (err) => {
         if (err) {
             throw err;
         }
 
-        console.log(`Created: ${filename} (packed)`);
+        fs.writeFile(filename, JSON.stringify(snyk), (err) => {
+            if (err) {
+                throw err;
+            }
+
+            console.log(`Created: ${filename} (packed)`);
+        });
     });
 });

--- a/packages/hint-no-vulnerable-javascript-libraries/scripts/pack-snyk.js
+++ b/packages/hint-no-vulnerable-javascript-libraries/scripts/pack-snyk.js
@@ -63,7 +63,7 @@ fs.readFile(require.resolve('js-library-detector'), 'utf8', (err, data) => {
 
     filterSnykData(getDetectablePackages(data), snyk.npm);
 
-    const dirname = path.resolve(__dirname, '../dist/src')
+    const dirname = path.resolve(__dirname, '../dist/src');
     const filename = path.resolve(dirname, 'snyk-snapshot.json');
 
     fs.mkdir(dirname, { recursive: true }, (err) => {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Changes the step which prunes the data included in the snapshot
to output directly to the dist folder instead of src folder.
Also updates the copy step to avoid copying the original
snapshot to dist.

This fixes the pruning step from updating the tracked original
file which was resulting in diffs in git (and occasionally made
it into PRs).