### PR TITLE
Update: bump the manifest version to v3

### DIFF
--- a/packages/extension-browser/src/manifest.json
+++ b/packages/extension-browser/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "author": "webhint",
   "background": {
-    "scripts": [
+    "service_worker": [
       "background-script.js"
     ],
     "persistent": false
@@ -9,14 +9,14 @@
   "icons": {
     "180": "icon.png"
   },
-  "browser_action": {
+  "action": {
       "default_title": "webhint",
       "default_popup": "browser-action/browser-action.html"
   },
   "default_locale": "en",
   "description": "Quickly test your website to see if there are any issues with accessibility, browser compatibility, security, performance and more.",
   "devtools_page": "devtools/devtools.html",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "webhint",
   "permissions": [
     "<all_urls>",


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

The first step to adding support for Manifest v3, addresses the concern laid out on #5308.

This PR bumps the manifest file version to v3 which is intended to be followed up with changes related to functionality to make the browser extension compatible.

It has no breaking changes.