### PR TITLE
Chore: Test for regressed broken-links-package.

### DIFF
--- a/packages/hint-no-broken-links/tests/tests.ts
+++ b/packages/hint-no-broken-links/tests/tests.ts
@@ -323,4 +323,15 @@ const tests: HintTest[] = [
     }
 ];
 
+const httpTests: HintTest[] = [
+    {
+        name: `This test should pass as it has valid links (hosted on http to https links) `,
+        serverConfig: {
+            '/': { content: generateHTMLPage('', bodyWithValidLinks) },
+            '/about': { content: 'My about page content' }
+        }
+    }
+];
+
+testHint(hintPath, httpTests, {https: false});
 testHint(hintPath, tests, {https: true});


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the Contributor License Agreement (after creating PR)
- [X] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [X] Added/Updated related documentation.
- [X] Added/Updated related tests.

## Short description of the change(s)
PR #5317 provided a fix for a broken behavior on`broken-links-package`: 
- A `http` behavior with valid `https` links was being marked as as a `broken-link`. 

This PR provides a test to avoid regressing the behavior in the future.
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
