### PR TITLE
Chore: Remove usage of eval from utils-worker

### DIFF
--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -64,7 +64,6 @@
     "@typescript-eslint/parser": "^4.33.0",
     "assert": "^2.0.0",
     "ava": "^4.0.1",
-    "axe-core": "4.4.1",
     "browserslist": "^4.19.3",
     "copyfiles": "^2.4.1",
     "crypto-browserify": "^3.12.0",

--- a/packages/extension-browser/tests/end-to-end.ts
+++ b/packages/extension-browser/tests/end-to-end.ts
@@ -114,6 +114,10 @@ test('It runs end-to-end in a page', async (t) => {
         console.log('Page Error: ', e);
     });
 
+    page.on('console', (e) => {
+        console.log(e.type(), e.text());
+    });
+
     const resultsPromise = page.evaluate((content: string, url: string) => {
         return new Promise<Results>((resolve) => {
             const listeners: (((events: Events) => void))[] = [];

--- a/packages/extension-browser/webpack.config.js
+++ b/packages/extension-browser/webpack.config.js
@@ -4,6 +4,7 @@ const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = (env) => {
     return {
+        amd: false,
         context: __dirname,
         entry: {
             'background-script': './dist/src/background-script.js',

--- a/packages/extension-browser/webpack.config.js
+++ b/packages/extension-browser/webpack.config.js
@@ -14,11 +14,6 @@ module.exports = (env) => {
         mode: env && env.release ? 'production' : 'none',
         module: {
             rules: [
-                // Bundle `axe-core` as a raw string so it can be injected at runtime.
-                {
-                    test: /axe-core/,
-                    type: 'asset/source'
-                },
                 // Bundle `js-library-detector as a raw string so it can be injected at runtime.
                 {
                     test: /js-library-detector/,
@@ -89,7 +84,6 @@ module.exports = (env) => {
                 './request-async$': path.resolve(__dirname, 'dist/src/shims/request-async.js'),
                 'acorn-jsx$': path.resolve(__dirname, 'dist/src/shims/acorn-jsx.js'),
                 'acorn-jsx-walk$': path.resolve(__dirname, 'dist/src/shims/acorn-jsx-walk.js'),
-                'axe-core': require.resolve('axe-core/axe.min.js'),
                 'file-type': path.resolve(__dirname, 'dist/src/shims/file-type.js'),
                 'is-svg': path.resolve(__dirname, 'dist/src/shims/is-svg.js'),
                 url$: path.resolve(__dirname, 'dist/src/shims/url.js')

--- a/packages/hint-axe/package.json
+++ b/packages/hint-axe/package.json
@@ -9,7 +9,6 @@
     "workerThreads": false
   },
   "dependencies": {
-    "@hint/utils-fs": "^1.0.13",
     "@hint/utils-i18n": "^1.0.12",
     "@hint/utils-types": "^1.1.7",
     "axe-core": "^4.4.1"

--- a/packages/hint-axe/src/util/axe.ts
+++ b/packages/hint-axe/src/util/axe.ts
@@ -143,7 +143,7 @@ const evaluateAxe = async (context: HintContext, event: CanEvaluateScript, rules
             'document.body' :
             'document';
 
-        return await context.evaluate(`(function() {
+        return await context.evaluate(`(function(module) {
             ${source}
             var target = ${target};
             return window.axe.run(target, {
@@ -157,6 +157,8 @@ const evaluateAxe = async (context: HintContext, event: CanEvaluateScript, rules
 
         const err = e as Error;
         let message: string;
+
+        console.error(`Running axe-core failed: ${err.message}\n${err.stack}`);
 
         if (err.message.includes('evaluation exceeded')) {
             message = getMessage('notFastEnough', context.language);

--- a/packages/hint-axe/tsconfig.json
+++ b/packages/hint-axe/tsconfig.json
@@ -16,7 +16,6 @@
         { "path": "../hint" },
         { "path": "../utils-create-server" },
         { "path": "../utils-dom" },
-        { "path": "../utils-fs" },
         { "path": "../utils-i18n" },
         { "path": "../utils-tests-helpers" },
         { "path": "../utils-types" }

--- a/packages/hint/src/lib/types/events.ts
+++ b/packages/hint/src/lib/types/events.ts
@@ -45,7 +45,9 @@ export type FetchStart = Event;
 export type TraverseStart = Event;
 
 /** The object emitted by a connector on `traverse::end` */
-export type TraverseEnd = Event;
+export type TraverseEnd = Event & {
+    document: HTMLDocument;
+};
 
 /** The object emitted by a connector on `traverse::up` */
 export type TraverseUp = Event & {

--- a/packages/utils-dom/src/traverse.ts
+++ b/packages/utils-dom/src/traverse.ts
@@ -36,9 +36,7 @@ const traverseAndNotify = async (element: HTMLElement, document: HTMLDocument, e
 export const traverse = async (document: HTMLDocument, engine: EventEmitter2, resource: string): Promise<void> => {
     const documentElement = document.documentElement;
 
-    const event = { resource };
-
-    await engine.emitAsync('traverse::start', event);
+    await engine.emitAsync('traverse::start', { resource });
     await traverseAndNotify(documentElement, document, engine, resource);
-    await engine.emitAsync('traverse::end', event);
+    await engine.emitAsync('traverse::end', { document, resource });
 };

--- a/packages/utils-fs/src/load-js-file.ts
+++ b/packages/utils-fs/src/load-js-file.ts
@@ -1,11 +1,12 @@
-/* eslint-disable no-eval, no-process-env */
+/* eslint-disable no-process-env */
 /** Loads a JavaScript file. */
 export const loadJSFile = (filePath: string): any => {
     let file;
 
     /* istanbul ignore if */
     if (process.env.webpack) {
-        file = eval(`require("${filePath}")`);
+        // @ts-ignore
+        file = __non_webpack_require__(filePath);
     } else {
         file = require(filePath);
     }

--- a/packages/utils-worker/package.json
+++ b/packages/utils-worker/package.json
@@ -52,7 +52,6 @@
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "ava": "^4.0.1",
-    "axe-core": "^4.4.1",
     "browserslist": "^4.19.3",
     "copyfiles": "^2.4.1",
     "crypto-browserify": "^3.12.0",

--- a/packages/utils-worker/src/connector.ts
+++ b/packages/utils-worker/src/connector.ts
@@ -46,18 +46,10 @@ export default class WebWorkerConnector implements IConnector {
 
                 this._document = new HTMLDocument(snapshot, this._resource, this._originalDocument);
 
+                populateGlobals(self, this._document);
+
                 await traverse(this._document, this._engine, resource);
 
-                /*
-                 * Evaluate after the traversing, just in case something goes wrong
-                 * in any of the evaluation and some scripts are left in the DOM.
-                 */
-                const event = {
-                    document: this._document,
-                    resource
-                };
-
-                await this._engine.emitAsync('can-evaluate::script', event);
                 await this._engine.emitAsync('scan::end', { resource });
 
             } catch (err) /* istanbul ignore next */ {
@@ -127,14 +119,8 @@ export default class WebWorkerConnector implements IConnector {
         });
     }
 
-    public async evaluate(source: string): Promise<any> {
-        if (!this._document) {
-            throw new Error('No execution context is available');
-        }
-
-        populateGlobals(self, this._document);
-
-        return await eval(source); // eslint-disable-line no-eval
+    public evaluate(source: string): Promise<any> {
+        throw new Error('Not implemented');
     }
 
     public querySelectorAll(selector: string): HTMLElement[] {

--- a/packages/utils-worker/webpack.config.js
+++ b/packages/utils-worker/webpack.config.js
@@ -7,15 +7,6 @@ module.exports = (env) => {
         context: __dirname,
         entry: { webhint: './dist/src/webhint.js' },
         mode: env && env.release ? 'production' : 'none',
-        module: {
-            rules: [
-                // Bundle `axe-core` as a raw string so it can be injected at runtime.
-                {
-                    test: /axe-core/,
-                    type: 'asset/source'
-                }
-            ]
-        },
         node: { __dirname: true },
         optimization: {
             minimizer: [
@@ -44,7 +35,6 @@ module.exports = (env) => {
                 './request-async$': path.resolve(__dirname, 'dist/src/shims/request-async.js'),
                 'acorn-jsx$': path.resolve(__dirname, 'dist/src/shims/acorn-jsx.js'),
                 'acorn-jsx-walk$': path.resolve(__dirname, 'dist/src/shims/acorn-jsx-walk.js'),
-                'axe-core': require.resolve('axe-core/axe.min.js'),
                 'file-type': path.resolve(__dirname, 'dist/src/shims/file-type.js'),
                 'is-svg': path.resolve(__dirname, 'dist/src/shims/is-svg.js'),
                 url$: path.resolve(__dirname, 'dist/src/shims/url.js')

--- a/packages/utils/src/packages/load-resource.ts
+++ b/packages/utils/src/packages/load-resource.ts
@@ -130,7 +130,8 @@ const resolvePackage = (modulePath: string): string => {
 
     /* istanbul ignore if */
     if (process.env.webpack) { // eslint-disable-line no-process-env
-        pkgPath = eval(`require.resolve("${modulePath}")`); // eslint-disable-line no-eval
+        // @ts-ignore
+        pkgPath = __non_webpack_require__.resolve(modulePath);
     } else {
         pkgPath = require.resolve(modulePath);
     }

--- a/packages/utils/src/packages/load-resource.ts
+++ b/packages/utils/src/packages/load-resource.ts
@@ -131,7 +131,7 @@ const resolvePackage = (modulePath: string): string => {
     /* istanbul ignore if */
     if (process.env.webpack) { // eslint-disable-line no-process-env
         // @ts-ignore
-        pkgPath = __non_webpack_require__.resolve(modulePath);
+        pkgPath = __non_webpack_require__.resolve(modulePath); // eslint-disable-line camelcase
     } else {
         pkgPath = require.resolve(modulePath);
     }

--- a/packages/utils/src/packages/require-package.ts
+++ b/packages/utils/src/packages/require-package.ts
@@ -5,7 +5,8 @@ export const requirePackage = (modulePath: string): any => {
 
     /* istanbul ignore if */
     if (process.env.webpack) { // eslint-disable-line no-process-env
-        pkg = eval(`require("${modulePath}")`); // eslint-disable-line no-eval
+        // @ts-ignore
+        pkg = __non_webpack_require__(modulePath);
     } else {
         pkg = require(modulePath);
     }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
1. Replace `eval('require')` calls specific to webpack with `__non_webpack_require__`
2. Import `axe-core` directly instead of loading as a string
  a. Continues to allow evaluation in `connector-puppeteer` and similar via `axe.source`
  b. Enables direct execution in `utils-worker` via `axe.run`