### PR TITLE
Fix an issue where axe would not provide an html snippet - Fixes #5835

### DIFF
--- a/packages/hint-axe/src/util/axe.ts
+++ b/packages/hint-axe/src/util/axe.ts
@@ -284,7 +284,9 @@ export const register = (context: HintContext, rules: string[], disabled: string
                     }],
                     element,
                     forceSeverity,
-                    severity
+                    severity,
+                    codeSnippet: node.html,
+                    codeLanguge: "html"
                 });
             }
         }

--- a/packages/hint-axe/src/util/axe.ts
+++ b/packages/hint-axe/src/util/axe.ts
@@ -286,7 +286,7 @@ export const register = (context: HintContext, rules: string[], disabled: string
                     forceSeverity,
                     severity,
                     codeSnippet: node.html,
-                    codeLanguge: "html"
+                    codeLanguage: "html"
                 });
             }
         }

--- a/packages/hint-axe/src/util/axe.ts
+++ b/packages/hint-axe/src/util/axe.ts
@@ -278,15 +278,15 @@ export const register = (context: HintContext, rules: string[], disabled: string
                     ruleSeverity;
 
                 registration.context.report(resource, message, {
+                    codeLanguage: 'html',
+                    codeSnippet: node.html,
                     documentation: [{
                         link: violation.helpUrl,
                         text: getMessage('learnMore', context.language)
                     }],
                     element,
                     forceSeverity,
-                    severity,
-                    codeSnippet: node.html,
-                    codeLanguage: "html"
+                    severity
                 });
             }
         }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://openjsf.org/cla) (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

Sometimes axe would report an issue but not provide an HTML snippet for where the issue was found in the HTML document