### PR TITLE
Corrected compiler/target

### DIFF
--- a/packages/parser-typescript-config/src/schema.json
+++ b/packages/parser-typescript-config/src/schema.json
@@ -559,6 +559,8 @@
                                         "ES2020",
                                         "ES2021",
                                         "ES2022",
+                                        "ES2023",
+                                        "ES2024",
                                         "ESNext"
 
                                     ]
@@ -612,7 +614,7 @@
                                 "fixedChunkSizePolling"
                             ],
 
-                            
+
                             "default": "useFsEvents"
                         },
                         "experimentalDecorators": {
@@ -872,6 +874,12 @@
                                     },
                                     {
                                         "pattern": "^[Ee][Ss]2022(\\.([Aa][Rr][Rr][Aa][Yy]|[Ee][Rr][Rr][Oo][Rr]|[Ii][Nn][Tt][Ll]|[Oo][Bb][Jj][Ee][Cc][Tt]|[Ss][Tt][Rr][Ii][Nn][Gg]))?$"
+                                    },
+                                     {
+                                        "pattern": "^[Ee][Ss]2023(\\.([Aa][Rr][Rr][Aa][Yy]|[Ee][Rr][Rr][Oo][Rr]|[Ii][Nn][Tt][Ll]|[Oo][Bb][Jj][Ee][Cc][Tt]|[Ss][Tt][Rr][Ii][Nn][Gg]))?$"
+                                    },
+                                     {
+                                        "pattern": "^[Ee][Ss]2024(\\.([Aa][Rr][Rr][Aa][Yy]|[Ee][Rr][Rr][Oo][Rr]|[Ii][Nn][Tt][Ll]|[Oo][Bb][Jj][Ee][Cc][Tt]|[Ss][Tt][Rr][Ii][Nn][Gg]))?$"
                                     },
                                     {
                                         "pattern": "^[Ee][Ss][Nn][Ee][Xx][Tt](\\.([Aa][Rr][Rr][Aa][Yy]|[Aa][Ss][Yy][Nn][Cc][Ii][Tt][Ee][Rr][Aa][Bb][Ll][Ee]|[Bb][Ii][Gg][Ii][Nn][Tt]|[Ii][Nn][Tt][Ll]|[Pp][Rr][Oo][Mm][Ii][Ss][Ee]|[Ss][Tt][Rr][Ii][Nn][Gg]|[Ss][Yy][Mm][Bb][Oo][Ll]|[Ww][Ee][Aa][Kk][Rr][Ee][Ff]))?$"

--- a/packages/parser-typescript-config/src/schema.json
+++ b/packages/parser-typescript-config/src/schema.json
@@ -546,6 +546,8 @@
                             "anyOf": [
                                 {
                                     "enum": [
+
+
                                         "ES3",
                                         "ES5",
                                         "ES6",
@@ -558,6 +560,7 @@
                                         "ES2021",
                                         "ES2022",
                                         "ESNext"
+
                                     ]
                                 },
                                 {
@@ -608,6 +611,8 @@
                                 "useFsEventsOnParentDirectory",
                                 "fixedChunkSizePolling"
                             ],
+
+                            
                             "default": "useFsEvents"
                         },
                         "experimentalDecorators": {


### PR DESCRIPTION
This PR adds ES2023 and  ES2024 as a valid option for the target  and pattern in the TypeScript configuration schema, aligning it with the latest ECMAScript standard. This ensures users can take advantage of new language features without encountering validation issues. I tested the updated schema locally and verified that ES2023 and  ES2024 works as expected. Please let me know if any changes are needed — happy to adjust!