### PR TITLE
Update minimum node version to 14

### DIFF
--- a/packages/hint/docs/user-guide/index.md
+++ b/packages/hint/docs/user-guide/index.md
@@ -10,7 +10,7 @@ The examples provided on webhint.io are written with the `bash` command-line
 shell. For more information about `bash`, go to
 [Bash Guide for Beginners][TldpLdpBashBeginnersGuide].
 
-To verify that you have Node.js (version 10 or later) and `npm` installed, open
+To verify that you have Node.js (version 14 or later) and `npm` installed, open
 a `bash` command-line interface and run the following command:
 
 ```bash


### PR DESCRIPTION
Seems like this was a bit outdated hint does not run on node 12

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'hint@7.1.10',
npm WARN EBADENGINE   required: { node: '>=14.0.0' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
```

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
