### PR TITLE
Fix: Update 'latest-version' from 5.1.0 to 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "fs-extra": "^11.1.0",
     "globby": "^11.0.4",
     "json-schema-to-typescript": "^11.0.3",
-    "latest-version": "^5.1.0",
+    "latest-version": "^7.0.0",
     "listr": "^0.14.2",
     "listr-inquirer": "^0.1.0",
     "markdown-link-validator": "^1.0.1",
@@ -50,7 +50,7 @@
     "build": "yarn clean && yarn update:references && node scripts/build-or-test-all.js build",
     "build:scripts": "npm run clean:root && npm run lint:scripts && npm-run-all --parallel build:scripts:*",
     "build:scripts:non-ts": "copyfiles \"./scripts/**/{!(*.ts),.!(ts)}\" dist",
-    "build:scripts:ts": "tsc",
+    "build:scripts:ts": "tsc && node scripts/adapt-cjs-to-esm.js",
     "build:ts": "tsc -b",
     "cache": "node scripts/ava-cache.js",
     "clean": "npm-run-all clean:*",
@@ -85,5 +85,8 @@
     "packages": [
       "packages/*"
     ]
+  },
+  "dependencies": {
+    "@hint/utils-types": "^1.2.0"
   }
 }

--- a/scripts/adapt-cjs-to-esm.js
+++ b/scripts/adapt-cjs-to-esm.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+
+// Read the file content
+const filePath = 'dist/release/tasks/get-packages.js';
+
+fs.readFile(filePath, 'utf-8', (err, fileContent) => {
+    if (err) {
+        throw err;
+    }
+
+    // Replace the statement with a new one
+    const newContent = fileContent.replace(/const latest_version_1 = require\("latest-version"\);/, /const latest_version_1 = await require\("latest-version"\);/);
+
+    // Write the updated content back to the file
+    fs.writeFile(filePath, newContent, 'utf-8', (err) => {
+        if (err) {
+            throw err;
+        }
+        console.log('File updated successfully!');
+    });
+});


### PR DESCRIPTION
Updating 'latest-version' version from 5.1.0 to 7.0.0 and adapt 'get-package' file to work with this new version, from CommonJs to ESM.

Ref: #5464

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

This pull request updates the 'latest-version' version from 5.1.0 to 7.0.0 in the package.json file. The new version does not support CommonJS, but it supports ESM.
As a result, a new script has been developed that adapts CommonJS to ESM.
The new script, 'adapt-cjs-to-esm.js', reads the file content from 'dist/release/tasks/get-packages.js', replaces the statement with a new one, and writes the updated content back to the file.
Overall, this pull request ensures that the project is updated to use the latest version of 'latest-version' and is compatible with ESM.
