### PR TITLE
Fix: Remove reports for Via HTTP Header

### DIFF
--- a/packages/hint-no-disallowed-headers/README.md
+++ b/packages/hint-no-disallowed-headers/README.md
@@ -39,7 +39,6 @@ HTTP headers:
 * `Pragma`
 * `Public-Key-Pins`
 * `Public-Key-Pins-Report-Only`
-* `Via`
 * `X-AspNet-Version`
 * `X-AspNetMvc-version`
 * `X-Frame-Options`

--- a/packages/hint-no-disallowed-headers/src/_locales/en/messages.json
+++ b/packages/hint-no-disallowed-headers/src/_locales/en/messages.json
@@ -27,10 +27,6 @@
         "description": "Report message when the response includes the Pragma header",
         "message": "The 'Pragma' header should not be used, it is deprecated and is a request header only."
     },
-    "disallowedViaHeader": {
-        "description": "Report message when the response includes the Via header",
-        "message": "The 'Via' header should not be used, it is a request header only."
-    },
     "disallowedXFrameOptionsHeader": {
         "description": "Report message when the response includes the X-Frame-Options header",
         "message": "The 'X-Frame-Options' header should not be used. A similar effect, with more consistent support and stronger checks, can be achieved with the 'Content-Security-Policy' header and 'frame-ancestors' directive."

--- a/packages/hint-no-disallowed-headers/src/hint.ts
+++ b/packages/hint-no-disallowed-headers/src/hint.ts
@@ -106,7 +106,6 @@ export default class NoDisallowedHeadersHint implements IHint {
             host: 'disallowedHostHeader',
             p3p: 'disallowedP3PHeader',
             pragma: 'disallowedPragmaHeader',
-            via: 'disallowedViaHeader',
             'x-frame-options': 'disallowedXFrameOptionsHeader'
         };
 

--- a/packages/hint-no-disallowed-headers/tests/tests.ts
+++ b/packages/hint-no-disallowed-headers/tests/tests.ts
@@ -207,10 +207,6 @@ const testForSpecialHeaders: HintTest[] = [
     },
     {
         name: `HTML page is served with disallowed Via header`,
-        reports: [{
-            message: 'The \'Via\' header should not be used, it is a request header only.',
-            severity: Severity.warning
-        }],
         serverConfig: { '/': { headers: { Via: '1.1 varnish, 1.1 squid' } } }
     },
     {
@@ -233,7 +229,6 @@ const testForIgnoredSpecialHeaders: HintTest[] = [
                     Host: 'example.com',
                     P3P: 'cp="this is not a p3p policy"',
                     Pragma: 'no-cache',
-                    Via: '1.1 varnish, 1.1 squid',
                     'X-Frame-Options': 'SAMEORIGIN'
                 }
             }
@@ -259,7 +254,6 @@ testHint(hintPath, testForIgnoredSpecialHeaders, {
             'Host',
             'P3P',
             'Pragma',
-            'Via',
             'X-Frame-Options'
         ]
     }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

This PR removes the Via header from the list of disallowed headers in the `hint-no-disallowed-headers` package. The tests are updated to ensure that including this header does **not** produce any report. The list of disallowed headers is also updated in the README file.

Fixes #5159 

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
