### PR TITLE
Chore: Adding `hint-detect-css-reflows` to `utils-worker` 

### DIFF
--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -10,7 +10,7 @@
     "workerThreads": false
   },
   "browserslist": "last 2 chrome versions, last 2 firefox versions",
-  "bundleSize": 735000,
+  "bundleSize": 738000,
   "description": "webhint browser extension",
   "devDependencies": {
     "@hint/hint-axe": "^4.4.18",

--- a/packages/hint-detect-css-reflows/src/_locales/en/messages.json
+++ b/packages/hint-detect-css-reflows/src/_locales/en/messages.json
@@ -23,8 +23,8 @@
         "description": "PaintMetadata name",
         "message": "Detect CSS Paint Operations"
     },
-    "willTriggerLayout": {
+    "issueMessage": {
         "description": "Report message to show when the validation fails",
-        "message": "Changes to '$1' will trigger: '$2'. Which can impact performance."
+        "message": "'$1' changes to this property will trigger: '$2', which can impact performance."
     }
 }

--- a/packages/hint-detect-css-reflows/src/composite.ts
+++ b/packages/hint-detect-css-reflows/src/composite.ts
@@ -2,7 +2,6 @@
  * @fileoverview Let the developers know of what operations will be triggered by changes on the css properties
  */
 
-import * as path from 'path';
 import { Declaration, Rule } from 'postcss';
 
 import { HintContext } from 'hint/dist/src/lib/hint-context';
@@ -11,9 +10,8 @@ import { IHint} from 'hint/dist/src/lib/types';
 import { debug as d } from '@hint/utils-debug';
 import { Severity } from '@hint/utils-types';
 import { StyleEvents, StyleParse } from '@hint/parser-css';
-import { loadJSONFile } from '@hint/utils-fs';
-import { getCSSLocationFromNode, getUnprefixed } from '@hint/utils-css';
-const cssPropertiesObject = loadJSONFile(path.join(__dirname, 'assets', 'CSSReflow.json')) || {};
+import { getCSSLocationFromNode, getFullCSSCodeSnippet, getUnprefixed } from '@hint/utils-css';
+const cssPropertiesObject = require('./assets/CSSReflow.json') || {};
 
 import { getMessage } from './i18n.import';
 
@@ -72,7 +70,7 @@ export default class DetectCssCompositeHint implements IHint {
                 return item !== null;
             }).join(', ');
 
-            return getMessage('willTriggerLayout', context.language, [propertyName, triggeredCSSChangesArray]);
+            return getMessage('issueMessage', context.language, [propertyName, triggeredCSSChangesArray]);
         };
 
         context.on('parse::end::css', ({ ast, element, resource }: StyleParse) => {
@@ -85,6 +83,7 @@ export default class DetectCssCompositeHint implements IHint {
                     const location = getCSSLocationFromNode(declaration, { isValue: false });
                     const severity = Severity.hint;
                     const message = formatMessage(declaration);
+                    const codeSnippet = getFullCSSCodeSnippet(declaration);
 
                     context.report(
                         resource,
@@ -93,6 +92,7 @@ export default class DetectCssCompositeHint implements IHint {
                             codeLanguage: 'css',
                             element,
                             location,
+                            codeSnippet,
                             severity
                         });
                 }

--- a/packages/hint-detect-css-reflows/src/composite.ts
+++ b/packages/hint-detect-css-reflows/src/composite.ts
@@ -90,9 +90,9 @@ export default class DetectCssCompositeHint implements IHint {
                         message,
                         {
                             codeLanguage: 'css',
+                            codeSnippet,
                             element,
                             location,
-                            codeSnippet,
                             severity
                         });
                 }

--- a/packages/hint-detect-css-reflows/src/layout.ts
+++ b/packages/hint-detect-css-reflows/src/layout.ts
@@ -2,7 +2,6 @@
  * @fileoverview Let the developers know of what operations will be triggered by changes on the css properties
  */
 
-import * as path from 'path';
 import { Declaration, Rule } from 'postcss';
 
 import { HintContext } from 'hint/dist/src/lib/hint-context';
@@ -11,9 +10,8 @@ import { IHint} from 'hint/dist/src/lib/types';
 import { debug as d } from '@hint/utils-debug';
 import { Severity } from '@hint/utils-types';
 import { StyleEvents, StyleParse } from '@hint/parser-css';
-import { loadJSONFile } from '@hint/utils-fs';
-import { getCSSLocationFromNode, getUnprefixed } from '@hint/utils-css';
-const cssPropertiesObject = loadJSONFile(path.join(__dirname, 'assets', 'CSSReflow.json')) || {};
+import { getCSSLocationFromNode, getFullCSSCodeSnippet, getUnprefixed } from '@hint/utils-css';
+const cssPropertiesObject = require('./assets/CSSReflow.json') || {};
 
 import { getMessage } from './i18n.import';
 
@@ -72,7 +70,7 @@ export default class DetectCssLayoutHint implements IHint {
                 return item !== null;
             }).join(', ');
 
-            return getMessage('willTriggerLayout', context.language, [propertyName, triggeredCSSChangesArray]);
+            return getMessage('issueMessage', context.language, [propertyName, triggeredCSSChangesArray]);
         };
 
         context.on('parse::end::css', ({ ast, element, resource }: StyleParse) => {
@@ -85,6 +83,7 @@ export default class DetectCssLayoutHint implements IHint {
                     const location = getCSSLocationFromNode(declaration, { isValue: false });
                     const severity = Severity.hint;
                     const message = formatMessage(declaration);
+                    const codeSnippet = getFullCSSCodeSnippet(declaration);
 
                     context.report(
                         resource,
@@ -93,6 +92,7 @@ export default class DetectCssLayoutHint implements IHint {
                             codeLanguage: 'css',
                             element,
                             location,
+                            codeSnippet,
                             severity
                         });
                 }

--- a/packages/hint-detect-css-reflows/src/layout.ts
+++ b/packages/hint-detect-css-reflows/src/layout.ts
@@ -90,9 +90,9 @@ export default class DetectCssLayoutHint implements IHint {
                         message,
                         {
                             codeLanguage: 'css',
+                            codeSnippet,
                             element,
                             location,
-                            codeSnippet,
                             severity
                         });
                 }

--- a/packages/hint-detect-css-reflows/src/paint.ts
+++ b/packages/hint-detect-css-reflows/src/paint.ts
@@ -90,9 +90,9 @@ export default class DetectCssPaintHint implements IHint {
                         message,
                         {
                             codeLanguage: 'css',
+                            codeSnippet,
                             element,
                             location,
-                            codeSnippet,
                             severity
                         });
                 }

--- a/packages/hint-detect-css-reflows/src/paint.ts
+++ b/packages/hint-detect-css-reflows/src/paint.ts
@@ -2,7 +2,6 @@
  * @fileoverview Let the developers know of what operations will be triggered by changes on the css properties
  */
 
-import * as path from 'path';
 import { Declaration, Rule } from 'postcss';
 
 import { HintContext } from 'hint/dist/src/lib/hint-context';
@@ -11,9 +10,8 @@ import { IHint} from 'hint/dist/src/lib/types';
 import { debug as d } from '@hint/utils-debug';
 import { Severity } from '@hint/utils-types';
 import { StyleEvents, StyleParse } from '@hint/parser-css';
-import { loadJSONFile } from '@hint/utils-fs';
-import { getCSSLocationFromNode, getUnprefixed } from '@hint/utils-css';
-const cssPropertiesObject = loadJSONFile(path.join(__dirname, 'assets', 'CSSReflow.json')) || {};
+import { getCSSLocationFromNode, getFullCSSCodeSnippet, getUnprefixed } from '@hint/utils-css';
+const cssPropertiesObject = require('./assets/CSSReflow.json') || {};
 
 import { getMessage } from './i18n.import';
 
@@ -72,7 +70,7 @@ export default class DetectCssPaintHint implements IHint {
                 return item !== null;
             }).join(', ');
 
-            return getMessage('willTriggerLayout', context.language, [propertyName, triggeredCSSChangesArray]);
+            return getMessage('issueMessage', context.language, [propertyName, triggeredCSSChangesArray]);
         };
 
         context.on('parse::end::css', ({ ast, element, resource }: StyleParse) => {
@@ -85,6 +83,7 @@ export default class DetectCssPaintHint implements IHint {
                     const location = getCSSLocationFromNode(declaration, { isValue: false });
                     const severity = Severity.hint;
                     const message = formatMessage(declaration);
+                    const codeSnippet = getFullCSSCodeSnippet(declaration);
 
                     context.report(
                         resource,
@@ -93,6 +92,7 @@ export default class DetectCssPaintHint implements IHint {
                             codeLanguage: 'css',
                             element,
                             location,
+                            codeSnippet,
                             severity
                         });
                 }

--- a/packages/hint-detect-css-reflows/tests/composite.ts
+++ b/packages/hint-detect-css-reflows/tests/composite.ts
@@ -22,12 +22,12 @@ const tests: HintTest[] = [
         name: 'Hints should  be reported for properties in the CSSReflow.json file',
         reports: [
             {
-                message: `Changes to 'accent-color' will trigger: 'Composite'. Which can impact performance.`,
+                message: `'accent-color' changes to this property will trigger: 'Composite', which can impact performance.`,
                 position: { column: 4, endColumn: 16, endLine: 1, line: 1 },
                 severity: Severity.hint
             },
             {
-                message: `Changes to 'align-content' will trigger: 'Composite'. Which can impact performance.`,
+                message: `'align-content' changes to this property will trigger: 'Composite', which can impact performance.`,
                 position: { column: 4, endColumn: 16, endLine: 5, line: 5 },
                 severity: Severity.hint
             }

--- a/packages/hint-detect-css-reflows/tests/layout.ts
+++ b/packages/hint-detect-css-reflows/tests/layout.ts
@@ -22,7 +22,7 @@ const tests: HintTest[] = [
         name: 'Hints should  be reported for properties in the CSSReflow.json file',
         reports: [
             {
-                message: `Changes to 'padding-left' will trigger: 'Layout'. Which can impact performance.`,
+                message: `'padding-left' changes to this property will trigger: 'Layout', which can impact performance.`,
                 position: { column: 3, endColumn: 15, endLine: 5, line: 5 },
                 severity: Severity.hint
             }

--- a/packages/hint-detect-css-reflows/tests/paint.ts
+++ b/packages/hint-detect-css-reflows/tests/paint.ts
@@ -22,12 +22,12 @@ const tests: HintTest[] = [
         name: 'Hints should  be reported for properties in the CSSReflow.json file',
         reports: [
             {
-                message: `Changes to 'padding-left' will trigger: 'Paint'. Which can impact performance.`,
+                message: `'padding-left' changes to this property will trigger: 'Paint', which can impact performance.`,
                 position: { column: 3, endColumn: 15, endLine: 5, line: 5 },
                 severity: Severity.hint
             },
             {
-                message: `Changes to 'appearance' will trigger: 'Paint'. Which can impact performance.`,
+                message: `'appearance' changes to this property will trigger: 'Paint', which can impact performance.`,
                 position: { column: 4, endColumn: 14, endLine: 9, line: 9 },
                 severity: Severity.hint
             }

--- a/packages/utils-worker/package.json
+++ b/packages/utils-worker/package.json
@@ -10,7 +10,7 @@
     "timeout": "1m",
     "workerThreads": false
   },
-  "bundleSize": 2560000,
+  "bundleSize": 2590000,
   "description": "webhint web worker",
   "devDependencies": {
     "@hint/hint-axe": "^4.4.18",
@@ -19,6 +19,7 @@
     "@hint/hint-content-type": "^4.2.24",
     "@hint/hint-create-element-svg": "^1.3.24",
     "@hint/hint-css-prefix-order": "^1.5.4",
+    "@hint/hint-detect-css-reflows": "^1.0.1",
     "@hint/hint-disown-opener": "^4.0.20",
     "@hint/hint-highest-available-document-mode": "^5.0.20",
     "@hint/hint-http-cache": "^4.0.20",

--- a/packages/utils-worker/package.json
+++ b/packages/utils-worker/package.json
@@ -19,7 +19,7 @@
     "@hint/hint-content-type": "^4.2.24",
     "@hint/hint-create-element-svg": "^1.3.24",
     "@hint/hint-css-prefix-order": "^1.5.4",
-    "@hint/hint-detect-css-reflows": "^1.0.1",
+    "@hint/hint-detect-css-reflows": "^1.0.2",
     "@hint/hint-disown-opener": "^4.0.20",
     "@hint/hint-highest-available-document-mode": "^5.0.20",
     "@hint/hint-http-cache": "^4.0.20",

--- a/packages/utils-worker/tsconfig.json
+++ b/packages/utils-worker/tsconfig.json
@@ -19,6 +19,7 @@
         { "path": "../hint-content-type" },
         { "path": "../hint-create-element-svg" },
         { "path": "../hint-css-prefix-order" },
+        { "path": "../hint-detect-css-reflows" },
         { "path": "../hint-disown-opener" },
         { "path": "../hint-highest-available-document-mode" },
         { "path": "../hint-http-cache" },


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
- Changing the way CSSReflow.json is loaded in favor of require instead of loading the loadJSONFile
- Passing codeSnippet to the returned hint
- Rising the size limit on some packages as they are on the limit of size which can case issues with updates.
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
