### PR TITLE
stale-while-revalidate and stale-if-error caching directives are valid with value

### DIFF
--- a/packages/hint-http-cache/src/hint.ts
+++ b/packages/hint-http-cache/src/hint.ts
@@ -141,8 +141,8 @@ export default class HttpCacheHint implements IHint {
         const parseCacheControlHeader = (cacheControlHeader: string): ParsedDirectives => {
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
             const directives = ['must-revalidate', 'no-cache', 'no-store', 'no-transform', 'public', 'private', 'proxy-revalidate'];
-            const valueDirectives = ['max-age', 's-maxage', 'stale-while-revalidate'];
             const extensionDirectives = ['immutable', 'stale-while-revalidate', 'stale-if-error'];
+            const valueDirectives = ['max-age', 's-maxage', 'stale-while-revalidate', 'stale-if-error'];
 
             const usedDirectives = cacheControlHeader.split(',').map((value) => {
                 return value.trim();

--- a/packages/hint-http-cache/src/hint.ts
+++ b/packages/hint-http-cache/src/hint.ts
@@ -141,7 +141,7 @@ export default class HttpCacheHint implements IHint {
         const parseCacheControlHeader = (cacheControlHeader: string): ParsedDirectives => {
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
             const directives = ['must-revalidate', 'no-cache', 'no-store', 'no-transform', 'public', 'private', 'proxy-revalidate'];
-            const valueDirectives = ['max-age', 's-maxage'];
+            const valueDirectives = ['max-age', 's-maxage', 'stale-while-revalidate'];
             const extensionDirectives = ['immutable', 'stale-while-revalidate', 'stale-if-error'];
 
             const usedDirectives = cacheControlHeader.split(',').map((value) => {


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

``parseCacheControlHeader()`` now treats ``stale-while-revalidate`` and ``stale-if-error`` directives with value as valid directives.
They should be, according to [rfc5861](https://datatracker.ietf.org/doc/html/rfc5861).