### PR TITLE
Fix: support tsconfig module value `nodenext` #6020

### DIFF
--- a/packages/parser-typescript-config/src/schema.json
+++ b/packages/parser-typescript-config/src/schema.json
@@ -344,7 +344,7 @@
                                     ]
                                 },
                                 {
-                                    "pattern": "^([Cc][Oo][Mm][Mm][Oo][Nn][Jj][Ss]|[AaUu][Mm][Dd]|[Ss][Yy][Ss][Tt][Ee][Mm]|[Ee][Ss]([356]|20(1[567]|2[02])|[Nn][Ee][Xx][Tt])|[Nn][Oo][dD][Ee]16|[Nn][Oo][Dd][Ed][Nn][Ee][Xx][Tt]|[Nn][Oo][Nn][Ee])$"
+                                    "pattern": "^([Cc][Oo][Mm][Mm][Oo][Nn][Jj][Ss]|[AaUu][Mm][Dd]|[Ss][Yy][Ss][Tt][Ee][Mm]|[Ee][Ss]([356]|20(1[567]|2[02])|[Nn][Ee][Xx][Tt])|[Nn][Oo][dD][Ee]16|[Nn][Oo][Dd][Ee][Nn][Ee][Xx][Tt]|[Nn][Oo][Nn][Ee])$"
                                 }
                             ],
                             "markdownDescription": "Specify what module code is generated.\n\nSee more: https://www.typescriptlang.org/tsconfig#module"


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://openjsf.org/cla) (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

fixes a typo that isn't allowing lowercase `nodenext` as a tsconfig module value

fixes #6020 6020