### PR TITLE
Fix: Re-adding elementId to location(hint-context)

### DIFF
--- a/packages/hint/src/lib/hint-context.ts
+++ b/packages/hint/src/lib/hint-context.ts
@@ -149,20 +149,20 @@ export class HintContext<E extends Events = Events> {
     /** Finds the approximative location in the page's HTML for a match in an element. */
     public findProblemLocation(element: HTMLElement, offset: ProblemLocation | null, attribute?: string): ProblemLocation | null {
         if (attribute) {
-            const { column, line, startOffset } = element.getAttributeLocation(attribute);
+            const { column, elementId, line, startOffset } = element.getAttributeLocation(attribute);
 
             // Point to the just start of the attribute name (helps editors underline just the name).
-            return { column, line, startOffset };
+            return { column, elementId, line, startOffset };
         }
 
         if (offset) {
             return element.getContentLocation(offset);
         }
 
-        const { column, line, startOffset } = element.getLocation();
+        const { column, elementId, line, startOffset } = element.getLocation();
 
         // Point to the start of the element name (skipping '<', helps editors undeline just the name).
-        return { column: column + 1, line, startOffset };
+        return { column: column + 1, elementId, line, startOffset };
     }
 
     /** Reports a problem with the resource. */

--- a/packages/hint/src/lib/hint-context.ts
+++ b/packages/hint/src/lib/hint-context.ts
@@ -149,10 +149,10 @@ export class HintContext<E extends Events = Events> {
     /** Finds the approximative location in the page's HTML for a match in an element. */
     public findProblemLocation(element: HTMLElement, offset: ProblemLocation | null, attribute?: string): ProblemLocation | null {
         if (attribute) {
-            const { column, elementId, line, startOffset } = element.getAttributeLocation(attribute);
+            const { column, line, startOffset } = element.getAttributeLocation(attribute);
 
             // Point to the just start of the attribute name (helps editors underline just the name).
-            return { column, elementId, line, startOffset };
+            return { column, line, startOffset };
         }
 
         if (offset) {

--- a/packages/utils-dom/src/htmlelement.ts
+++ b/packages/utils-dom/src/htmlelement.ts
@@ -218,6 +218,7 @@ export class HTMLElement extends Node {
 
         return {
             column: location ? location.startCol - 1 : -1,
+            elementId: this._element.id,
             endColumn: location ? location.endCol - 1 : -1,
             endLine: location ? location.endLine - 1 : -1,
             endOffset: location ? location.endOffset : -1,

--- a/packages/utils-dom/src/htmlelement.ts
+++ b/packages/utils-dom/src/htmlelement.ts
@@ -218,7 +218,6 @@ export class HTMLElement extends Node {
 
         return {
             column: location ? location.startCol - 1 : -1,
-            elementId: this._element.id,
             endColumn: location ? location.endCol - 1 : -1,
             endLine: location ? location.endLine - 1 : -1,
             endOffset: location ? location.endOffset : -1,

--- a/packages/utils-worker/tests/integration.ts
+++ b/packages/utils-worker/tests/integration.ts
@@ -82,3 +82,18 @@ test('It allows disabling hints by default', async (t) => {
     // Validate `compat-api/html` was configured
     t.is(compatHtmlResults.length, 1);
 });
+
+test.only('Reported problems should have an elementId', async (t) => {
+    const data = { html: await readFile('fixtures/basic-hints.html') };
+    const results = await getResults({
+        defaultHintSeverity: 'off',
+        userConfig: {
+            hints: { 'compat-api/html': 'default' },
+            language: 'en-us'
+        }
+    }, data, t.log);
+
+    for (const problem of results.problems) {
+        t.not(problem.location.elementId, undefined);
+    }
+});


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)
Pull request #5261 inadvertently removed the `elementId` from the returned location returned by `findProblemLocation`. This PR reintroduces it.

<!--
If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
