### PR TITLE
Fix: Hide console when updating hint on Windows

### DIFF
--- a/packages/extension-vscode/src/utils/process.ts
+++ b/packages/extension-vscode/src/utils/process.ts
@@ -7,7 +7,7 @@ import { spawn, SpawnOptions } from 'child_process';
 /* istanbul ignore next */
 export const run = (command: string, options?: SpawnOptions) => {
     const parts = command.split(' ');
-    const spawnOptions: SpawnOptions = { stdio: 'inherit', ...options };
+    const spawnOptions: SpawnOptions = { stdio: 'inherit', windowsHide: true, ...options };
     const child = spawn(parts[0], parts.slice(1), spawnOptions);
 
     return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Aligns behavior for updates on Windows with other OSes.

- - - - - - - - - - - - - - - - - - - -

Ref microsoft/vscode-edge-devtools#976