### PR TITLE
Fix: Fixes an issue were dist folder was being ignored in extension-vscode.

### DIFF
--- a/packages/extension-vscode/.npmignore
+++ b/packages/extension-vscode/.npmignore
@@ -1,0 +1,2 @@
+!dist
+dist/tests

--- a/packages/extension-vscode/src/quickfix-provider.ts
+++ b/packages/extension-vscode/src/quickfix-provider.ts
@@ -78,7 +78,6 @@ export class QuickFixActionProvider {
          * TODO: link to diagnostic once https://github.com/microsoft/vscode/issues/126393 is fixed
          * action.diagnostics = [diagnostic];
          */
-
         return action;
     }
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [ x] Signed the Contributor License Agreement (after creating PR)
- [ x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ x] Added/Updated related documentation.
- [x ] Added/Updated related tests.

## Short description of the change(s)
Latest `npm` extension-vscode package does not include the dist folder which breaks the extension. 
This seems to be caused by the `.gitignore` on the upper level folder, solution is to create a `.npmignore `
which overrides `.gitignore` configuration when publishing on `npm`

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
