### PR TITLE
VS Code extension: reject process promise if code is null

### DIFF
--- a/packages/extension-vscode/src/utils/process.ts
+++ b/packages/extension-vscode/src/utils/process.ts
@@ -16,7 +16,8 @@ export const run = (command: string, options?: SpawnOptions) => {
         });
 
         child.on('exit', (code) => {
-            if (code) {
+            // Explicitly check for 0 as code can also be null (if the process was killed, etc.)
+            if (code !== 0) {
                 reject(new Error('NoExitCodeZero'));
             } else {
                 resolve();


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [ ] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

[Per the Node documentation](https://nodejs.org/dist/latest-v18.x/docs/api/child_process.html#event-exit), `code` can be `null` if the process was terminated. Being forcefully killed typically doesn't indicate success, so when that happens, reject the promise.