### PR TITLE
Fix: Avoid false positives when using {...spread} in JSX

### DIFF
--- a/packages/hint-axe/package.json
+++ b/packages/hint-axe/package.json
@@ -16,6 +16,8 @@
   },
   "description": "hint that that checks using axe for accessibility related best practices",
   "devDependencies": {
+    "@hint/parser-javascript": "^3.1.17",
+    "@hint/parser-jsx": "^1.0.18",
     "@hint/utils-create-server": "^3.4.17",
     "@hint/utils-dom": "^2.1.12",
     "@hint/utils-tests-helpers": "^6.3.11",

--- a/packages/hint-axe/tests/fixtures/forms.jsx
+++ b/packages/hint-axe/tests/fixtures/forms.jsx
@@ -1,0 +1,4 @@
+
+function Test() {
+    return <input />;
+}

--- a/packages/hint-axe/tests/fixtures/spread.jsx
+++ b/packages/hint-axe/tests/fixtures/spread.jsx
@@ -1,0 +1,4 @@
+
+function Test(props) {
+    return <input {...props}/>;
+}

--- a/packages/hint-axe/tests/forms.ts
+++ b/packages/hint-axe/tests/forms.ts
@@ -1,0 +1,31 @@
+import * as path from 'path';
+import { getHintPath, HintLocalTest, testLocalHint } from '@hint/utils-tests-helpers';
+import { Severity } from '@hint/utils-types';
+
+import { axeCoreVersion } from './_utils';
+
+const hintPath = getHintPath(__filename, true);
+
+const tests: HintLocalTest[] = [
+    {
+        name: `Label is required on form elements`,
+        path: path.join(__dirname, 'fixtures', 'forms.jsx'),
+        reports: [
+            {
+                documentation: [{
+                    link: `https://dequeuniversity.com/rules/axe/${axeCoreVersion}/label?application=axeAPI`,
+                    text: 'Learn more about this axe rule at Deque University'
+                }],
+                message: 'Form elements must have labels: Element has no title attribute Element has no placeholder attribute',
+                position: { match: 'input' },
+                severity: Severity.error
+            }
+        ]
+    },
+    {
+        name: `Label is implied when {...spread} is used`,
+        path: path.join(__dirname, 'fixtures', 'spread.jsx')
+    }
+];
+
+testLocalHint(hintPath, tests, { parsers: ['javascript', 'jsx'] });

--- a/packages/hint-axe/tsconfig.json
+++ b/packages/hint-axe/tsconfig.json
@@ -14,6 +14,8 @@
     ],
     "references": [
         { "path": "../hint" },
+        { "path": "../parser-javascript" },
+        { "path": "../parser-jsx" },
         { "path": "../utils-create-server" },
         { "path": "../utils-dom" },
         { "path": "../utils-fs" },

--- a/packages/hint-button-type/src/hint.ts
+++ b/packages/hint-button-type/src/hint.ts
@@ -51,6 +51,8 @@ export default class ButtonTypeHint implements IHint {
 
             if (element.isAttributeAnExpression('type')) {
                 // Assume template expressions will map to a valid value.
+            } else if (!element.hasAttribute('type') && element.hasAttributeSpread()) {
+                // Assume missing attributes were provided via {...spread}, if present.
             } else if (elementType === null || elementType === '') {
                 const severity = inAForm(element) ?
                     Severity.warning :

--- a/packages/hint-button-type/src/hint.ts
+++ b/packages/hint-button-type/src/hint.ts
@@ -50,10 +50,14 @@ export default class ButtonTypeHint implements IHint {
             const elementType = element.getAttribute('type');
 
             if (element.isAttributeAnExpression('type')) {
-                // Assume template expressions will map to a valid value.
-            } else if (!element.hasAttribute('type') && element.hasAttributeSpread()) {
-                // Assume missing attributes were provided via {...spread}, if present.
-            } else if (elementType === null || elementType === '') {
+                return; // Assume template expressions will map to a valid value.
+            }
+
+            if (!element.hasAttribute('type') && element.hasAttributeSpread()) {
+                return; // Assume missing attributes were provided via {...spread}, if present.
+            }
+
+            if (elementType === null || elementType === '') {
                 const severity = inAForm(element) ?
                     Severity.warning :
                     Severity.hint;

--- a/packages/hint-button-type/tests/tests.ts
+++ b/packages/hint-button-type/tests/tests.ts
@@ -6,9 +6,12 @@ const hintPath = getHintPath(__filename);
 
 const button = {
     buttonWithButtonType: '<button type="button"></button>',
+    buttonWithExpressionType: '<button type="{expression}"></button>',
     buttonWithInvalidButtonType: '<button type="random"></button>',
+    buttonWithInvalidButtonTypeAndSpread: '<button type="random" {...spread}></button>',
     buttonWithoutType: '<button></button>',
     buttonWithoutTypeInForm: '<form><button></button></form',
+    buttonWithSpreadType: '<button {...spread}></button>',
     buttonWithSubmitType: '<button type="submit"></button>'
 };
 
@@ -20,6 +23,14 @@ const tests: HintTest[] = [
     {
         name: 'Button with a valid attribute "type" passes',
         serverConfig: generateHTMLPage('', button.buttonWithButtonType)
+    },
+    {
+        name: 'Button with a type provided as an expression passes',
+        serverConfig: generateHTMLPage('', button.buttonWithExpressionType)
+    },
+    {
+        name: 'Button with type potentially provided via spread passes',
+        serverConfig: generateHTMLPage('', button.buttonWithSpreadType)
     },
     {
         name: `Button without an attribute "type" fails with hint if not in a form`,
@@ -44,6 +55,14 @@ const tests: HintTest[] = [
             severity: Severity.error
         }],
         serverConfig: generateHTMLPage('', button.buttonWithInvalidButtonType)
+    },
+    {
+        name: `Button with an invalid attribute "type" fails even when {...spread} is present`,
+        reports: [{
+            message: `Button type should be 'button', 'reset', or 'submit'.`,
+            severity: Severity.error
+        }],
+        serverConfig: generateHTMLPage('', button.buttonWithInvalidButtonTypeAndSpread)
     }
 ];
 

--- a/packages/parser-jsx/src/parser.ts
+++ b/packages/parser-jsx/src/parser.ts
@@ -31,7 +31,34 @@ const HTML_ELEMENTS_WITH_ONLY_NON_TEXT_CHILDREN = [
     'ul'
 ];
 
+/**
+ * Attributes assumed to be provided by {...spread} if not otherwise specified.
+ * Entries under "*" apply to all elements. Others apply only to specific tags.
+ */
+const EXPECTED_SPREAD_ATTRIBUTES = new Map([
+    ['*', ['title']]
+]);
+
 const debug = d(__filename);
+
+/**
+ * Add attributes we assume to be included in a spread to avoid false-positives.
+ * Most notably this includes "title" to assume a label was provided.
+ *
+ * @param tagName The name of the element being augmented.
+ * @param attribs The attributes collection to augment.
+ */
+const addExpectedSpreadAttributes = (tagName: string, attribs: { [name: string]: string }): void => {
+    const localExpectedAttributes = EXPECTED_SPREAD_ATTRIBUTES.get(tagName) ?? [];
+    const globalExpectedAttributes = EXPECTED_SPREAD_ATTRIBUTES.get('*') ?? [];
+    const expectedAttributes = [...localExpectedAttributes, ...globalExpectedAttributes];
+
+    for (const expectedAttribute of expectedAttributes) {
+        if (!attribs[expectedAttribute]) {
+            attribs[expectedAttribute] = '{expression}';
+        }
+    }
+};
 
 /**
  * Check if the provided `Node` is a native HTML element in JSX.
@@ -95,13 +122,17 @@ const mapAttributeName = (name: string) => {
 /**
  * Translate collections of `JSXAttribute`s to their HTML AST equivalent.
  */
-const mapAttributes = (node: JSXElement) => {
+const mapAttributes = (node: JSXElement, tagName: string) => {
     const attribs: { [name: string]: string } = {};
     const locations: parse5.AttributesLocation = {};
 
+    let hasSpread = false;
+
     for (const attribute of node.openingElement.attributes) {
-        if (attribute.type !== 'JSXAttribute') {
-            continue; // TODO: Do something useful with JSXSpreadAttribute instances.
+        if (attribute.type === 'JSXSpreadAttribute') {
+            attribs['{...spread}'] = '';
+            hasSpread = true;
+            continue;
         }
         /* istanbul ignore if */
         if (attribute.name.type !== 'JSXIdentifier') {
@@ -125,6 +156,10 @@ const mapAttributes = (node: JSXElement) => {
         locations[name] = mapLocation(attribute);
     }
 
+    if (hasSpread) {
+        addExpectedSpreadAttributes(tagName, attribs);
+    }
+
     return {
         attribs,
         attrs: locations,
@@ -143,7 +178,7 @@ const mapElement = (node: JSXElement, childMap: ChildMap): ElementData => {
     }
 
     const { name } = node.openingElement.name;
-    const { attrs, ...attribs } = mapAttributes(node);
+    const { attrs, ...attribs } = mapAttributes(node, name);
     const children = childMap.get(node) || [];
 
     return {
@@ -258,8 +293,10 @@ export default class JSXParser extends Parser<HTMLEvents> {
             const roots: RootMap = new Map();
             const childMap: ChildMap = new Map();
 
+            debugger; // eslint-disable-line
             walk.ancestor(ast, {
                 JSXElement(node, /* istanbul ignore next */ ancestors = []) {
+                    debugger; // eslint-disable-line
                     if (!isNativeElement(node)) {
                         return;
                     }

--- a/packages/parser-jsx/src/parser.ts
+++ b/packages/parser-jsx/src/parser.ts
@@ -293,10 +293,8 @@ export default class JSXParser extends Parser<HTMLEvents> {
             const roots: RootMap = new Map();
             const childMap: ChildMap = new Map();
 
-            debugger; // eslint-disable-line
             walk.ancestor(ast, {
                 JSXElement(node, /* istanbul ignore next */ ancestors = []) {
-                    debugger; // eslint-disable-line
                     if (!isNativeElement(node)) {
                         return;
                     }

--- a/packages/parser-jsx/tests/tests.ts
+++ b/packages/parser-jsx/tests/tests.ts
@@ -96,11 +96,25 @@ test('It serializes attributes', async (t) => {
     t.is(button.outerHTML, '<button type="button">Test</button>');
 });
 
-test('It ignores spread attributes', async (t) => {
-    const { document } = await parseJSX(`const jsx = <button type="button" {...foo}>Test</button>;`);
+test('It replaces spread attributes with a placeholder', async (t) => {
+    const { document } = await parseJSX(`const jsx = <button type="button" title="test" {...foo}>Test</button>;`);
     const button = document.querySelectorAll('button')[0];
 
-    t.is(button.outerHTML, '<button type="button">Test</button>');
+    t.is(button.outerHTML, '<button type="button" title="test" {...spread}="">Test</button>');
+});
+
+test('It synthesizes a title attribute when spread notation is used', async (t) => {
+    const { document } = await parseJSX(`const jsx = <input {...props}/>;`);
+    const button = document.querySelectorAll('input')[0];
+
+    t.is(button.getAttribute('title'), '{expression}');
+});
+
+test('It keeps an existing title attribute when spread notation is used', async (t) => {
+    const { document } = await parseJSX(`const jsx = <input title="Name" {...props}/>;`);
+    const button = document.querySelectorAll('input')[0];
+
+    t.is(button.getAttribute('title'), 'Name');
 });
 
 test('It handles boolean attributes', async (t) => {

--- a/packages/utils-dom/src/htmlelement.ts
+++ b/packages/utils-dom/src/htmlelement.ts
@@ -161,6 +161,15 @@ export class HTMLElement extends Node {
 
     /**
      * Non-standard.
+     * Check if additional attributes were provided via spread notation,
+     * meaning the exact set of provided attributes is unknown.
+     */
+    public hasAttributeSpread(): boolean {
+        return this.hasAttribute('{...spread}');
+    }
+
+    /**
+     * Non-standard.
      * Check if the value of an attribute was provided as a template
      * expression, meaning the exact value of the attribute is unknown.
      */

--- a/packages/utils-dom/tests/htmlelement.ts
+++ b/packages/utils-dom/tests/htmlelement.ts
@@ -65,6 +65,13 @@ test('hasAttributes', (t) => {
     t.false(doc.body.hasAttributes());
 });
 
+test('hasAttributeSpread', (t) => {
+    const doc = createHTMLDocument('<input {...spread}/><input type="text"/>', 'http://localhost/');
+
+    t.true(doc.body.children[0].hasAttributeSpread());
+    t.false(doc.body.children[1].hasAttributeSpread());
+});
+
 test('isAttributeAnExpression', (t) => {
     const doc = createHTMLDocument('<div id={id} class="foo">{value}</div>', 'http://localhost/');
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Introduces a placeholder for `{...spread}` in the transformed HTML along
with a `utils-dom` helper to identify whether additional, unknown attributes
may be present. Uses this helper in `hint-button-type` to avoid triggering
a false-positive.

Also updates JSX-to-HTML conversion to assume a `title` attribute when
`{...spread}` is present if not already set. This ensures a label is provided
for any transformed element with spread, avoiding false-positives in
`hint-axe`.

- - - - - - - - - - - - - - - - - - - -

Fix #5166
Fix microsoft/vscode-edge-devtools/issues/1031