### PR TITLE
Docs: Update links to OpenJS Foundation CoC

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -19,7 +19,7 @@ see below:
       to close the issue.
 
     * webhint adheres to the JS Foundation Code of Conduct
-      https://js.foundation/community/code-of-conduct.
+      https://code-of-conduct.openjsf.org/
 
 -->
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The code is available under the [Apache 2.0 license][license].
 [local user guide]: ./packages/hint/docs/user-guide/index.md
 [node]: https://nodejs.org/en/download/current/
 [npx]: https://github.com/zkat/npx
-[ojs coc]: https://github.com/openjs-foundation/cross-project-council/blob/master/CODE_OF_CONDUCT.md
+[ojs coc]: https://code-of-conduct.openjsf.org/
 [online service]: https://webhint.io/scanner/
 [user guide]: https://webhint.io/docs/user-guide/
 [VS Code extension]: https://webhint.io/docs/user-guide/extensions/vscode-webhint/

--- a/packages/hint/README.md
+++ b/packages/hint/README.md
@@ -63,7 +63,7 @@ version](https://github.com/webhintio/hint/blob/HEAD/packages/hint/docs/contribu
 ## Code of Conduct
 
 This project adheres to the JS Foundation’s [code of
-conduct](https://js.foundation/community/code-of-conduct).
+conduct](https://code-of-conduct.openjsf.org/).
 By participating in this project you agree to abide by its terms.
 
 ## License


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- **N/A** Added/Updated related documentation.
- **N/A** Added/Updated related tests.

## Short description of the change(s)
After [fixing CLA links pointing to a non-existent subdomain of `js.foundation`](https://github.com/webhintio/hint/pull/5691), wondered if there are any other `js.foundation` links that don't work anymore. And found out the Code of Conduct doesn't point to the document but to the OpenJS Foundation main site. Fixing it by pointing to the OpenJS Foundation Code of Conduct (found the link by grabbing it from their website's "Code of Conduct" item in the "About" dropdown).

Replaced the one in the README as this one seems more canonical than a markdown document in a GitHub repo
