### PR TITLE
Fix: Add Node enums required by axe-core

### DIFF
--- a/packages/utils-dom/src/cssstyledeclaration.ts
+++ b/packages/utils-dom/src/cssstyledeclaration.ts
@@ -15,6 +15,6 @@ export class CSSStyleDeclaration {
      * https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/getPropertyValue
      */
     public getPropertyValue(name: string) {
-        return this._styles[name];
+        return this._styles[name] || '';
     }
 }

--- a/packages/utils-dom/src/node.ts
+++ b/packages/utils-dom/src/node.ts
@@ -9,6 +9,19 @@ export class Node {
     private _node: NodeData;
 
     /**
+     * https://developer.mozilla.org/docs/Web/API/Node/nodeType
+     */
+    public static ELEMENT_NODE = 1;
+    public static ATTRIBUTE_NODE = 2;
+    public static TEXT_NODE = 3;
+    public static CDATA_SECTION_NODE = 4;
+    public static PROCESSING_INSTRUCTION_NODE = 7;
+    public static COMMENT_NODE = 8;
+    public static DOCUMENT_NODE = 9;
+    public static DOCUMENT_TYPE_NODE = 10;
+    public static DOCUMENT_FRAGMENT_NODE = 11;
+
+    /**
      * https://developer.mozilla.org/docs/Web/API/Node/ownerDocument
      */
     public ownerDocument: HTMLDocument;
@@ -77,17 +90,17 @@ export class Node {
     public get nodeType(): number {
         switch (this._node.type) {
             case 'comment':
-                return 8;
+                return Node.COMMENT_NODE;
             case 'directive':
-                return 10;
+                return Node.DOCUMENT_TYPE_NODE;
             case 'root':
-                return 9;
+                return Node.DOCUMENT_NODE;
             case 'script':
             case 'style':
             case 'tag':
-                return 1;
+                return Node.ELEMENT_NODE;
             case 'text':
-                return 3;
+                return Node.TEXT_NODE;
             /* istanbul ignore next */
             default:
                 throw new Error(`Unrecognized node type ${(this._node as any).type}`);

--- a/packages/utils-dom/tests/axe.ts
+++ b/packages/utils-dom/tests/axe.ts
@@ -31,21 +31,36 @@ const runAxe = async (html: string, rule: string) => {
 };
 
 type TestOptions = {
-    pass: string;
-    fail: string;
+    pass: string | string[];
+    fail: string | string[];
 }
 
 const testAxe = async (t: ExecutionContext, { pass, fail }: TestOptions) => {
     const rule = t.title;
-    const passResults = await runAxe(pass, rule);
-    const failResults = await runAxe(fail, rule);
+    const passTests = Array.isArray(pass) ? pass : [pass];
+    const failTests = Array.isArray(fail) ? fail : [fail];
 
-    t.log(passResults.violations[0]);
-    t.log(failResults);
+    for (const p of passTests) {
+        const results = await runAxe(p, rule);
 
-    t.is(failResults.violations.length, 1);
-    t.is(failResults.violations[0].id, rule);
-    t.is(passResults.violations.length, 0);
+        if (results.violations.length || results.incomplete.length) {
+            t.log(results);
+        }
+
+        t.is(results.violations.length, 0, 'All rules should pass');
+        t.is(results.incomplete.length, 0, 'No rules should be incomplete');
+    }
+
+    for (const f of failTests) {
+        const results = await runAxe(f, rule);
+
+        if (!results.violations.length || results.incomplete.length) {
+            t.log(results);
+        }
+
+        t.is(results.violations.length, 1, 'One rule should fail');
+        t.is(results.violations[0].id, rule, 'No rules should be incomplete');
+    }
 };
 
 test.serial('aria-hidden-focus', async (t) => {
@@ -106,7 +121,10 @@ test.serial('image-alt', async (t) => {
 
 test.serial('label', async (t) => {
     await testAxe(t, {
-        fail: '<label>Name</label><input id="name">',
+        fail: [
+            '<label>Name</label><input id="name">',
+            '<input type="search"><label for="test">Test</label><input id="test">'
+        ],
         pass: '<label for="name">Name</label><input id="name">'
     });
 });

--- a/packages/utils-dom/tests/axe.ts
+++ b/packages/utils-dom/tests/axe.ts
@@ -59,7 +59,8 @@ const testAxe = async (t: ExecutionContext, { pass, fail }: TestOptions) => {
         }
 
         t.is(results.violations.length, 1, 'One rule should fail');
-        t.is(results.violations[0].id, rule, 'No rules should be incomplete');
+        t.is(results.violations[0].id, rule, 'The failed rule id should match the test');
+        t.is(results.incomplete.length, 0, 'No rules should be incomplete');
     }
 };
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Fixes internal axe-core errors in `isVisible` when incorrectly
calling `getAttribute` on a document node. Similarly fixes
axe-core errors calling `match` on the return value of
`getProperty` which needed to be the empty string when
no match exists. Both of these issues were causing results
to be omitted for the `label` rule in certain circumstances.

Also enhances the test helpers to allow passing a list of
tests to validate for each axe-rule (instead of just one pass/fail).