### PR TITLE
Docs: Update CLA link and add it in PR template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,7 @@ before contributing.
 
 <!-- Link labels -->
 
-[cla]: https://cla.js.foundation/webhintio/hint
+[cla]: https://openjsf.org/cla
 [coc]: https://github.com/webhintio/.github/blob/main/CODE_OF_CONDUCT
 [contributor guide]: https://webhint.io/docs/contributor-guide/
 [pr process]: https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ For the following items put an "x" between the square brackets
 
 Make sure you:
 
-- [ ] Signed the Contributor License Agreement (after creating PR)
+- [ ] Signed the [Contributor License Agreement](https://openjsf.org/cla) (after creating PR)
 - [ ] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)
 
 For non-trivial changes, please make sure you also:


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- **N/A** Added/Updated related documentation.
- **N/A** Added/Updated related tests.

## Short description of the change(s)
- Update of https://github.com/webhintio/hint/pull/5691 with new link

After looking for the CLA in docs for my [first contribution](https://github.com/webhintio/hint/pull/5690) found out the only reference to it had a link that didn't work (domain doesn't exist). Fixing that link + adding a link in PR template so impatient contributors like me can browse the CLA whilst the CLA signing comment appears. 