### PR TITLE
Fix: Axe-core throws errors with local iframes

### DIFF
--- a/packages/hint-axe/package.json
+++ b/packages/hint-axe/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hint/utils-i18n": "^1.0.13",
+    "@hint/utils-network": "^1.0.21",
     "@hint/utils-types": "^1.2.0",
     "axe-core": "^4.4.1"
   },

--- a/packages/hint-axe/src/util/axe.ts
+++ b/packages/hint-axe/src/util/axe.ts
@@ -145,12 +145,8 @@ const evaluateAxe = async (context: HintContext, event: CanEvaluateScript, rules
      * This is caused by an axe-core bug which is currently tracked here:
      * https://github.com/dequelabs/axe-core/issues/3002
      */
-    let shouldScanIframes = true;
     const uri = getAsUri(resource);
-
-    if (uri && uri.protocol.includes('file')) {
-        shouldScanIframes = false;
-    }
+    const shouldScanIframes = !(uri && uri.protocol.includes('file'));
 
     /* istanbul ignore next */
     try {

--- a/packages/hint-axe/tests/fixtures/local-default-iframe.html
+++ b/packages/hint-axe/tests/fixtures/local-default-iframe.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang='en'>
+<body>
+    <div>
+        <div>
+            <span>iframe: default-src CSP</span>
+            <iframe marginwidth="0"
+            title="iframe: default-src CSP"
+            marginheight="0"
+            hspace="0"
+            vspace="0"
+            frameborder="10"
+            scrolling="no" src="http://bing.com"></iframe>
+        </div>
+    </div>
+</body>
+</html>

--- a/packages/hint-axe/tests/language.ts
+++ b/packages/hint-axe/tests/language.ts
@@ -1,5 +1,6 @@
+import * as path from 'path';
 import { generateHTMLPage } from '@hint/utils-create-server';
-import { getHintPath, HintTest, testHint } from '@hint/utils-tests-helpers';
+import { getHintPath, HintTest, HintLocalTest, testHint, testLocalHint } from '@hint/utils-tests-helpers';
 import { Severity } from '@hint/utils-types';
 
 import { axeCoreVersion } from './_utils';
@@ -55,5 +56,13 @@ const testsWithCustomConfiguration: HintTest[] = [
     }
 ];
 
+const localConnectorDefaultCspIframe: HintLocalTest[] = [
+    {
+        name: `A local html file with iframes should not throw exceptions`,
+        path: path.join(__dirname, 'fixtures', 'local-default-iframe.html')
+    }
+];
+
 testHint(hintPath, tests);
 testHint(hintPath, testsWithCustomConfiguration, { hintOptions: { 'html-has-lang': 'off' } });
+testLocalHint(hintPath, localConnectorDefaultCspIframe, { parsers: ['html'] });

--- a/packages/hint-axe/tsconfig.json
+++ b/packages/hint-axe/tsconfig.json
@@ -19,6 +19,7 @@
         { "path": "../utils-create-server" },
         { "path": "../utils-dom" },
         { "path": "../utils-i18n" },
+        { "path": "../utils-network" },
         { "path": "../utils-tests-helpers" },
         { "path": "../utils-types" }
     ]

--- a/packages/utils-worker/package.json
+++ b/packages/utils-worker/package.json
@@ -10,7 +10,7 @@
     "timeout": "1m",
     "workerThreads": false
   },
-  "bundleSize": 2600000,
+  "bundleSize": 2560000,
   "description": "webhint web worker",
   "devDependencies": {
     "@hint/hint-axe": "^4.4.15",

--- a/packages/utils-worker/package.json
+++ b/packages/utils-worker/package.json
@@ -10,7 +10,7 @@
     "timeout": "1m",
     "workerThreads": false
   },
-  "bundleSize": 2550000,
+  "bundleSize": 2600000,
   "description": "webhint web worker",
   "devDependencies": {
     "@hint/hint-axe": "^4.4.15",


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [X] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [X] Added/Updated related documentation.
- [X] Added/Updated related tests.

## Short description of the change(s)
Fixes an issue where axe-core throws:
`allowedOrigins value "null" is not a valid origin`

This is due to a axe-core throwing an error instead of finishing the analysis, this is currently an open bug in dequelabs:
`dequelabs/axe-core`
`issue: 3002`

This only manifests under the following conditions:
- local `html` files only
- file has iframes
- the iframes have the `Default` CSP
- The exception gets bubbled and eventually crashes `webhint`. To avoid this the proposed fix is to not scan `iframes` for local `html` files.
-----
Fix #5285

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
