### PR TITLE
Fix: Scoping `detect-css-reflows` to animations

### DIFF
--- a/packages/hint-detect-css-reflows/README.md
+++ b/packages/hint-detect-css-reflows/README.md
@@ -1,33 +1,51 @@
 # Detect CSS Reflows (`detect-css-reflows`)
 
-Let the developers know if changes to a specific CSS property will trigger
-changes on the Layout, Composite or Paint rendering pipeline.
+Let the developers know if changes to a specific CSS property inside @keyframes
+will trigger changes on the Layout, Composite or Paint rendering pipeline.
 
 ## Why is this important?
 
 Understanding what rendering pipeline operations will be triggered by changes
 on specific CSS properties can prevent users from introducing unintentional
-performance hits.
+performance hits. `Paint` and `Layout` operations should be minimized or avoided
+when combined with animations.
 
 ## What does the hint check?
 
-It scans the css properties against a defined properties and associated
-rendering triggers.
+It scans the css properties inside @keyframes property against a defined
+set of properties and associated rendering triggers.
 
 ### Examples that **trigger** the hint
 
-A list of code examples that will fail this hint.
-It's good to put some edge cases in here.
+`left` property triggers a `Layout` operation its use should be minimized inside
+`@keyframes` to avoid jankiness or slow animations.
+
+```css
+@keyframes performance-with-layout-trigger {
+    0% {
+        left: 0;
+
+    }
+    100% {
+        left: 400px;
+    }
+}
+```
 
 ### Examples that **pass** the hint
 
-In the following example, this hint will warn user that making changes to
-the `padding-left` property will trigger changes on the `Layout` and `Paint`
-pipeline.
+A better approach is to use `translate` which will trigger only once, at the
+end of the animation.
 
 ```css
-.example {
-    padding-left: auto;
+@keyframes performance-without-layout-trigger {
+    0% {
+        transform: translateX(0);
+
+    }
+    100% {
+        transform: translateX(400px);
+    }
 }
 ```
 

--- a/packages/hint-detect-css-reflows/src/_locales/en/messages.json
+++ b/packages/hint-detect-css-reflows/src/_locales/en/messages.json
@@ -1,7 +1,7 @@
 {
     "composite_description": {
         "description": "Metadata description",
-        "message": "Let the developers if changes to the CSS properties will trigger a composite operation"
+        "message": "Let the developers if changes to the CSS properties inside @keyframes will trigger a composite operation"
     },
     "composite_name": {
         "description": "Metadata name",
@@ -9,7 +9,7 @@
     },
     "layout_description": {
         "description": "Metadata description",
-        "message": "Let the developers if changes to the CSS properties will trigger a layout operation"
+        "message": "Let the developers if changes to the CSS properties inside @keyframes will trigger a layout operation"
     },
     "layout_name": {
         "description": "Metadata name",
@@ -17,7 +17,7 @@
     },
     "paint_description": {
         "description": "Metadata description",
-        "message": "Let the developers if changes to the CSS properties will trigger a paint operation"
+        "message": "Let the developers if changes to the CSS properties inside @keyframes will trigger a paint operation"
     },
     "paint_name": {
         "description": "PaintMetadata name",
@@ -25,6 +25,6 @@
     },
     "issueMessage": {
         "description": "Report message to show when the validation fails",
-        "message": "'$1' changes to this property will trigger: '$2', which can impact performance."
+        "message": "'$1' changes to this property will trigger: '$2', which can impact performance when used inside @keyframes."
     }
 }

--- a/packages/hint-detect-css-reflows/src/composite.ts
+++ b/packages/hint-detect-css-reflows/src/composite.ts
@@ -2,7 +2,7 @@
  * @fileoverview Let the developers know of what operations will be triggered by changes on the css properties
  */
 
-import { Declaration, Rule } from 'postcss';
+import { Declaration, AtRule, Rule } from 'postcss';
 
 import { HintContext } from 'hint/dist/src/lib/hint-context';
 // The list of types depends on the events you want to capture.
@@ -31,7 +31,6 @@ export default class DetectCssCompositeHint implements IHint {
 
     public constructor(context: HintContext<StyleEvents>) {
 
-        // Your code here.
         const validateRule = (rule: Rule) => {
             // Code to validate the hint on the event when an element is visited.
 
@@ -51,6 +50,29 @@ export default class DetectCssCompositeHint implements IHint {
                     results.add(decl);
                 }
             });
+
+            return results;
+        };
+
+        const validateAtRule = (rule: AtRule) => {
+
+            let results = new Set<Declaration>();
+
+            if (rule.name === 'keyframes') {
+
+                // only care about css animations
+                rule.each((decl) => {
+                    switch (decl.type) {
+                        case 'rule': {
+                            results = new Set([...results, ...validateRule(decl)]);
+                            break;
+                        }
+                        default: {
+                            break;
+                        }
+                    }
+                });
+            }
 
             return results;
         };
@@ -76,27 +98,35 @@ export default class DetectCssCompositeHint implements IHint {
         context.on('parse::end::css', ({ ast, element, resource }: StyleParse) => {
             debug('Validating detect-css-reflows');
 
-            ast.walkRules((rule) => {
-                const results = validateRule(rule);
+            for (const node of ast.nodes) {
+                switch (node.type) {
+                    case 'atrule': {
+                        const results = validateAtRule(node);
 
-                for (const declaration of results) {
-                    const location = getCSSLocationFromNode(declaration, { isValue: false });
-                    const severity = Severity.hint;
-                    const message = formatMessage(declaration);
-                    const codeSnippet = getFullCSSCodeSnippet(declaration);
+                        for (const declaration of results) {
+                            const location = getCSSLocationFromNode(declaration, { isValue: false });
+                            const severity = Severity.hint;
+                            const message = formatMessage(declaration);
+                            const codeSnippet = getFullCSSCodeSnippet(declaration);
 
-                    context.report(
-                        resource,
-                        message,
-                        {
-                            codeLanguage: 'css',
-                            codeSnippet,
-                            element,
-                            location,
-                            severity
-                        });
+                            context.report(
+                                resource,
+                                message,
+                                {
+                                    codeLanguage: 'css',
+                                    codeSnippet,
+                                    element,
+                                    location,
+                                    severity
+                                });
+                        }
+                        break;
+                    }
+                    default:
+                        // only care about at rules
+                        break;
                 }
-            });
+            }
         });
         // As many events as you need
     }

--- a/packages/hint-detect-css-reflows/src/layout.ts
+++ b/packages/hint-detect-css-reflows/src/layout.ts
@@ -2,7 +2,7 @@
  * @fileoverview Let the developers know of what operations will be triggered by changes on the css properties
  */
 
-import { Declaration, Rule } from 'postcss';
+import { Declaration, AtRule, Rule } from 'postcss';
 
 import { HintContext } from 'hint/dist/src/lib/hint-context';
 // The list of types depends on the events you want to capture.
@@ -31,7 +31,6 @@ export default class DetectCssLayoutHint implements IHint {
 
     public constructor(context: HintContext<StyleEvents>) {
 
-        // Your code here.
         const validateRule = (rule: Rule) => {
             // Code to validate the hint on the event when an element is visited.
 
@@ -51,6 +50,29 @@ export default class DetectCssLayoutHint implements IHint {
                     results.add(decl);
                 }
             });
+
+            return results;
+        };
+
+        const validateAtRule = (rule: AtRule) => {
+
+            let results = new Set<Declaration>();
+
+            if (rule.name === 'keyframes') {
+
+                // only care about css animations
+                rule.each((decl) => {
+                    switch (decl.type) {
+                        case 'rule': {
+                            results = new Set([...results, ...validateRule(decl)]);
+                            break;
+                        }
+                        default: {
+                            break;
+                        }
+                    }
+                });
+            }
 
             return results;
         };
@@ -76,27 +98,35 @@ export default class DetectCssLayoutHint implements IHint {
         context.on('parse::end::css', ({ ast, element, resource }: StyleParse) => {
             debug('Validating detect-css-reflows');
 
-            ast.walkRules((rule) => {
-                const results = validateRule(rule);
+            for (const node of ast.nodes) {
+                switch (node.type) {
+                    case 'atrule': {
+                        const results = validateAtRule(node);
 
-                for (const declaration of results) {
-                    const location = getCSSLocationFromNode(declaration, { isValue: false });
-                    const severity = Severity.hint;
-                    const message = formatMessage(declaration);
-                    const codeSnippet = getFullCSSCodeSnippet(declaration);
+                        for (const declaration of results) {
+                            const location = getCSSLocationFromNode(declaration, { isValue: false });
+                            const severity = Severity.hint;
+                            const message = formatMessage(declaration);
+                            const codeSnippet = getFullCSSCodeSnippet(declaration);
 
-                    context.report(
-                        resource,
-                        message,
-                        {
-                            codeLanguage: 'css',
-                            codeSnippet,
-                            element,
-                            location,
-                            severity
-                        });
+                            context.report(
+                                resource,
+                                message,
+                                {
+                                    codeLanguage: 'css',
+                                    codeSnippet,
+                                    element,
+                                    location,
+                                    severity
+                                });
+                        }
+                        break;
+                    }
+                    default:
+                        // only care about at rules
+                        break;
                 }
-            });
+            }
         });
         // As many events as you need
     }

--- a/packages/hint-detect-css-reflows/tests/composite.ts
+++ b/packages/hint-detect-css-reflows/tests/composite.ts
@@ -22,12 +22,12 @@ const tests: HintTest[] = [
         name: 'Hints should  be reported for properties in the CSSReflow.json file',
         reports: [
             {
-                message: `'accent-color' changes to this property will trigger: 'Composite', which can impact performance.`,
+                message: `'accent-color' changes to this property will trigger: 'Composite', which can impact performance when used inside @keyframes.`,
                 position: { column: 8, endColumn: 20, endLine: 10, line: 10 },
                 severity: Severity.hint
             },
             {
-                message: `'align-content' changes to this property will trigger: 'Composite', which can impact performance.`,
+                message: `'align-content' changes to this property will trigger: 'Composite', which can impact performance when used inside @keyframes.`,
                 position: { column: 8, endColumn: 21, endLine: 14, line: 14 },
                 severity: Severity.hint
             }

--- a/packages/hint-detect-css-reflows/tests/composite.ts
+++ b/packages/hint-detect-css-reflows/tests/composite.ts
@@ -23,12 +23,12 @@ const tests: HintTest[] = [
         reports: [
             {
                 message: `'accent-color' changes to this property will trigger: 'Composite', which can impact performance.`,
-                position: { column: 4, endColumn: 16, endLine: 1, line: 1 },
+                position: { column: 8, endColumn: 20, endLine: 10, line: 10 },
                 severity: Severity.hint
             },
             {
                 message: `'align-content' changes to this property will trigger: 'Composite', which can impact performance.`,
-                position: { column: 4, endColumn: 16, endLine: 5, line: 5 },
+                position: { column: 8, endColumn: 21, endLine: 14, line: 14 },
                 severity: Severity.hint
             }
         ],

--- a/packages/hint-detect-css-reflows/tests/fixtures/composite-triggers.css
+++ b/packages/hint-detect-css-reflows/tests/fixtures/composite-triggers.css
@@ -14,5 +14,9 @@
     100% {
         align-content: last center;
     }
+
+    test {
+        not valid:{}
+    }
 }
 

--- a/packages/hint-detect-css-reflows/tests/fixtures/composite-triggers.css
+++ b/packages/hint-detect-css-reflows/tests/fixtures/composite-triggers.css
@@ -5,3 +5,14 @@
 .example2 {
     align-content: last center;
 }
+
+@keyframes test {
+    50% {
+        accent-color: blue;
+    }
+
+    100% {
+        align-content: last center;
+    }
+}
+

--- a/packages/hint-detect-css-reflows/tests/fixtures/layout-triggers.css
+++ b/packages/hint-detect-css-reflows/tests/fixtures/layout-triggers.css
@@ -3,5 +3,12 @@
 }
 
 .example2 {
-   padding-left: 10%;
+    padding-left: 10%;
+}
+
+@keyframes test {
+    50% {
+        accent-color: blue;
+        padding-left: 16%;
+    }
 }

--- a/packages/hint-detect-css-reflows/tests/fixtures/layout-triggers.css
+++ b/packages/hint-detect-css-reflows/tests/fixtures/layout-triggers.css
@@ -11,4 +11,8 @@
         accent-color: blue;
         padding-left: 16%;
     }
+
+    test {
+        not valid:{}
+    }
 }

--- a/packages/hint-detect-css-reflows/tests/fixtures/paint-triggers.css
+++ b/packages/hint-detect-css-reflows/tests/fixtures/paint-triggers.css
@@ -9,3 +9,14 @@
 .example2 {
     appearance: textfield;
  }
+
+ @keyframes test {
+    50% {
+        accent-color: blue;
+        padding-left: 16%;
+    }
+
+    75% {
+        appearance: textfield;
+    }
+}

--- a/packages/hint-detect-css-reflows/tests/fixtures/paint-triggers.css
+++ b/packages/hint-detect-css-reflows/tests/fixtures/paint-triggers.css
@@ -16,6 +16,10 @@
         padding-left: 16%;
     }
 
+    test {
+        not valid:{}
+    }
+
     75% {
         appearance: textfield;
     }

--- a/packages/hint-detect-css-reflows/tests/layout.ts
+++ b/packages/hint-detect-css-reflows/tests/layout.ts
@@ -22,7 +22,7 @@ const tests: HintTest[] = [
         name: 'Hints should  be reported for properties in the CSSReflow.json file',
         reports: [
             {
-                message: `'padding-left' changes to this property will trigger: 'Layout', which can impact performance.`,
+                message: `'padding-left' changes to this property will trigger: 'Layout', which can impact performance when used inside @keyframes.`,
                 position: { column: 8, endColumn: 20, endLine: 11, line: 11 },
                 severity: Severity.hint
             }

--- a/packages/hint-detect-css-reflows/tests/layout.ts
+++ b/packages/hint-detect-css-reflows/tests/layout.ts
@@ -23,7 +23,7 @@ const tests: HintTest[] = [
         reports: [
             {
                 message: `'padding-left' changes to this property will trigger: 'Layout', which can impact performance.`,
-                position: { column: 3, endColumn: 15, endLine: 5, line: 5 },
+                position: { column: 8, endColumn: 20, endLine: 11, line: 11 },
                 severity: Severity.hint
             }
         ],

--- a/packages/hint-detect-css-reflows/tests/paint.ts
+++ b/packages/hint-detect-css-reflows/tests/paint.ts
@@ -23,12 +23,12 @@ const tests: HintTest[] = [
         reports: [
             {
                 message: `'padding-left' changes to this property will trigger: 'Paint', which can impact performance.`,
-                position: { column: 3, endColumn: 15, endLine: 5, line: 5 },
+                position: { column: 8, endColumn: 20, endLine: 15, line: 15 },
                 severity: Severity.hint
             },
             {
                 message: `'appearance' changes to this property will trigger: 'Paint', which can impact performance.`,
-                position: { column: 4, endColumn: 14, endLine: 9, line: 9 },
+                position: { column: 8, endColumn: 18, endLine: 19, line: 19 },
                 severity: Severity.hint
             }
         ],

--- a/packages/hint-detect-css-reflows/tests/paint.ts
+++ b/packages/hint-detect-css-reflows/tests/paint.ts
@@ -22,12 +22,12 @@ const tests: HintTest[] = [
         name: 'Hints should  be reported for properties in the CSSReflow.json file',
         reports: [
             {
-                message: `'padding-left' changes to this property will trigger: 'Paint', which can impact performance.`,
+                message: `'padding-left' changes to this property will trigger: 'Paint', which can impact performance when used inside @keyframes.`,
                 position: { column: 8, endColumn: 20, endLine: 15, line: 15 },
                 severity: Severity.hint
             },
             {
-                message: `'appearance' changes to this property will trigger: 'Paint', which can impact performance.`,
+                message: `'appearance' changes to this property will trigger: 'Paint', which can impact performance when used inside @keyframes.`,
                 position: { column: 8, endColumn: 18, endLine: 19, line: 19 },
                 severity: Severity.hint
             }

--- a/packages/hint-detect-css-reflows/tests/paint.ts
+++ b/packages/hint-detect-css-reflows/tests/paint.ts
@@ -28,7 +28,7 @@ const tests: HintTest[] = [
             },
             {
                 message: `'appearance' changes to this property will trigger: 'Paint', which can impact performance when used inside @keyframes.`,
-                position: { column: 8, endColumn: 18, endLine: 19, line: 19 },
+                position: { column: 8, endColumn: 18, endLine: 23, line: 23 },
                 severity: Severity.hint
             }
         ],


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [ ] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
This PR modifies the `hint-detect-css-reflows` to be scoped only to properties inside `@keyframes` as it is where the `Layout` and `Paint` can become a factor for jankiness or slow animations
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
