### PR TITLE
Chore: Fix `detect-css-reflows` in meta and docs.

### DIFF
--- a/packages/hint-detect-css-reflows/README.md
+++ b/packages/hint-detect-css-reflows/README.md
@@ -1,4 +1,4 @@
-# hint-detect-css-reflows (`hint-detect-css-reflows`)
+# Detect CSS Reflows (`detect-css-reflows`)
 
 Let the developers know if changes to a specific CSS property will trigger
 changes on the Layout, Composite or Paint rendering pipeline.
@@ -36,16 +36,16 @@ pipeline.
 You can decide the granularity and severity of your reports up to the
 following categories:
 
-- hint-detect-css-reflows/composite
-- hint-detect-css-reflows/layout
-- hint-detect-css-reflows/paint
+- detect-css-reflows/composite
+- detect-css-reflows/layout
+- detect-css-reflows/paint
 
 ## How to use this hint?
 
 To use it you will have to install it via `npm`:
 
 ```bash
-npm install hint-detect-css-reflows
+npm install hint --save-dev
 ```
 
 Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
@@ -62,9 +62,9 @@ configuration file:
     "formatters": [...],
     "parsers": [...],
     "hints": {
-        "hint-detect-css-reflows/composite": "off",
-        "hint-detect-css-reflows/layout": "hint",
-        "hint-detect-css-reflows/paint": "off"
+        "detect-css-reflows/composite": "off",
+        "detect-css-reflows/layout": "hint",
+        "detect-css-reflows/paint": "off"
     },
     ...
 }

--- a/packages/hint-detect-css-reflows/docs/composite.md
+++ b/packages/hint-detect-css-reflows/docs/composite.md
@@ -1,4 +1,4 @@
-# hint-detect-css-reflows/composite (`hint-detect-css-reflows/composite`)
+# Detect CSS Reflows - Composite (`detect-css-reflows/composite`)
 
 Let the developers know if changes to a specific CSS property will trigger
 changes on the Composite rendering pipeline.
@@ -35,14 +35,14 @@ the `accent-color` property will trigger changes on the `Composite` pipeline.
 You can decide the granularity and severity of your reports up to the
 following categories:
 
-- hint-detect-css-reflows/composite
+- detect-css-reflows/composite
 
 ## How to use this hint?
 
 To use it you will have to install it via `npm`:
 
 ```bash
-npm install hint-detect-css-reflows
+npm install hint --save-dev
 ```
 
 Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
@@ -59,7 +59,7 @@ configuration file:
     "formatters": [...],
     "parsers": [...],
     "hints": {
-        "hint-detect-css-reflows/composite": "error"
+        "detect-css-reflows/composite": "error"
     },
     ...
 }

--- a/packages/hint-detect-css-reflows/docs/layout.md
+++ b/packages/hint-detect-css-reflows/docs/layout.md
@@ -1,4 +1,4 @@
-# hint-detect-css-reflows/layout (`hint-detect-css-reflows/layout`)
+# Detect CSS Reflows - Layout (`detect-css-reflows/layout`)
 
 Let the developers know if changes to a specific CSS property will trigger
 changes on the Layout rendering pipeline.
@@ -35,14 +35,14 @@ the `padding-left` property will trigger changes on the `Layout` pipeline.
 You can decide the granularity and severity of your reports up to the
 following categories:
 
-- hint-detect-css-reflows/layout
+- detect-css-reflows/layout
 
 ## How to use this hint?
 
 To use it you will have to install it via `npm`:
 
 ```bash
-npm install hint-detect-css-reflows
+npm install hint --save-dev
 ```
 
 Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
@@ -59,7 +59,7 @@ configuration file:
     "formatters": [...],
     "parsers": [...],
     "hints": {
-        "hint-detect-css-reflows/layout": "error"
+        "detect-css-reflows/layout": "error"
     },
     ...
 }

--- a/packages/hint-detect-css-reflows/docs/paint.md
+++ b/packages/hint-detect-css-reflows/docs/paint.md
@@ -1,4 +1,4 @@
-# hint-detect-css-reflows/paint (`hint-detect-css-reflows/paint`)
+# Detect CSS Reflows - Paint (`detect-css-reflows/paint`)
 
 Let the developers know if changes to a specific CSS property will trigger
 changes on the Paint rendering pipeline.
@@ -35,14 +35,14 @@ the `padding-left` property will trigger changes on the `Paint` pipeline.
 You can decide the granularity and severity of your reports up to the
 following categories:
 
-- hint-detect-css-reflows/layout
+- detect-css-reflows/layout
 
 ## How to use this hint?
 
 To use it you will have to install it via `npm`:
 
 ```bash
-npm install hint-detect-css-reflows
+npm install hint --save-dev
 ```
 
 Note: You can make `npm` install it as a `devDependency` using the `--save-dev`
@@ -59,7 +59,7 @@ configuration file:
     "formatters": [...],
     "parsers": [...],
     "hints": {
-        "hint-detect-css-reflows/paint": "error"
+        "detect-css-reflows/paint": "error"
     },
     ...
 }

--- a/packages/hint-detect-css-reflows/src/composite.ts
+++ b/packages/hint-detect-css-reflows/src/composite.ts
@@ -35,7 +35,7 @@ export default class DetectCssCompositeHint implements IHint {
         const validateRule = (rule: Rule) => {
             // Code to validate the hint on the event when an element is visited.
 
-            debug(`Validating hint-detect-css-reflows`);
+            debug(`Validating detect-css-reflows`);
             const results = new Set<Declaration>();
 
             rule.each((decl) => {
@@ -74,7 +74,7 @@ export default class DetectCssCompositeHint implements IHint {
         };
 
         context.on('parse::end::css', ({ ast, element, resource }: StyleParse) => {
-            debug('Validating hint-detect-css-reflows');
+            debug('Validating detect-css-reflows');
 
             ast.walkRules((rule) => {
                 const results = validateRule(rule);

--- a/packages/hint-detect-css-reflows/src/layout.ts
+++ b/packages/hint-detect-css-reflows/src/layout.ts
@@ -35,7 +35,7 @@ export default class DetectCssLayoutHint implements IHint {
         const validateRule = (rule: Rule) => {
             // Code to validate the hint on the event when an element is visited.
 
-            debug(`Validating hint-detect-css-reflows`);
+            debug(`Validating detect-css-reflows`);
             const results = new Set<Declaration>();
 
             rule.each((decl) => {
@@ -74,7 +74,7 @@ export default class DetectCssLayoutHint implements IHint {
         };
 
         context.on('parse::end::css', ({ ast, element, resource }: StyleParse) => {
-            debug('Validating hint-detect-css-reflows');
+            debug('Validating detect-css-reflows');
 
             ast.walkRules((rule) => {
                 const results = validateRule(rule);

--- a/packages/hint-detect-css-reflows/src/meta/composite.ts
+++ b/packages/hint-detect-css-reflows/src/meta/composite.ts
@@ -20,7 +20,7 @@ const meta: HintMetadata = {
     getName(language: string) {
         return getMessage('composite_name', language);
     },
-    id: 'hint-detect-css-reflows/composite',
+    id: 'detect-css-reflows/composite',
     schema: [schema],
     scope: HintScope.any
 };

--- a/packages/hint-detect-css-reflows/src/meta/layout.ts
+++ b/packages/hint-detect-css-reflows/src/meta/layout.ts
@@ -20,7 +20,7 @@ const meta: HintMetadata = {
     getName(language: string) {
         return getMessage('layout_name', language);
     },
-    id: 'hint-detect-css-reflows/layout',
+    id: 'detect-css-reflows/layout',
     schema: [schema],
     scope: HintScope.any
 };

--- a/packages/hint-detect-css-reflows/src/meta/paint.ts
+++ b/packages/hint-detect-css-reflows/src/meta/paint.ts
@@ -20,7 +20,7 @@ const meta: HintMetadata = {
     getName(language: string) {
         return getMessage('paint_name', language);
     },
-    id: 'hint-detect-css-reflows/paint',
+    id: 'detect-css-reflows/paint',
     schema: [schema],
     scope: HintScope.any
 };

--- a/packages/hint-detect-css-reflows/src/paint.ts
+++ b/packages/hint-detect-css-reflows/src/paint.ts
@@ -35,7 +35,7 @@ export default class DetectCssPaintHint implements IHint {
         const validateRule = (rule: Rule) => {
             // Code to validate the hint on the event when an element is visited.
 
-            debug(`Validating hint-detect-css-reflows`);
+            debug(`Validating detect-css-reflows`);
             const results = new Set<Declaration>();
 
             rule.each((decl) => {
@@ -74,7 +74,7 @@ export default class DetectCssPaintHint implements IHint {
         };
 
         context.on('parse::end::css', ({ ast, element, resource }: StyleParse) => {
-            debug('Validating hint-detect-css-reflows');
+            debug('Validating detect-css-reflows');
 
             ast.walkRules((rule) => {
                 const results = validateRule(rule);


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
Some of the meta files and docs had the incorrect prefix `hint-` in the name, although this is correct
in some parts of the code, others do not expect it to be in that format like `utils-worker` so I'm renaming them.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
