### PR TITLE
Fix: Respect default severity for a11y hints

### DIFF
--- a/packages/configuration-accessibility/index.json
+++ b/packages/configuration-accessibility/index.json
@@ -4,21 +4,21 @@
         "html",
         "summary"
     ],
-    "hints": {
-        "axe/aria": "error",
-        "axe/color": "error",
-        "axe/forms": "error",
-        "axe/keyboard": "error",
-        "axe/language": "error",
-        "axe/name-role-value": "error",
-        "axe/parsing": "error",
-        "axe/semantics": "error",
-        "axe/sensory-and-visual-cues": "error",
-        "axe/structure": "error",
-        "axe/tables": "error",
-        "axe/text-alternatives": "error",
-        "axe/time-and-media": "error"
-    },
+    "hints": [
+        "axe/aria",
+        "axe/color",
+        "axe/forms",
+        "axe/keyboard",
+        "axe/language",
+        "axe/name-role-value",
+        "axe/parsing",
+        "axe/semantics",
+        "axe/sensory-and-visual-cues",
+        "axe/structure",
+        "axe/tables",
+        "axe/text-alternatives",
+        "axe/time-and-media"
+    ],
     "hintsTimeout": 120000,
     "parsers": []
 }

--- a/packages/hint-axe/scripts/create/create-config.js
+++ b/packages/hint-axe/scripts/create/create-config.js
@@ -10,12 +10,12 @@ const createConfig = async (categories) => {
     const filename = '../configuration-accessibility/index.json';
     const configPackage = JSON.parse(await readFile(filename));
 
-    configPackage.hints = {};
+    configPackage.hints = [];
 
     for (const category of categories) {
         const id = `axe/${categoryId(category)}`;
 
-        configPackage.hints[id] = 'error';
+        configPackage.hints.push(id);
     }
 
     const json = JSON.stringify(configPackage, null, 4);


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Align the format of `configuration-accessibility` with other webhint default
configurations. Specifically this updates the configuration to avoid specifying
an explicit severity, allowing the severity to be determined per-report based
on the underlying `axe-core` impact.