### PR TITLE
Fix: Reverting node-fetch to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "private": true,
   "resolutions": {
     "json-schema": "^0.4.0",
-    "node-fetch": "^2.6.7",
+    "node-fetch": "^2.x",
     "thenify": "^3.3.1",
     "tsconfig-paths": "^4.1.2"
   },

--- a/packages/connector-puppeteer/package.json
+++ b/packages/connector-puppeteer/package.json
@@ -21,7 +21,7 @@
     "puppeteer-core": "^13.0.1"
   },
   "resolutions": {
-    "node-fetch": "^2.6.7"
+    "node-fetch": "^2.x"
   },
   "description": "hint connector for browsers supported by Puppeteer",
   "devDependencies": {

--- a/packages/utils-connector-tools/package.json
+++ b/packages/utils-connector-tools/package.json
@@ -17,7 +17,7 @@
     "data-urls": "^3.0.2",
     "iconv-lite": "^0.6.3",
     "https": "^1.0.0",
-    "node-fetch": "^3.3.1"
+    "node-fetch": "^2.x"
   },
   "description": "hint tools for connectors",
   "devDependencies": {

--- a/packages/utils-network/package.json
+++ b/packages/utils-network/package.json
@@ -17,7 +17,7 @@
     "content-type": "^1.0.5",
     "lodash": "^4.17.21",
     "https": "^1.0.0",
-    "node-fetch": "^3.3.1"
+    "node-fetch": "^2.x"
   },
   "description": "utils for network",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8016,10 +8016,10 @@ node-addon-api@^4.3.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
   integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
 
-node-fetch@2.6.1, node-fetch@2.6.5, node-fetch@3.3.0, node-fetch@^2.6.1, node-fetch@^2.6.7, node-fetch@^3.3.1:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+node-fetch@2.6.1, node-fetch@2.6.5, node-fetch@3.3.0, node-fetch@^2.6.1, node-fetch@^2.6.7, node-fetch@^2.x:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
+  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)
This PR revert back node version to v2 as v3 requires ESM.

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
