### PR TITLE
Fix: Replacing url for a knockout dependency

### DIFF
--- a/packages/hint-no-vulnerable-javascript-libraries/package.json
+++ b/packages/hint-no-vulnerable-javascript-libraries/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-markdown": "^2.2.1",
     "jquery": "2.1.4",
-    "knockout": "https://github.com/knockout/knockout/archive/v3.4.0-rc.tar.gz",
+    "knockout": "https://codeload.github.com/knockout/knockout/tar.gz/refs/tags/v3.4.0-rc",
     "moment": "^2.29.4",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6763,9 +6763,9 @@ kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-"knockout@https://github.com/knockout/knockout/archive/v3.4.0-rc.tar.gz":
+"knockout@https://codeload.github.com/knockout/knockout/tar.gz/refs/tags/v3.4.0-rc":
   version "3.4.0-rc"
-  resolved "https://github.com/knockout/knockout/archive/v3.4.0-rc.tar.gz#9cfd26d3c03af4481d6c6b72f2e6e06de8f2a1e7"
+  resolved "https://codeload.github.com/knockout/knockout/tar.gz/refs/tags/v3.4.0-rc#9cfd26d3c03af4481d6c6b72f2e6e06de8f2a1e7"
 
 latest-version@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
A dependency in `hint/fix-no-vulnerable-javascript-libraries` changed URL and was timing out, I had to point to a more recent url.
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
