### PR TITLE
Fix: Off-by-one issue with JSX column locations

### DIFF
--- a/packages/parser-jsx/src/parser.ts
+++ b/packages/parser-jsx/src/parser.ts
@@ -92,13 +92,13 @@ const isAttributeOrNativeElement = (node: Node) => {
 /**
  * Translate JS AST locations to HTML AST locations.
  */
-const mapLocation = (node: Node, { startColumnOffset = 0 } = {}): parse5.Location => {
+const mapLocation = (node: Node): parse5.Location => {
     // TODO: Remove `columnOffset` once `Problem` supports a range.
     return {
-        endCol: node.loc && (node.loc.end.column) || -1,
+        endCol: node.loc && (node.loc.end.column + 1) || -1,
         endLine: node.loc && node.loc.end.line || -1,
         endOffset: node.range && node.range[1] || -1,
-        startCol: node.loc && (node.loc.start.column + startColumnOffset) || -1,
+        startCol: node.loc && (node.loc.start.column + 1) || -1,
         startLine: node.loc && node.loc.start.line || -1,
         startOffset: node.range && node.range[0] || -1
     };
@@ -193,9 +193,9 @@ const mapElement = (node: JSXElement, childMap: ChildMap): ElementData => {
             endTag: node.closingElement ? mapLocation(node.closingElement) : undefined as any, // TODO: Fix types to allow undefined (matches parse5 behavior)
             startTag: {
                 attrs,
-                ...mapLocation(node.openingElement, { startColumnOffset: 1 })
+                ...mapLocation(node.openingElement)
             },
-            ...mapLocation(node, { startColumnOffset: 1 })
+            ...mapLocation(node)
         },
         type: 'tag'
     };


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Lines are 1-based in the JS AST, but columns are 0-based.
We need both to be 1-based in the parse5 HTML AST, this
was already special-cased for the start tag, but needed to be
applied for all column positions.