### PR TITLE
Fix: Allow Node.js style resolution in config 

### DIFF
--- a/packages/utils-json/src/export-require.ts
+++ b/packages/utils-json/src/export-require.ts
@@ -1,0 +1,5 @@
+// This file exists so that functions using require.resolve can
+// stub it
+const importedRequire = require;
+
+export { importedRequire };

--- a/packages/utils-json/src/types.ts
+++ b/packages/utils-json/src/types.ts
@@ -40,6 +40,10 @@ export type ExtendableConfiguration = {
     extends?: string;
 };
 
+export interface IFilePathError extends Error {
+    code: string;
+}
+
 export interface IParsingError extends Error {
     resource: string;
 }

--- a/packages/utils-json/tests/final-config.ts
+++ b/packages/utils-json/tests/final-config.ts
@@ -2,26 +2,29 @@ import anyTest, { TestFn, ExecutionContext } from 'ava';
 import * as sinon from 'sinon';
 import * as proxyquire from 'proxyquire';
 
-import { IParsingError } from '../src/types';
+import { IParsingError, IFilePathError } from '../src/types';
+
+const baseConfig = {
+    compilerOptions: {
+        noImplicitAny: true,
+        strictNullChecks: true
+    }
+};
+
 
 type FileModule = {
     extends: string | null;
     name: string;
 };
 
-type LoadJSONFileModule = () => FileModule | null;
+type LoadJSONFileModule = () => FileModule | typeof baseConfig | null;
 
 type AsPathString = () => string;
-
-type Path = {
-    dirname: () => string;
-    resolve: () => string;
-};
 
 type ParserContext = {
     asPathString: AsPathString;
     loadJSONFileModule: LoadJSONFileModule;
-    path: Path;
+    resolve: () => string;
     sandbox: sinon.SinonSandbox;
 };
 
@@ -38,25 +41,20 @@ const initContext = (t: ExecutionContext<ParserContext>) => {
         return '';
     };
 
-    t.context.path = {
-        dirname(): string {
-            return '';
-        },
-        resolve(): string {
-            return '';
-        }
+    t.context.resolve = (): string => {
+        return '';
     };
     t.context.sandbox = sinon.createSandbox();
 };
 
 const loadScript = (context: ParserContext) => {
     const script: typeof import('../src/final-config') = proxyquire('../src/final-config', {
+        './export-require': { importedRequire: { resolve: context.resolve }},
         '@hint/utils-fs': { loadJSONFile: context.loadJSONFileModule },
         '@hint/utils-network': {
             asPathString: context.asPathString,
             asUri
-        },
-        path: context.path
+        }
     });
 
     return script.finalConfig;
@@ -81,7 +79,7 @@ test('If there is a circular reference, it should return an instance of an Error
     const sandbox = t.context.sandbox;
 
     sandbox.stub(t.context, 'asPathString').returns('circularReference');
-    sandbox.stub(t.context.path, 'resolve').returns('circularReference');
+    sandbox.stub(t.context, 'resolve').returns('circularReference');
 
     const finalConfig = loadScript(t.context);
     const config = { extends: 'circularReference' };
@@ -92,11 +90,11 @@ test('If there is a circular reference, it should return an instance of an Error
     t.is(result.message, 'Circular reference found in file circularReference');
 });
 
-test('If one of the extended files is no a valid JSON, it should return an instance of an Error', (t) => {
+test('If one of the extended files is not a valid JSON, it should return an instance of an Error', (t) => {
     const sandbox = t.context.sandbox;
 
     sandbox.stub(t.context, 'asPathString').returns('valid-with-invalid-extends');
-    sandbox.stub(t.context.path, 'resolve').returns('invalid-extends');
+    sandbox.stub(t.context, 'resolve').returns('invalid-extends');
     sandbox.stub(t.context, 'loadJSONFileModule').throws(new Error('InvalidJSON'));
 
     const finalConfig = loadScript(t.context);
@@ -108,11 +106,63 @@ test('If one of the extended files is no a valid JSON, it should return an insta
     t.true(result instanceof Error);
 });
 
+test(`If one of the extended files is not a valid JSON location, it should return a MODULE_NOT_FOUND error`, (t) => {
+    const customError = new Error('customError') as IFilePathError;
+
+    customError.code = 'MODULE_NOT_FOUND';
+
+    const sandbox = t.context.sandbox;
+    const config = { extends: '@tsconfig/strictest/tsconfig.json' };
+
+    sandbox.stub(t.context, 'resolve').throws(customError);
+    const finalConfig = loadScript(t.context);
+    const result = finalConfig(config, 'resource');
+
+    t.true(result && (result as IFilePathError).code === 'MODULE_NOT_FOUND');
+});
+
+test(`If one of the extended files is a JSON module, it should inherit from it`, (t) => {
+    const userPath = '/home/user/packages/utils-json/node_modules/@tsconfig/strictest/tsconfig.json';
+    const sandbox = t.context.sandbox;
+
+    sandbox.stub(t.context, 'resolve').returns(userPath);
+    sandbox.stub(t.context, 'loadJSONFileModule').returns(baseConfig);
+
+    const finalConfig = loadScript(t.context);
+
+    const config = { extends: '@tsconfig/strictest/tsconfig.json' };
+
+    const result = finalConfig(config, 'resource');
+
+    t.true(typeof result === typeof baseConfig);
+    t.true((result as unknown as typeof baseConfig).compilerOptions.noImplicitAny ===
+        baseConfig.compilerOptions.noImplicitAny);
+});
+
+test(`If one of the extended files is a JSON module, it should merge both properties`, (t) => {
+    const userPath = '/home/user/packages/utils-json/node_modules/@tsconfig/strictest/tsconfig.json';
+    const sandbox = t.context.sandbox;
+
+    sandbox.stub(t.context, 'resolve').returns(userPath);
+    sandbox.stub(t.context, 'loadJSONFileModule').returns(baseConfig);
+
+    const finalConfig = loadScript(t.context);
+
+    const config = {
+        checkJs: true,
+        extends: '@tsconfig/strictest/tsconfig.json'
+    };
+
+    const result = finalConfig(config, 'resource');
+
+    t.true((result as any).checkJs);
+});
+
 test('If everything is ok, it should merge all the extended configurations', (t) => {
     const sandbox = t.context.sandbox;
 
     sandbox.stub(t.context, 'asPathString').returns('valid-with-extends');
-    sandbox.stub(t.context.path, 'resolve')
+    sandbox.stub(t.context, 'resolve')
         .onFirstCall()
         .returns('valid-extends')
         .onSecondCall()


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [ ] Signed the Contributor License Agreement (after creating PR)
- [ ] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

Fix behavior in final-config where path resolution was done by
using path.resolve instead of require.resolve. This allows NodeJS
fallback behavior when searching for a module
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #5169

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
