### PR TITLE
Chore: Disable axe-core svg-img-alt rule by default

### DIFF
--- a/packages/hint-axe/scripts/create/utils.js
+++ b/packages/hint-axe/scripts/create/utils.js
@@ -5,6 +5,20 @@ const { startCase } = require('lodash');
 /** @typedef {import('axe-core').RuleMetadata} RuleMeta */
 
 /**
+ * Additional rules which are disabled by default.
+ * Typically these are added because the rule doesn't
+ * work correctly in some or all webhint contexts.
+ */
+const disabledRules = new Set([
+    /**
+     * Disabled due to false-positives in jsdom contexts.
+     * Occurs because jsdom reports `display: none` for `<svg><title>`.
+     * See https://github.com/webhintio/hint/issues/5030.
+     */
+    'svg-img-alt'
+]);
+
+/**
  * @param {string} str
  */
 const capitalize = (str) => {
@@ -33,7 +47,7 @@ const escapeKey = (id) => {
  * @param {RuleMeta} rule
  */
 const isRuleDisabled = (rule) => {
-    return rule.tags.includes('experimental') || rule.tags.every((tag) => {
+    return disabledRules.has(rule.ruleId) || rule.tags.includes('experimental') || rule.tags.every((tag) => {
         return !tag.startsWith('wcag');
     });
 };

--- a/packages/hint-axe/tests/text-alternatives.ts
+++ b/packages/hint-axe/tests/text-alternatives.ts
@@ -1,0 +1,21 @@
+import { generateHTMLPage } from '@hint/utils-create-server';
+import { getHintPath, HintTest, testHint } from '@hint/utils-tests-helpers';
+
+const hintPath = getHintPath(__filename, true);
+
+const html = {
+    role: generateHTMLPage(undefined, `
+<div>
+    <h1>test</h1>
+    <svg role="img"><title>test</title></svg>
+</div>`)
+};
+
+const tests: HintTest[] = [
+    {
+        name: `HTML passes an svg with role`,
+        serverConfig: html.role
+    }
+];
+
+testHint(hintPath, tests);


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Disabled due to false positives in jsdom.

- - - - - - - - - - - - - - - - - - - -

Fix #5030 