### PR TITLE
Fix: Issue with glob latest version and windows

### DIFF
--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -135,7 +135,7 @@
     "copy:version": "node ./scripts/copy-version.js",
     "host-ui": "node scripts/host-ui.js",
     "lint": "npm-run-all lint:*",
-    "lint-bundle-size": "node ./scripts/bundle-size.js",
+    "lint-bundle-size": "node ./scripts/bundle-size.js ./dist/chromium",
     "lint:js": "eslint . --cache --ext .js,.md,.ts --ext tsx --ignore-path ../../.eslintignore",
     "lint:dependencies": "node ../../scripts/lint-dependencies.js",
     "lint:md": "node ../../scripts/lint-markdown.js",

--- a/packages/extension-browser/scripts/bundle-size.js
+++ b/packages/extension-browser/scripts/bundle-size.js
@@ -5,7 +5,14 @@ const packageJSON = require('../package.json');
 
 const folder = process.argv[2];
 
-glob(`${path.resolve(__dirname, '..', folder)}/webhint-*.zip`, (err, files) => {
+let extensionPath = path.resolve(__dirname, '..', folder);
+
+extensionPath = path.join(extensionPath, 'webhint-*.zip');
+
+// starting on v8 glob expects all paths to be forward slash
+extensionPath = extensionPath.replace(/\\/g, '/');
+
+glob(extensionPath, (err, files) => {
     if (err) {
         throw new Error(`Validating bundle size failed: ${err}`);
     }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
Fixing an issue between the latest version of glob (8) and windows paths. Starting on V8 glob only support forward paths, which `path.resolve` was failing to return. Fix was to replace the characters and standardize the path.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
