### PR TITLE
Fix: Ensure development configuration is installed

### DIFF
--- a/packages/extension-vscode/src/utils/webhint-packages.ts
+++ b/packages/extension-vscode/src/utils/webhint-packages.ts
@@ -6,7 +6,7 @@ const updateWebhintTimeout = 120000;
 
 /* istanbul ignore next */
 const installWebhint = (options: InstallOptions) => {
-    return installPackages(['hint@latest', 'typescript@latest'], options);
+    return installPackages(['@hint/configuration-development@latest', 'hint@latest', 'typescript@latest'], options);
 };
 
 /**


### PR DESCRIPTION
The `hint` package treats `@hint/configuration-development` as an
optional dependency which means npm can choose to ignore it if there
are issues during install. However, when using the VS Code extension
this configuration is expected to exist, leading to errors in the
extension if it is not present.

Fixed by explicitly requesting the package for this configuration
in addition to `hint` when installing the shared webhint instance.