### PR TITLE
Fix: Ignore internal VS Code files

### DIFF
--- a/packages/extension-vscode/src/server.ts
+++ b/packages/extension-vscode/src/server.ts
@@ -30,6 +30,9 @@ connection.onDidChangeWatchedFiles(async () => {
 
 // Re-validate the document whenever the content changes.
 documents.onDidChangeContent(async (change) => {
+    if (!change.document.uri.startsWith('file://')) {
+        return; // Only analyze local files (e.g. not internal vscode:// files)
+    }
     await analyzer.validateTextDocument(change.document, workspace);
 });
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Fixes an issue with webhint picking up internal VS Code settings and
configuration files, then failing when the URL scheme doesn't appear
local. Since these files shouldn't be analyzed, inputs are now filtered
to only scan URLs explicitly referencing local files (`file://`).

Ref microsoft/vscode-edge-devtools#910