### PR TITLE
Fix: Requester breaking when mixing http and https

### DIFF
--- a/packages/utils-connector-tools/src/requester.ts
+++ b/packages/utils-connector-tools/src/requester.ts
@@ -249,6 +249,8 @@ export class Requester {
                         isHTTPS = true;
                     }
 
+                    let agent;
+
                     if (this._options.strictSSL || isHTTPS) {
                         let httpsAgentOptions;
 
@@ -259,10 +261,10 @@ export class Requester {
 
                         const httpsAgent = new https.Agent(httpsAgentOptions);
 
-                        this._options.agent = httpsAgent;
+                        agent = httpsAgent;
                     }
 
-                    const response = await fetch(uriString, this._options);
+                    const response = await fetch(uriString, {...this._options, agent});
 
                     rawBodyResponse = await response.buffer();
 


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [ ] Signed the Contributor License Agreement (after creating PR)
- [ ] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

Currently once the requester encounters an https request, it expects all future requests to be https, as well.  If it's asked to fetch an http URL after having fetched an https url, it fails with an error.

It proved problematic when testing a site that's hosted on http but links to https sites. The `no-broken-links` rule was throwing "Broken link found (domain not found)" errors for links that work perfectly fine.
