### PR TITLE
Chore: Throttle 'hint' update checks to once a day

### DIFF
--- a/packages/extension-vscode/src/utils/webhint-packages.ts
+++ b/packages/extension-vscode/src/utils/webhint-packages.ts
@@ -1,3 +1,6 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
 import { hasFile, mkdir } from './fs';
 import { createPackageJson, installPackages, loadPackage, InstallOptions } from './packages';
 
@@ -29,7 +32,19 @@ export const updateSharedWebhint = async (globalStoragePath: string) => {
             await createPackageJson(globalStoragePath);
         }
 
+        // Throttle updates to no more than once a day.
+        const lastUpdateFile = path.resolve(`${globalStoragePath}/last-update.txt`);
+        if (await hasFile(lastUpdateFile)) {
+            const lastUpdate = await fs.promises.readFile(lastUpdateFile, { encoding: 'utf-8' });
+            const oneDayInMs = 24 * 60 * 60 * 1000;
+            if (parseInt(lastUpdate) > Date.now() - oneDayInMs) {
+                console.log('Last check for "hint" updates was less than 24 hours ago, skipping');
+                return;
+            }
+        }
+
         await installWebhint({ cwd: globalStoragePath });
+        await fs.promises.writeFile(lastUpdateFile, `${Date.now()}`, { encoding: 'utf-8' });
     } catch (err) {
         console.warn('Unable to install shared webhint instance', err);
     }
@@ -46,11 +61,11 @@ const loadSharedWebhint = async (globalStoragePath: string): Promise<typeof impo
 
         /**
          * The shared package has been loaded successfully but it could be outdated.
-         * The update process kicks off after a few seconds to allow everything to
+         * The update process kicks off after a few minutes to allow everything to
          * get started first.
          */
         setTimeout(() => {
-            console.log(`Updating shared version of "hint"`);
+            console.log(`Checking if shared version of "hint" needs updated`);
 
             updateSharedWebhint(globalStoragePath);
         }, updateWebhintTimeout);

--- a/packages/extension-vscode/src/utils/webhint-packages.ts
+++ b/packages/extension-vscode/src/utils/webhint-packages.ts
@@ -32,13 +32,16 @@ export const updateSharedWebhint = async (globalStoragePath: string) => {
             await createPackageJson(globalStoragePath);
         }
 
-        // Throttle updates to no more than once a day.
         const lastUpdateFile = path.resolve(`${globalStoragePath}/last-update.txt`);
+
+        // Throttle updates to no more than once a day.
         if (await hasFile(lastUpdateFile)) {
             const lastUpdate = await fs.promises.readFile(lastUpdateFile, { encoding: 'utf-8' });
             const oneDayInMs = 24 * 60 * 60 * 1000;
+
             if (parseInt(lastUpdate) > Date.now() - oneDayInMs) {
                 console.log('Last check for "hint" updates was less than 24 hours ago, skipping');
+
                 return;
             }
         }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Writes a timestamp after a successful check for updates.
Validates timestamp is older than 24 hours before checking again.