### PR TITLE
Fix: Updates extra-data to match the latest mdn. (with tests)

### DIFF
--- a/packages/connector-puppeteer/tests/basic.ts
+++ b/packages/connector-puppeteer/tests/basic.ts
@@ -1,0 +1,79 @@
+/* eslint-disable no-sync */
+
+import { URL } from 'url';
+
+import * as sinon from 'sinon';
+import anyTest, { TestFn, ExecutionContext } from 'ava';
+
+import { generateHTMLPage, Server, ServerConfiguration } from '@hint/utils-create-server';
+import { Engine, Events, IConnector, IConnectorConstructor } from 'hint';
+
+import Connector from '../src/connector';
+
+const name = 'puppeteer';
+
+type Context = {
+    engine: Engine<Events>;
+    engineEmitSpy: sinon.SinonSpy<any, boolean>;
+    engineEmitAsyncSpy: sinon.SinonSpy<any, any>;
+};
+
+const test = anyTest as TestFn<Context>;
+
+test.beforeEach((t) => {
+    const engine: Engine<Events> = {
+        emit(): boolean {
+            return false;
+        },
+        async emitAsync(): Promise<any> { },
+        on(): Engine {
+            return null as any;
+        }
+    } as any;
+
+    t.context.engineEmitSpy = sinon.spy(engine, 'emit');
+    t.context.engineEmitAsyncSpy = sinon.spy(engine, 'emitAsync');
+
+    t.context.engine = engine;
+});
+
+test.afterEach.always((t) => {
+    t.context.engineEmitSpy.restore();
+    t.context.engineEmitAsyncSpy.restore();
+});
+
+const validateTest = async (t: ExecutionContext<Context>, Connector: IConnectorConstructor, serverConfig: ServerConfiguration, validateFunction: (connector: IConnector) => void) => {
+    const server = await Server.create({ configuration: serverConfig });
+    const { engine } = t.context;
+    const connector = new Connector(engine, { detached: true });
+
+    await connector.collect(new URL(`http://localhost:${server.port}/`));
+    validateFunction(connector);
+    await Promise.all([connector.close(), server.stop()]);
+
+    return server;
+};
+
+test(`[${name}] Connector dom getter is returning a value`, async (t) => {
+    const serverConfig: ServerConfiguration = { '/': generateHTMLPage(`<title>Test</title>`) };
+
+    const functionToValidate = (connector: IConnector) => {
+        t.not(connector.dom, undefined);
+    };
+
+    await validateTest(t, Connector, serverConfig, functionToValidate);
+
+    t.is(t.context.engineEmitAsyncSpy.withArgs('fetch::end::html').callCount, 1);
+});
+
+test(`[${name}] Connector html getter is returning a value`, async (t) => {
+    const serverConfig: ServerConfiguration = { '/': generateHTMLPage(`<title>Test</title>`) };
+
+    const functionToValidate = (connector: IConnector) => {
+        t.not(connector.html, undefined);
+    };
+
+    await validateTest(t, Connector, serverConfig, functionToValidate);
+
+    t.is(t.context.engineEmitAsyncSpy.withArgs('fetch::end::html').callCount, 1);
+});

--- a/packages/connector-puppeteer/tests/fixtures/basic.js
+++ b/packages/connector-puppeteer/tests/fixtures/basic.js
@@ -1,0 +1,3 @@
+module.exports = {
+  action: () => { }
+};

--- a/packages/utils-compat-data/scripts/extra-data.js
+++ b/packages/utils-compat-data/scripts/extra-data.js
@@ -35,10 +35,12 @@ const extraData = {
         },
         types: {
             color: {
-                alpha_hexadecimal_notation: {
-                    __compat: {
-                        match: {
-                            regex_token: '^#[0-9a-fA-F]{4}(?:[0-9a-fA-F]{4})?$'
+                rgb_hexadecimal_notation:{
+                    alpha_hexadecimal_notation: {
+                        __compat: {
+                            match: {
+                                regex_token: '^#[0-9a-fA-F]{4}(?:[0-9a-fA-F]{4})?$'
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [ ] Signed the Contributor License Agreement (after creating PR)
- [ ] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
The latest yarn.lock update brought mdn.css.types.color to the latest shape:
https://github.com/mdn/browser-compat-data/commit/04c35fdc59a052cb8580c6739408678d742eb6be

This PR updates extra-data.js to the match the latest shape.

It also add an unrelated test as it is now failing the test coverage threshold which prevents check in.
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
