### PR TITLE
Fix: Upgrade of utils-network to 1.0.25 breaks hint

### DIFF
--- a/packages/utils-network/package.json
+++ b/packages/utils-network/package.json
@@ -17,7 +17,7 @@
     "content-type": "^1.0.5",
     "lodash": "^4.17.21",
     "https": "^1.0.0",
-    "node-fetch": "^3.3.1"
+    "node-fetch": "^2.6.11"
   },
   "description": "utils for network",
   "devDependencies": {


### PR DESCRIPTION
util-network was upgraded to a new major version of node-fetch which is now an ESM module. This breaks hint.

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
