### PR TITLE
Fix: Adjust fix locations for embedded languages, e.g. CSS in HTML

### DIFF
--- a/packages/hint-css-prefix-order/tests/fixtures/prefixes-last-webkit.fixed.html
+++ b/packages/hint-css-prefix-order/tests/fixtures/prefixes-last-webkit.fixed.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+    <head>
+        <style>
+            .example {
+                -webkit-appearance: none;
+                -moz-appearance: none;
+                appearance: none;
+            }
+        </style>
+    </head>
+</html>

--- a/packages/hint-css-prefix-order/tests/tests.ts
+++ b/packages/hint-css-prefix-order/tests/tests.ts
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 import { generateHTMLPage } from '@hint/utils-create-server';
 import { getHintPath, HintTest, testHint } from '@hint/utils-tests-helpers';
 import { readFile } from '@hint/utils-fs';
@@ -34,7 +36,9 @@ const generateConfig = (fileName: string) => {
 };
 
 const getFixedContent = (fileName: string): string => {
-    return readFile(`${__dirname}/fixtures/${fileName}.fixed.css`);
+    const {name, ext} = path.parse(fileName);
+
+    return readFile(`${__dirname}/fixtures/${name}.fixed${ext || '.css'}`);
 };
 
 const tests: HintTest[] = [
@@ -177,6 +181,7 @@ const tests: HintTest[] = [
     {
         name: 'Prefixed properties listed last fail in HTML (webkit)',
         reports: [{
+            fixes: { match: getFixedContent('prefixes-last-webkit.html') },
             message: `'appearance' should be listed after '-webkit-appearance'.`,
             position: {
                 column: 16,

--- a/packages/utils-dom/src/htmlelement.ts
+++ b/packages/utils-dom/src/htmlelement.ts
@@ -265,6 +265,8 @@ export class HTMLElement extends Node {
         if (offset.line === 0) {
             return {
                 column: column + offset.column,
+                endColumn: offset.endColumn && (offset.endLine === 0 ? column + offset.endColumn : offset.endColumn),
+                endLine: offset.endLine && (line + offset.endLine),
                 line
             };
         }
@@ -272,6 +274,8 @@ export class HTMLElement extends Node {
         // Otherwise adjust just the resulting line.
         return {
             column: offset.column,
+            endColumn: offset.endColumn,
+            endLine: offset.endLine && (line + offset.endLine),
             line: line + offset.line
         };
     }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Updates `context.report` to adjust any provided `fixes` by the location
of the provided `element` if the `codeLanguage` is anything other
than `html` (meaning it is embedded).

Also fixes `element.getContentLocation` to include adjusting the
end location of the provided offset (if present) to ensure the full
range is adjusted and not just the start.

Lastly adds a new test case for `hint-css-prefix-order` to verify
fixes are applied correctly for CSS in HTML.