### PR TITLE
Docs: Remove references to retired online scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The code is available under the [Apache 2.0 license][license].
 [local user guide]: ./packages/hint/docs/user-guide/index.md
 [node]: https://nodejs.org/en/download/current/
 [npx]: https://github.com/zkat/npx
-[ojs coc]: https://github.com/openjs-foundation/cross-project-council/blob/master/CODE_OF_CONDUCT.md
+[ojs coc]: https://code-of-conduct.openjsf.org/
 [user guide]: https://webhint.io/docs/user-guide/
 [VS Code extension]: https://webhint.io/docs/user-guide/extensions/vscode-webhint/
 [yarn]: http://yarnpkg.com/

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ webhint is a customizable linting tool that helps you improve your site's
 accessibility, speed, cross-browser compatibility, and more by checking your
 code for best practices and common errors.
 
-It can be run from the command line (CLI), via a [browser extension][], as a
-[VS Code extension][], and from the [online service][].
+It can be run from the command line (CLI), via a [browser extension][], and as
+a [VS Code extension][].
 
 To use it from the CLI you will need to install [`Node.js`][node]
 (v14.x or later) on your machine, and you can use [`npx`][npx] to test it.
@@ -126,7 +126,6 @@ The code is available under the [Apache 2.0 license][license].
 [node]: https://nodejs.org/en/download/current/
 [npx]: https://github.com/zkat/npx
 [ojs coc]: https://github.com/openjs-foundation/cross-project-council/blob/master/CODE_OF_CONDUCT.md
-[online service]: https://webhint.io/scanner/
 [user guide]: https://webhint.io/docs/user-guide/
 [VS Code extension]: https://webhint.io/docs/user-guide/extensions/vscode-webhint/
 [yarn]: http://yarnpkg.com/

--- a/packages/hint/docs/about/FAQ.md
+++ b/packages/hint/docs/about/FAQ.md
@@ -56,15 +56,6 @@ currently available. It utilizes the [Language Server Protocol][lsp]
 which makes it suitable for porting to other editors if there's
 community interest.
 
-## Is there an online service?
-
-Yes! You can scan an online website in [here][scanner].
-
-If you have any feedback on the results page, please open an
-issue in the [website repository][scanner-issues]. If the issue is
-related to the results themselves, then open an issue in the [webhint
-repository][webhint-issues].
-
 ## What is the logo?
 
 Our logo is Nellie the narwhal. Narwhals are not only [awesome][narwhal
@@ -97,7 +88,4 @@ telling us what you think can be improved.
 [narwhal echolocation]: http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0162069
 [narwhal song]: https://www.youtube.com/watch?v=ykwqXuMPsoc
 [new issue]: https://github.com/webhintio/hint/issues/new
-[scanner]: https://webhint.io/scanner/
-[scanner-issues]: https://github.com/webhintio/webhint.io/issues/new
-[webhint-issues]: https://github.com/webhintio/hint/issues/new
 [ssllabs]: https://www.ssllabs.com/ssltest/


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- **N/A** Added/Updated related documentation.
- **N/A** Added/Updated related tests.

## Short description of the change(s)
Online scanner [is not available anymore](https://github.com/webhintio/webhintio.github.io/issues/989#issuecomment-940397677) so removing references to it in docs.

Relates to https://github.com/webhintio/webhintio.github.io/issues/989

### Search
Did `grep -r 'scanner' .` and found those occurrences relating to the web scanner only :) 
