### PR TITLE
Chore: Disable lint-markdown-validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "clean:root": "rimraf dist",
     "lint": "npm-run-all --parallel lint:*",
     "lint:dependencies": "node scripts/lint-dependencies.js",
-    "lint:md": "node scripts/lint-markdown && markdown-link-validator . -i www\\.cloudflare\\.com/learning/dns/what-is-dns/ -i twitter\\.com/jacobrossi/status/591435377291866112 -f igm",
+    "lint:md": "node scripts/lint-markdown",
     "lint:packages": "yarn workspaces run lint",
     "lint:scripts": "eslint scripts release --cache --ext .js,.md,.ts",
     "prebuild": "node scripts/prebuild.js",


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the Contributor License Agreement (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

Disables `markdown-link-validator` as part of the `lint:md` step. It seems that it does not meet it's original purpose anymore, which to my understanding, is to keep a clean ecosystem with working links. `markdown-link-validator` only runs when the file is checked-in or changed but those links can expire between these times. At the moment of writing this there are more than 50 expired links, so I think is better to run it as a scheduled action.
