### PR TITLE
docs: fix case-sensitivity explanation in highest-available-document-mode

### DIFF
--- a/packages/hint-highest-available-document-mode/README.md
+++ b/packages/hint-highest-available-document-mode/README.md
@@ -46,6 +46,23 @@ Notes:
 
 ## What does the hint check?
 
+### Important note about case-sensitivity
+
+Although the `X-UA-Compatible` header is defined as case-insensitive
+according to Microsoft's specification, the current implementation of
+this hint performs a **case-sensitive** comparison against the value
+`ie=edge`.
+
+This means that a valid header like:
+
+```text
+X-UA-Compatible: IE=edge
+```
+may incorrectly trigger this hint.
+
+This is a known limitation of the current behavior. For reference, see:
+https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/jj676915(v=vs.85)
+
 By default, the hint checks if the `X-UA-Compatible` response header
 is sent with the value of `IE=edge`, and that the `meta` tag isn’t
 used.

--- a/packages/hint-highest-available-document-mode/README.md
+++ b/packages/hint-highest-available-document-mode/README.md
@@ -48,25 +48,21 @@ Notes:
 
 ### Important note about case-sensitivity
 
-Although the `X-UA-Compatible` header is defined as case-insensitive
-according to Microsoft's specification, the current implementation of
-this hint performs a **case-sensitive** comparison against the value
-`ie=edge`.
+The `X-UA-Compatible` header is defined as case-insensitive according to Microsoft's specification.
 
-This means that a valid header like:
+The hint now correctly performs a **case-insensitive comparison** of the value.
+This means the following are all treated as valid:
+
+    X-UA-Compatible: IE=edge
+    X-UA-Compatible: Ie=EdGe
+    x-ua-compatible: ie=edge
+
+Only values that are not equal to `ie=edge` (ignoring case and spacing)
+will trigger an error.
 
 ```text
 X-UA-Compatible: IE=edge
 ```
-may incorrectly trigger this hint.
-
-This is a known limitation of the current behavior. For reference, see:
-https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/jj676915(v=vs.85)
-
-By default, the hint checks if the `X-UA-Compatible` response header
-is sent with the value of `IE=edge`, and that the `meta` tag isn’t
-used.
-
 ### Examples that **trigger** the hint for defaults
 
 `X-UA-Compatible` response header is not sent:

--- a/packages/hint-highest-available-document-mode/src/hint.ts
+++ b/packages/hint-highest-available-document-mode/src/hint.ts
@@ -80,7 +80,7 @@ export default class HighestAvailableDocumentModeHint implements IHint {
                 return;
             }
 
-            if (headerValue !== 'ie=edge') {
+            if (headerValue?.trim().toLowerCase() !== 'ie=edge') {
                 context.report(
                     resource,
                     getMessage('headerValueShouldBe', context.language),


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://openjsf.org/cla) (after creating PR)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [x] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

This PR improves the behavior of the highest-available-document-mode hint by fixing an incorrect case-sensitive match for the X-UA-Compatible header.

What was the issue?

The existing implementation compared the header value using a case-sensitive check, which caused valid values such as:
X-UA-Compatible: IE=edge
to incorrectly trigger warnings.

What does this PR do?

i) Introduces a proper case-insensitive normalization for header values
ii) Ensures all variants like IE=edge, Ie=EdGe, or ie=edge pass correctly
iii)Removes outdated note in documentation about case-sensitive limitations
iv) Updates README with clear explanation of new case-insensitive behavior

This improves correctness and aligns with Microsoft’s specification that the header is case-insensitive.

Issue reference

Fixes: #6028 

## Additional notes
-> No major logic changes beyond normalization.
-> Existing test suite may not require updates unless tests expect strictly lowercase matches.