### PR TITLE
Build: Adding Microsoft Security DevOps to pipelines

### DIFF
--- a/.github/workflows/msdo.yml
+++ b/.github/workflows/msdo.yml
@@ -1,0 +1,26 @@
+name: Microsoft Security DevOps
+# https://github.com/microsoft/security-devops-action
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  RunScan:
+    # Note: Currently only windows-latest vms are supported.
+    # https://github.com/microsoft/security-devops-action#limitations
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run Microsoft Security DevOps
+        uses: microsoft/security-devops-action@preview
+        id: msdo
+
+      - name: Upload results to Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: ${{ steps.msdo.outputs.sarifFile }}

--- a/.github/workflows/msdo.yml
+++ b/.github/workflows/msdo.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Run Microsoft Security DevOps
         uses: microsoft/security-devops-action@preview
         id: msdo
+        with:
+          tools: eslint
 
       - name: Upload results to Security tab
         uses: github/codeql-action/upload-sarif@v1


### PR DESCRIPTION
## Pull request checklist
Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

The goal is to implement Microsoft Security DevOps action for enhanced security analysis of the webhint codebase. This will help make webhint and webhint users more secure. 

Reopen of #5177