### PR TITLE
Fix: Forcing resolution of mdn/browser-compat-data on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "json-schema": "^0.4.0",
     "node-fetch": "^2.x",
     "thenify": "^3.3.1",
-    "tsconfig-paths": "^4.1.2"
+    "tsconfig-paths": "^4.1.2",
+    "@mdn/browser-compat-data": "^5.5.23"
   },
   "scripts": {
     "build": "yarn clean && yarn update:references && node scripts/build-or-test-all.js build",

--- a/packages/utils-compat-data/tests/support.ts
+++ b/packages/utils-compat-data/tests/support.ts
@@ -138,12 +138,12 @@ test('Nested property value type query works', (t) => {
 
 test('At-rule query works', (t) => {
     const unsupported = getUnsupported(
-        { rule: 'supports' },
-        ['edge 12', 'ie 11']
+        { rule: 'scope' },
+        ['edge 117']
     );
 
     t.is(unsupported && unsupported.length, 1);
-    t.is(unsupported && unsupported[0], 'ie 11');
+    t.is(unsupported && unsupported[0], 'edge 117');
 });
 
 test('Selector query works', (t) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -483,12 +483,7 @@
     semver "^7.3.4"
     tar "^6.1.0"
 
-"@mdn/browser-compat-data@5.2.17":
-  version "5.2.17"
-  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-5.2.17.tgz#2aae9599f17793730af298da0dc5dcfa4a4b8d0f"
-  integrity sha512-aA+rFHhXmq14GVIcEWNk8OntLEOQFwEZk9ZgG5VcDquz+pQhIjJPXacR+rwL9Z0Elfg909EcRRHC96p06/CNUg==
-
-"@mdn/browser-compat-data@^5.5.23":
+"@mdn/browser-compat-data@5.2.17", "@mdn/browser-compat-data@^5.5.23":
   version "5.5.23"
   resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-5.5.23.tgz#14b8f80118b5ab5e5cb2e40f07e0e70b23bf107a"
   integrity sha512-nIy38qL3nfNcGOz5J2BJQpBXa7vM9QO1+wbyvqqS89lgNTWE8Q10whLsmE0sTVBooXiEaRc4fVME5IXjCYiHAw==


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://openjsf.org/cla) (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
There were a couple of version of `@mdn/browser-compat-data` due to a indirect reference, this PR forces all dependencies to be on the same version. 

Fixes #5723 