### PR TITLE
Fix: Fixes a warning in utils-worker package for missing vm module

### DIFF
--- a/packages/utils-worker/package.json
+++ b/packages/utils-worker/package.json
@@ -74,6 +74,7 @@
     "terser-webpack-plugin": "^5.3.6",
     "typescript": "^4.5.5",
     "util.promisify": "^1.1.1",
+    "vm-browserify": "1.1.2",
     "webpack": "^5.76.0",
     "webpack-cli": "^4.9.1"
   },

--- a/packages/utils-worker/webpack.config.js
+++ b/packages/utils-worker/webpack.config.js
@@ -45,7 +45,8 @@ module.exports = (env) => {
                 os: 'os-browserify',
                 path: 'path-browserify',
                 setImmediate: 'setimmediate',
-                stream: 'stream-browserify'
+                stream: 'stream-browserify',
+                vm: 'vm-browserify'
             }
         }
     };

--- a/scripts/lint-dependencies.js
+++ b/scripts/lint-dependencies.js
@@ -47,6 +47,7 @@ const ignoredDependencies = new Set([
     'style-loader',
     'typescript',
     'typed-css-modules',
+    'vm-browserify',
     'vsce',
     'vscode-languageclient',
     'web-ext',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11580,6 +11580,11 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+vm-browserify@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
+  integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
 vm2@^3.9.3:
   version "3.9.19"
   resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.19.tgz#be1e1d7a106122c6c492b4d51c2e8b93d3ed6a4a"


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [ ] Signed the Contributor License Agreement (after creating PR)
- [ ] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)
Recent builds have a warning when running the tests about a missing dependency that was used to be fullfilled
```
WARNING in ../../node_modules/asn1.js/lib/asn1/api.js 21:12-42
Module not found: Error: Can't resolve 'vm' in '/home/vidorteg/vidorteg-webhint/node_modules/asn1.js/lib/asn1'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "vm": require.resolve("vm-browserify") }'
        - install 'vm-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
```
So applying the suggested fix
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
