### PR TITLE
Fix: Fixing "...emit for this file requires using private name 'Context'"

### DIFF
--- a/packages/utils-worker/package.json
+++ b/packages/utils-worker/package.json
@@ -74,7 +74,6 @@
     "terser-webpack-plugin": "^5.3.6",
     "typescript": "^4.5.5",
     "util.promisify": "^1.1.1",
-    "vm-browserify": "1.1.2",
     "webpack": "^5.76.0",
     "webpack-cli": "^4.9.1"
   },

--- a/packages/utils-worker/webpack.config.js
+++ b/packages/utils-worker/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = (env) => {
                 path: 'path-browserify',
                 setImmediate: 'setimmediate',
                 stream: 'stream-browserify',
-                vm: 'vm-browserify'
+                vm: false
             }
         }
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11580,11 +11580,6 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vm-browserify@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
-  integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
-
 vm2@^3.9.3:
   version "3.9.19"
   resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.19.tgz#be1e1d7a106122c6c492b4d51c2e8b93d3ed6a4a"


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)
Fixing "...emit for this file requires using private name 'Context'", caused by the inclusion of VM polyfill. Switching it off instead.
<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
